### PR TITLE
Golangci lint fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,11 @@ format: tools
 	golangci-lint run --timeout 10m60s ./...  & \
 	wait
 
+ci-fix: tools
+	@echo "$(OK_COLOR)>> [golangci-lint] running$(NO_COLOR) fix" & \
+	golangci-lint run --timeout 10m60s ./... --fix & \
+	wait
+
 tools:
 	@if ! command -v gci > /dev/null ; then \
 		echo ">> [$@]: gci not found: installing"; \

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -6,12 +6,11 @@ import (
 
 	"github.com/kdeps/kdeps/pkg/archiver"
 	"github.com/kdeps/kdeps/pkg/logging"
-
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
-// NewAddCommand creates the 'add' command and passes the necessary dependencies
+// NewAddCommand creates the 'add' command and passes the necessary dependencies.
 func NewAddCommand(fs afero.Fs, ctx context.Context, kdepsDir string, logger *logging.Logger) *cobra.Command {
 	return &cobra.Command{
 		Use:     "install [package]",

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -4,17 +4,16 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/docker/docker/client"
 	"github.com/kdeps/kdeps/pkg/archiver"
 	"github.com/kdeps/kdeps/pkg/docker"
 	"github.com/kdeps/kdeps/pkg/logging"
-
-	"github.com/docker/docker/client"
 	"github.com/kdeps/schema/gen/kdeps"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
-// NewBuildCommand creates the 'build' command and passes the necessary dependencies
+// NewBuildCommand creates the 'build' command and passes the necessary dependencies.
 func NewBuildCommand(fs afero.Fs, ctx context.Context, kdepsDir string, systemCfg *kdeps.Kdeps, logger *logging.Logger) *cobra.Command {
 	return &cobra.Command{
 		Use:     "build [package]",

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -25,7 +25,7 @@ func NewAgentCommand(fs afero.Fs, ctx context.Context, kdepsDir string, logger *
 			}
 
 			// Pass the agentName to GenerateAgent
-			if err := template.GenerateAgent(fs, logger, agentName); err != nil {
+			if err := template.GenerateAgent(fs, ctx, logger, agentName); err != nil {
 				fmt.Println("Error:", err)
 			}
 		},

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -6,12 +6,11 @@ import (
 
 	"github.com/kdeps/kdeps/pkg/logging"
 	"github.com/kdeps/kdeps/pkg/template"
-
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
-// NewAgentCommand creates the 'new' command and passes the necessary dependencies
+// NewAgentCommand creates the 'new' command and passes the necessary dependencies.
 func NewAgentCommand(fs afero.Fs, ctx context.Context, kdepsDir string, logger *logging.Logger) *cobra.Command {
 	newCmd := &cobra.Command{
 		Use:     "new [agentName]",

--- a/cmd/package.go
+++ b/cmd/package.go
@@ -4,17 +4,16 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/kdeps/kdeps/pkg/archiver"
 	"github.com/kdeps/kdeps/pkg/environment"
 	"github.com/kdeps/kdeps/pkg/logging"
 	"github.com/kdeps/kdeps/pkg/workflow"
-
-	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
-// Define styles using lipgloss
+// Define styles using lipgloss.
 var (
 	primaryStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("75"))
 	secondaryStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("211"))
@@ -22,7 +21,7 @@ var (
 	errorStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true)
 )
 
-// NewPackageCommand creates the 'package' command and passes the necessary dependencies
+// NewPackageCommand creates the 'package' command and passes the necessary dependencies.
 func NewPackageCommand(fs afero.Fs, ctx context.Context, kdepsDir string, env *environment.Environment, logger *logging.Logger) *cobra.Command {
 	return &cobra.Command{
 		Use:     "package [agent-dir]",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,7 +26,7 @@ open-source LLM models that are orchestrated by a graph-based dependency workflo
 		`Fetch and use the latest schema and libraries. It is recommended to set the GITHUB_TOKEN environment
 variable to prevent errors caused by rate limit exhaustion.`)
 	rootCmd.AddCommand(NewAgentCommand(fs, ctx, kdepsDir, logger))
-	rootCmd.AddCommand(NewScaffoldCommand(fs, logger))
+	rootCmd.AddCommand(NewScaffoldCommand(fs, ctx, logger))
 	rootCmd.AddCommand(NewAddCommand(fs, ctx, kdepsDir, logger))
 	rootCmd.AddCommand(NewPackageCommand(fs, ctx, kdepsDir, env, logger))
 	rootCmd.AddCommand(NewBuildCommand(fs, ctx, kdepsDir, systemCfg, logger))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,13 +6,12 @@ import (
 	"github.com/kdeps/kdeps/pkg/environment"
 	"github.com/kdeps/kdeps/pkg/logging"
 	"github.com/kdeps/kdeps/pkg/schema"
-
 	"github.com/kdeps/schema/gen/kdeps"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
-// NewRootCommand returns the root command with all subcommands attached
+// NewRootCommand returns the root command with all subcommands attached.
 func NewRootCommand(fs afero.Fs, ctx context.Context, kdepsDir string, systemCfg *kdeps.Kdeps, env *environment.Environment, logger *logging.Logger) *cobra.Command {
 	cobra.EnableCommandSorting = false
 	rootCmd := &cobra.Command{

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -4,17 +4,16 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/docker/docker/client"
 	"github.com/kdeps/kdeps/pkg/archiver"
 	"github.com/kdeps/kdeps/pkg/docker"
 	"github.com/kdeps/kdeps/pkg/logging"
-
-	"github.com/docker/docker/client"
 	"github.com/kdeps/schema/gen/kdeps"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
-// NewRunCommand creates the 'run' command and passes the necessary dependencies
+// NewRunCommand creates the 'run' command and passes the necessary dependencies.
 func NewRunCommand(fs afero.Fs, ctx context.Context, kdepsDir string, systemCfg *kdeps.Kdeps, logger *logging.Logger) *cobra.Command {
 	return &cobra.Command{
 		Use:     "run [package]",

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -6,12 +6,11 @@ import (
 
 	"github.com/kdeps/kdeps/pkg/logging"
 	"github.com/kdeps/kdeps/pkg/template"
-
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
-// NewScaffoldCommand creates the 'scaffold' subcommand for generating specific agent files
+// NewScaffoldCommand creates the 'scaffold' subcommand for generating specific agent files.
 func NewScaffoldCommand(fs afero.Fs, ctx context.Context, logger *logging.Logger) *cobra.Command {
 	return &cobra.Command{
 		Use:   "scaffold [agentName] [fileNames...]",

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/kdeps/kdeps/pkg/logging"
@@ -11,7 +12,7 @@ import (
 )
 
 // NewScaffoldCommand creates the 'scaffold' subcommand for generating specific agent files
-func NewScaffoldCommand(fs afero.Fs, logger *logging.Logger) *cobra.Command {
+func NewScaffoldCommand(fs afero.Fs, ctx context.Context, logger *logging.Logger) *cobra.Command {
 	return &cobra.Command{
 		Use:   "scaffold [agentName] [fileNames...]",
 		Short: "Scaffold specific files for an agent",
@@ -21,7 +22,7 @@ func NewScaffoldCommand(fs afero.Fs, logger *logging.Logger) *cobra.Command {
 			fileNames := args[1:]
 
 			for _, fileName := range fileNames {
-				if err := template.GenerateSpecificAgentFile(fs, logger, agentName, fileName); err != nil {
+				if err := template.GenerateSpecificAgentFile(fs, ctx, logger, agentName, fileName); err != nil {
 					logger.Error("Error scaffolding file:", err)
 					fmt.Println("Error:", err)
 				} else {

--- a/main.go
+++ b/main.go
@@ -90,7 +90,7 @@ func handleNonDockerMode(fs afero.Fs, ctx context.Context, env *environment.Envi
 
 		logger.Info("Configuration file generated", "file", cfgFile)
 
-		cfgFile, err = cfg.EditConfiguration(fs, env, logger)
+		cfgFile, err = cfg.EditConfiguration(fs, ctx, env, logger)
 		if err != nil {
 			logger.Error("Error occurred editing configuration")
 		}
@@ -114,7 +114,7 @@ func handleNonDockerMode(fs afero.Fs, ctx context.Context, env *environment.Envi
 		return
 	}
 
-	kdepsDir, err := cfg.GetKdepsPath(*systemCfg)
+	kdepsDir, err := cfg.GetKdepsPath(ctx, *systemCfg)
 	if err != nil {
 		logger.Error("Error occurred while getting Kdeps system path")
 		return

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func main() {
 	logger := logging.GetLogger()
 
 	// Setup environment
-	env, err := setupEnvironment(fs)
+	env, err := setupEnvironment(fs, ctx)
 	if err != nil {
 		logger.Error("Failed to set up environment", "error", err)
 		return
@@ -76,13 +76,13 @@ func handleDockerMode(fs afero.Fs, ctx context.Context, env *environment.Environ
 }
 
 func handleNonDockerMode(fs afero.Fs, ctx context.Context, env *environment.Environment, logger *logging.Logger) {
-	cfgFile, err := cfg.FindConfiguration(fs, env, logger)
+	cfgFile, err := cfg.FindConfiguration(fs, ctx, env, logger)
 	if err != nil {
 		logger.Error("Error occurred finding configuration")
 	}
 
 	if cfgFile == "" {
-		cfgFile, err = cfg.GenerateConfiguration(fs, env, logger)
+		cfgFile, err = cfg.GenerateConfiguration(fs, ctx, env, logger)
 		if err != nil {
 			logger.Fatal("Error occurred generating configuration", "error", err)
 			return
@@ -127,8 +127,8 @@ func handleNonDockerMode(fs afero.Fs, ctx context.Context, env *environment.Envi
 }
 
 // setupEnvironment initializes the environment using the filesystem.
-func setupEnvironment(fs afero.Fs) (*environment.Environment, error) {
-	environ, err := environment.NewEnvironment(fs, nil)
+func setupEnvironment(fs afero.Fs, ctx context.Context) (*environment.Environment, error) {
+	environ, err := environment.NewEnvironment(fs, ctx, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/archiver/archiver_test.go
+++ b/pkg/archiver/archiver_test.go
@@ -10,13 +10,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cucumber/godog"
 	"github.com/kdeps/kdeps/pkg/enforcer"
 	"github.com/kdeps/kdeps/pkg/environment"
 	"github.com/kdeps/kdeps/pkg/logging"
 	"github.com/kdeps/kdeps/pkg/resource"
 	"github.com/kdeps/kdeps/pkg/workflow"
-
-	"github.com/cucumber/godog"
 	"github.com/kr/pretty"
 	"github.com/spf13/afero"
 )
@@ -256,7 +255,7 @@ func theWorkflowActionConfigurationWillBeRewrittenTo(arg1 string) error {
 	}
 
 	if wf.GetAction() != arg1 {
-		return errors.New(fmt.Sprintf("%s = %s does not match!", wf.GetAction(), arg1))
+		return fmt.Errorf("%s = %s does not match!", wf.GetAction(), arg1)
 	}
 
 	return nil
@@ -372,7 +371,7 @@ func theProjectWillBeArchivedTo(arg1 string) error {
 func theresADataFile() error {
 	doc := "THIS IS A TEXT FILE: "
 
-	for x := 0; x < 10; x++ {
+	for x := range 10 {
 		num := strconv.Itoa(x)
 		file := filepath.Join(dataDir, fmt.Sprintf("textfile-%s.txt", num))
 
@@ -526,15 +525,7 @@ func itHasAFileWithIdPropertyAndDependentOnWithRunBlockAndIsNotNull(arg1, arg2, 
 		var fieldLines []string
 		for _, value := range values {
 			value = strings.TrimSpace(value) // Trim any leading/trailing whitespace
-			fieldLines = append(fieldLines, fmt.Sprintf(`%s {
-["key"] = """
-@(exec.stdout["anAction"])
-@(exec.stdin["anAction2"])
-@(exec.stderr["anAction2"])
-@(http.client["anAction3"].response)
-@(llm.chat["anAction4"].response)
-"""
-}`, value))
+			fieldLines = append(fieldLines, value+" {\n[\"key\"] = \"\"\"\n@(exec.stdout[\"anAction\"])\n@(exec.stdin[\"anAction2\"])\n@(exec.stderr[\"anAction2\"])\n@(http.client[\"anAction3\"].response)\n@(llm.chat[\"anAction4\"].response)\n\"\"\"\n}")
 		}
 		fieldSection = "run {\n" + strings.Join(fieldLines, "\n") + "\n}"
 	} else {
@@ -599,7 +590,7 @@ func itHasAFileWithIdPropertyAndDependentOnWithRunBlockAndIsNull(arg1, arg2, arg
 		var fieldLines []string
 		for _, value := range values {
 			value = strings.TrimSpace(value) // Trim any leading/trailing whitespace
-			fieldLines = append(fieldLines, fmt.Sprintf(`%s=null`, value))
+			fieldLines = append(fieldLines, value+"=null")
 		}
 		fieldSection = "run {\n" + strings.Join(fieldLines, "\n") + "\n}"
 	} else {

--- a/pkg/archiver/archiver_test.go
+++ b/pkg/archiver/archiver_test.go
@@ -336,7 +336,7 @@ func theContentOfThatArchiveFileWillBeExtractedTo(arg1 string) error {
 }
 
 func thePklFilesIsValid() error {
-	if err := enforcer.EnforcePklTemplateAmendsRules(testFs, workflowFile, logger); err != nil {
+	if err := enforcer.EnforcePklTemplateAmendsRules(testFs, ctx, workflowFile, logger); err != nil {
 		return err
 	}
 
@@ -344,7 +344,7 @@ func thePklFilesIsValid() error {
 }
 
 func theProjectIsValid() error {
-	if err := enforcer.EnforceFolderStructure(testFs, workflowFile, logger); err != nil {
+	if err := enforcer.EnforceFolderStructure(testFs, ctx, workflowFile, logger); err != nil {
 		return err
 	}
 
@@ -357,7 +357,7 @@ func theProjectWillBeArchivedTo(arg1 string) error {
 		return err
 	}
 
-	fpath, err := PackageProject(testFs, wf, kdepsDir, aiAgentDir, logger)
+	fpath, err := PackageProject(testFs, ctx, wf, kdepsDir, aiAgentDir, logger)
 	if err != nil {
 		return err
 	}
@@ -409,7 +409,7 @@ func thePklFilesIsInvalid() error {
 
 	workflowFile = file
 
-	if err := enforcer.EnforcePklTemplateAmendsRules(testFs, workflowFile, logger); err == nil {
+	if err := enforcer.EnforcePklTemplateAmendsRules(testFs, ctx, workflowFile, logger); err == nil {
 		return errors.New("expected an error, but got nil")
 	}
 
@@ -417,7 +417,7 @@ func thePklFilesIsInvalid() error {
 }
 
 func theProjectIsInvalid() error {
-	if err := enforcer.EnforceFolderStructure(testFs, workflowFile, logger); err == nil {
+	if err := enforcer.EnforceFolderStructure(testFs, ctx, workflowFile, logger); err == nil {
 		return errors.New("expected an error, but got nil")
 	}
 
@@ -430,7 +430,7 @@ func theProjectWillNotBeArchivedTo(arg1 string) error {
 		return err
 	}
 
-	fpath, err := PackageProject(testFs, wf, kdepsDir, aiAgentDir, logger)
+	fpath, err := PackageProject(testFs, ctx, wf, kdepsDir, aiAgentDir, logger)
 	if err == nil {
 		return errors.New("expected an error, but got nil")
 	}

--- a/pkg/archiver/archiver_test.go
+++ b/pkg/archiver/archiver_test.go
@@ -37,6 +37,7 @@ var (
 )
 
 func TestFeatures(t *testing.T) {
+	t.Parallel()
 	suite := godog.TestSuite{
 		ScenarioInitializer: func(ctx *godog.ScenarioContext) {
 			ctx.Step(`^a kdeps archive "([^"]*)" is opened$`, aKdepsArchiveIsOpened)

--- a/pkg/archiver/block_handler.go
+++ b/pkg/archiver/block_handler.go
@@ -7,7 +7,7 @@ import (
 	"github.com/kdeps/schema/gen/workflow"
 )
 
-// Handle the values inside the requires { ... } block
+// Handle the values inside the requires { ... } block.
 func handleRequiresBlock(blockContent string, wf workflow.Workflow) string {
 	name, version := wf.GetName(), wf.GetVersion()
 

--- a/pkg/archiver/file_ops.go
+++ b/pkg/archiver/file_ops.go
@@ -1,6 +1,7 @@
 package archiver
 
 import (
+	"context"
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
@@ -15,7 +16,7 @@ import (
 )
 
 // Move a directory by copying and then deleting the original
-func MoveFolder(fs afero.Fs, src string, dest string) error {
+func MoveFolder(fs afero.Fs, ctx context.Context, src string, dest string) error {
 	// Walk through the source directory and handle files and directories
 	err := afero.Walk(fs, src, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -66,7 +67,7 @@ func MoveFolder(fs afero.Fs, src string, dest string) error {
 	return fs.RemoveAll(src)
 }
 
-func getFileMD5(fs afero.Fs, filePath string, length int) (string, error) {
+func getFileMD5(fs afero.Fs, ctx context.Context, filePath string, length int) (string, error) {
 	// Open the file using afero's filesystem
 	file, err := fs.Open(filePath)
 	if err != nil {
@@ -94,16 +95,16 @@ func getFileMD5(fs afero.Fs, filePath string, length int) (string, error) {
 }
 
 // Move the original file to a new name with MD5 and copy the latest file
-func CopyFile(fs afero.Fs, src, dst string, logger *logging.Logger) error {
+func CopyFile(fs afero.Fs, ctx context.Context, src, dst string, logger *logging.Logger) error {
 	// Check if the destination file exists
 	if _, err := fs.Stat(dst); err == nil {
 		// Calculate MD5 for both source and destination files
-		srcMD5, err := getFileMD5(fs, src, 8)
+		srcMD5, err := getFileMD5(fs, ctx, src, 8)
 		if err != nil {
 			return fmt.Errorf("failed to calculate MD5 for source file: %w", err)
 		}
 
-		dstMD5, err := getFileMD5(fs, dst, 8)
+		dstMD5, err := getFileMD5(fs, ctx, dst, 8)
 		if err != nil {
 			return fmt.Errorf("failed to calculate MD5 for destination file: %w", err)
 		}
@@ -158,7 +159,7 @@ func CopyFile(fs afero.Fs, src, dst string, logger *logging.Logger) error {
 	return nil
 }
 
-func CopyDataDir(fs afero.Fs, wf pklWf.Workflow, kdepsDir, projectDir, compiledProjectDir, agentName, agentVersion,
+func CopyDataDir(fs afero.Fs, ctx context.Context, wf pklWf.Workflow, kdepsDir, projectDir, compiledProjectDir, agentName, agentVersion,
 	agentAction string, processWorkflows bool, logger *logging.Logger,
 ) error {
 	var srcDir, destDir string
@@ -168,7 +169,7 @@ func CopyDataDir(fs afero.Fs, wf pklWf.Workflow, kdepsDir, projectDir, compiledP
 
 	if processWorkflows {
 		// Helper function to copy resources
-		copyResources := func(src, dst string) error {
+		copyResources := func(ctx context.Context, src, dst string) error {
 			return afero.Walk(fs, src, func(path string, info os.FileInfo, walkErr error) error {
 				if walkErr != nil {
 					logger.Error("Error walking source directory", "path", src, "error", walkErr)
@@ -191,7 +192,7 @@ func CopyDataDir(fs afero.Fs, wf pklWf.Workflow, kdepsDir, projectDir, compiledP
 						return err
 					}
 				} else {
-					if err := CopyFile(fs, path, dstPath, logger); err != nil {
+					if err := CopyFile(fs, ctx, path, dstPath, logger); err != nil {
 						logger.Error("Failed to copy file", "src", path, "dst", dstPath, "error", err)
 						return err
 					}
@@ -208,7 +209,7 @@ func CopyDataDir(fs afero.Fs, wf pklWf.Workflow, kdepsDir, projectDir, compiledP
 			}
 
 			if exists {
-				version, err := getLatestVersion(agentVersionPath, logger)
+				version, err := getLatestVersion(ctx, agentVersionPath, logger)
 				if err != nil {
 					logger.Error("Failed to get latest agent version", "agentVersionPath", agentVersionPath, "error", err)
 					return err
@@ -229,7 +230,7 @@ func CopyDataDir(fs afero.Fs, wf pklWf.Workflow, kdepsDir, projectDir, compiledP
 		}
 
 		if exists {
-			if err := copyResources(src, dst); err != nil {
+			if err := copyResources(ctx, src, dst); err != nil {
 				logger.Error("Failed to copy resources", "src", src, "dst", dst, "error", err)
 				return err
 			}
@@ -272,7 +273,7 @@ func CopyDataDir(fs afero.Fs, wf pklWf.Workflow, kdepsDir, projectDir, compiledP
 			}
 		} else {
 			// If it's a file, copy the file
-			if err := CopyFile(fs, path, dstPath, logger); err != nil {
+			if err := CopyFile(fs, ctx, path, dstPath, logger); err != nil {
 				logger.Error("Failed to copy file", "src", path, "dst", dstPath, "error", err)
 				return err
 			}

--- a/pkg/archiver/file_ops.go
+++ b/pkg/archiver/file_ops.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-// Move a directory by copying and then deleting the original
+// Move a directory by copying and then deleting the original.
 func MoveFolder(fs afero.Fs, ctx context.Context, src string, dest string) error {
 	// Walk through the source directory and handle files and directories
 	err := afero.Walk(fs, src, func(path string, info os.FileInfo, err error) error {
@@ -94,7 +94,7 @@ func getFileMD5(fs afero.Fs, ctx context.Context, filePath string, length int) (
 	return md5String[:length], nil
 }
 
-// Move the original file to a new name with MD5 and copy the latest file
+// Move the original file to a new name with MD5 and copy the latest file.
 func CopyFile(fs afero.Fs, ctx context.Context, src, dst string, logger *logging.Logger) error {
 	// Check if the destination file exists
 	if _, err := fs.Stat(dst); err == nil {

--- a/pkg/archiver/package_handler.go
+++ b/pkg/archiver/package_handler.go
@@ -120,7 +120,7 @@ func ExtractPackage(fs afero.Fs, ctx context.Context, kdepsDir string, kdepsPack
 
 	// Move the extracted files from the temporary directory to the permanent location
 	extractBasePath := filepath.Join(kdepsDir, "agents", agentName, agentVersion)
-	if err := MoveFolder(fs, tempDir, extractBasePath); err != nil {
+	if err := MoveFolder(fs, ctx, tempDir, extractBasePath); err != nil {
 		return nil, fmt.Errorf("Failed to move extracted package to kdeps system directory: %s", extractBasePath)
 	}
 
@@ -136,14 +136,14 @@ func ExtractPackage(fs afero.Fs, ctx context.Context, kdepsDir string, kdepsPack
 	destinationFile := filepath.Join(packageDir, baseFilename)
 	sourceFile := kdepsPackage
 
-	err = CopyFile(fs, sourceFile, destinationFile, logger)
+	err = CopyFile(fs, ctx, sourceFile, destinationFile, logger)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to copy kdeps package to packages directory: %w", err)
 	}
 
 	kdepsPackage = destinationFile
 
-	_, err = PrepareRunDir(fs, wfConfig, kdepsDir, kdepsPackage, logger)
+	_, err = PrepareRunDir(fs, ctx, wfConfig, kdepsDir, kdepsPackage, logger)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to prepare runtime directory: %w", err)
 	}
@@ -198,7 +198,7 @@ func ExtractPackage(fs afero.Fs, ctx context.Context, kdepsDir string, kdepsPack
 	}
 
 	// Get the MD5 hash of the file
-	md5Hash, err := getFileMD5(fs, kdepsPackage, 5)
+	md5Hash, err := getFileMD5(fs, ctx, kdepsPackage, 5)
 	if err != nil {
 		return nil, fmt.Errorf("Error calculating MD5: %w", err)
 	}
@@ -213,9 +213,9 @@ func ExtractPackage(fs afero.Fs, ctx context.Context, kdepsDir string, kdepsPack
 }
 
 // PackageProject compresses the contents of projectDir into a kdeps file in kdepsDir
-func PackageProject(fs afero.Fs, wf pklWf.Workflow, kdepsDir, compiledProjectDir string, logger *logging.Logger) (string, error) {
+func PackageProject(fs afero.Fs, ctx context.Context, wf pklWf.Workflow, kdepsDir, compiledProjectDir string, logger *logging.Logger) (string, error) {
 	// Enforce the folder structure
-	if err := enforcer.EnforceFolderStructure(fs, compiledProjectDir, logger); err != nil {
+	if err := enforcer.EnforceFolderStructure(fs, ctx, compiledProjectDir, logger); err != nil {
 		logger.Error("Failed to enforce folder structure", "error", err)
 		return "", err
 	}

--- a/pkg/archiver/package_handler.go
+++ b/pkg/archiver/package_handler.go
@@ -13,7 +13,6 @@ import (
 	"github.com/kdeps/kdeps/pkg/enforcer"
 	"github.com/kdeps/kdeps/pkg/logging"
 	"github.com/kdeps/kdeps/pkg/workflow"
-
 	pklWf "github.com/kdeps/schema/gen/workflow"
 	"github.com/spf13/afero"
 )
@@ -212,7 +211,7 @@ func ExtractPackage(fs afero.Fs, ctx context.Context, kdepsDir string, kdepsPack
 	return kdeps, nil
 }
 
-// PackageProject compresses the contents of projectDir into a kdeps file in kdepsDir
+// PackageProject compresses the contents of projectDir into a kdeps file in kdepsDir.
 func PackageProject(fs afero.Fs, ctx context.Context, wf pklWf.Workflow, kdepsDir, compiledProjectDir string, logger *logging.Logger) (string, error) {
 	// Enforce the folder structure
 	if err := enforcer.EnforceFolderStructure(fs, ctx, compiledProjectDir, logger); err != nil {
@@ -222,7 +221,7 @@ func PackageProject(fs afero.Fs, ctx context.Context, wf pklWf.Workflow, kdepsDi
 
 	// Create the output filename for the package
 	outFile := fmt.Sprintf("%s-%s.kdeps", wf.GetName(), wf.GetVersion())
-	packageDir := fmt.Sprintf("%s/packages", kdepsDir)
+	packageDir := kdepsDir + "/packages"
 
 	if _, err := fs.Stat(packageDir); err != nil {
 		if err := fs.MkdirAll(packageDir, 0o777); err != nil {
@@ -324,14 +323,14 @@ func PackageProject(fs afero.Fs, ctx context.Context, wf pklWf.Workflow, kdepsDi
 	return tarGzPath, nil
 }
 
-// Function to search for workflow.pkl file in a given folder
+// Function to search for workflow.pkl file in a given folder.
 func FindWorkflowFile(fs afero.Fs, folder string, logger *logging.Logger) (string, error) {
 	fileName := "workflow.pkl"
 
 	// Check if the folder exists and is a directory
 	info, err := fs.Stat(folder)
 	if err != nil {
-		return "", fmt.Errorf("error accessing folder: %v", err)
+		return "", fmt.Errorf("error accessing folder: %w", err)
 	}
 	if !info.IsDir() {
 		return "", fmt.Errorf("the path provided is not a directory: %s", folder)
@@ -356,7 +355,7 @@ func FindWorkflowFile(fs afero.Fs, folder string, logger *logging.Logger) (strin
 	})
 
 	if err != nil && err != filepath.SkipDir {
-		return "", fmt.Errorf("error searching for file: %v", err)
+		return "", fmt.Errorf("error searching for file: %w", err)
 	}
 
 	if foundPath == "" {

--- a/pkg/archiver/resource_compiler.go
+++ b/pkg/archiver/resource_compiler.go
@@ -12,12 +12,11 @@ import (
 
 	"github.com/kdeps/kdeps/pkg/enforcer"
 	"github.com/kdeps/kdeps/pkg/logging"
-
 	pklWf "github.com/kdeps/schema/gen/workflow"
 	"github.com/spf13/afero"
 )
 
-// CompileResources processes .pkl files from the project directory and copies them to the resources directory
+// CompileResources processes .pkl files from the project directory and copies them to the resources directory.
 func CompileResources(fs afero.Fs, ctx context.Context, wf pklWf.Workflow, resourcesDir string, projectDir string, logger *logging.Logger) error {
 	projectResourcesDir := filepath.Join(projectDir, "resources")
 
@@ -51,7 +50,7 @@ func CompileResources(fs afero.Fs, ctx context.Context, wf pklWf.Workflow, resou
 	return nil
 }
 
-// processResourcePklFiles processes a .pkl file and writes modifications to the resources directory
+// processResourcePklFiles processes a .pkl file and writes modifications to the resources directory.
 func processResourcePklFiles(fs afero.Fs, ctx context.Context, file string, wf pklWf.Workflow, resourcesDir string, logger *logging.Logger) error {
 	name, version := wf.GetName(), wf.GetVersion()
 
@@ -174,7 +173,6 @@ func processResourcePklFiles(fs afero.Fs, ctx context.Context, file string, wf p
 				}
 			}
 		}
-
 	}
 
 	// Write back to the file if modifications were made
@@ -273,7 +271,7 @@ func CheckAndValidatePklFiles(fs afero.Fs, ctx context.Context, projectResources
 	files, err := afero.ReadDir(fs, projectResourcesDir)
 	if err != nil {
 		logger.Error("Error reading resource directory", "error", err)
-		return fmt.Errorf("failed to read directory '%s': %v", projectResourcesDir, err)
+		return fmt.Errorf("failed to read directory '%s': %w", projectResourcesDir, err)
 	}
 
 	// Filter for .pkl files
@@ -295,7 +293,7 @@ func CheckAndValidatePklFiles(fs afero.Fs, ctx context.Context, projectResources
 		logger.Debug("Validating .pkl file", "file", pklFile)
 		if err := enforcer.EnforcePklTemplateAmendsRules(fs, ctx, pklFile, logger); err != nil {
 			logger.Error("Validation failed for .pkl file", "file", pklFile, "error", err)
-			return fmt.Errorf("validation failed for '%s': %v", pklFile, err)
+			return fmt.Errorf("validation failed for '%s': %w", pklFile, err)
 		}
 	}
 

--- a/pkg/archiver/version_utils.go
+++ b/pkg/archiver/version_utils.go
@@ -1,6 +1,7 @@
 package archiver
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,7 +12,7 @@ import (
 )
 
 // Function to compare version numbers
-func compareVersions(versions []string, logger *logging.Logger) string {
+func compareVersions(ctx context.Context, versions []string, logger *logging.Logger) string {
 	logger.Debug("Comparing versions", "versions", versions)
 	sort.Slice(versions, func(i, j int) bool {
 		// Split the version strings into parts
@@ -35,7 +36,7 @@ func compareVersions(versions []string, logger *logging.Logger) string {
 	return latestVersion
 }
 
-func getLatestVersion(directory string, logger *logging.Logger) (string, error) {
+func getLatestVersion(ctx context.Context, directory string, logger *logging.Logger) (string, error) {
 	var versions []string
 
 	// Walk through the directory to collect version names
@@ -65,6 +66,6 @@ func getLatestVersion(directory string, logger *logging.Logger) (string, error) 
 	}
 
 	// Find the latest version
-	latestVersion := compareVersions(versions, logger)
+	latestVersion := compareVersions(ctx, versions, logger)
 	return latestVersion, nil
 }

--- a/pkg/archiver/version_utils.go
+++ b/pkg/archiver/version_utils.go
@@ -2,7 +2,7 @@ package archiver
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"os"
 	"path/filepath"
 	"sort"
@@ -11,7 +11,7 @@ import (
 	"github.com/kdeps/kdeps/pkg/logging"
 )
 
-// Function to compare version numbers
+// Function to compare version numbers.
 func compareVersions(ctx context.Context, versions []string, logger *logging.Logger) string {
 	logger.Debug("Comparing versions", "versions", versions)
 	sort.Slice(versions, func(i, j int) bool {
@@ -20,7 +20,7 @@ func compareVersions(ctx context.Context, versions []string, logger *logging.Log
 		v2 := strings.Split(versions[j], ".")
 
 		// Compare each part of the version (major, minor, patch)
-		for k := 0; k < len(v1); k++ {
+		for k := range v1 {
 			if v1[k] != v2[k] {
 				result := v1[k] > v2[k]
 				logger.Debug("Version comparison result", "v1", v1, "v2", v2, "result", result)
@@ -60,7 +60,7 @@ func getLatestVersion(ctx context.Context, directory string, logger *logging.Log
 
 	// Check if versions were found
 	if len(versions) == 0 {
-		err = fmt.Errorf("no versions found")
+		err = errors.New("no versions found")
 		logger.Warn("No versions found", "directory", directory)
 		return "", err
 	}

--- a/pkg/archiver/version_utils_test.go
+++ b/pkg/archiver/version_utils_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Test for compareVersions
+// Test for compareVersions.
 func TestCompareVersions(t *testing.T) {
 	var ctx context.Context
 	logging.CreateLogger()
@@ -39,7 +39,7 @@ func TestCompareVersions(t *testing.T) {
 	}
 }
 
-// Test for getLatestVersion
+// Test for getLatestVersion.
 func TestGetLatestVersion(t *testing.T) {
 	var ctx context.Context
 	logging.CreateLogger()

--- a/pkg/archiver/version_utils_test.go
+++ b/pkg/archiver/version_utils_test.go
@@ -1,6 +1,7 @@
 package archiver
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,6 +12,7 @@ import (
 
 // Test for compareVersions
 func TestCompareVersions(t *testing.T) {
+	var ctx context.Context
 	logging.CreateLogger()
 	logger := logging.GetLogger()
 
@@ -29,9 +31,9 @@ func TestCompareVersions(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			if test.expectPanic {
-				assert.Panics(t, func() { compareVersions(test.versions, logger) })
+				assert.Panics(t, func() { compareVersions(ctx, test.versions, logger) })
 			} else {
-				assert.Equal(t, test.expected, compareVersions(test.versions, logger))
+				assert.Equal(t, test.expected, compareVersions(ctx, test.versions, logger))
 			}
 		})
 	}
@@ -39,6 +41,7 @@ func TestCompareVersions(t *testing.T) {
 
 // Test for getLatestVersion
 func TestGetLatestVersion(t *testing.T) {
+	var ctx context.Context
 	logging.CreateLogger()
 	logger := logging.GetLogger()
 
@@ -54,20 +57,20 @@ func TestGetLatestVersion(t *testing.T) {
 	}
 
 	t.Run("Valid directory with versions", func(t *testing.T) {
-		latestVersion, err := getLatestVersion(tempDir, logger)
+		latestVersion, err := getLatestVersion(ctx, tempDir, logger)
 		assert.NoError(t, err, "Expected no error")
 		assert.Equal(t, "2.3.0", latestVersion, "Expected latest version")
 	})
 
 	t.Run("Empty directory", func(t *testing.T) {
 		emptyDir := t.TempDir()
-		latestVersion, err := getLatestVersion(emptyDir, logger)
+		latestVersion, err := getLatestVersion(ctx, emptyDir, logger)
 		assert.Error(t, err, "Expected error for no versions found")
 		assert.Equal(t, "", latestVersion, "Expected empty latest version")
 	})
 
 	t.Run("Invalid directory path", func(t *testing.T) {
-		latestVersion, err := getLatestVersion("/invalid/path", logger)
+		latestVersion, err := getLatestVersion(ctx, "/invalid/path", logger)
 		assert.Error(t, err, "Expected error for invalid path")
 		assert.Equal(t, "", latestVersion, "Expected empty latest version")
 	})

--- a/pkg/archiver/version_utils_test.go
+++ b/pkg/archiver/version_utils_test.go
@@ -12,6 +12,7 @@ import (
 
 // Test for compareVersions.
 func TestCompareVersions(t *testing.T) {
+	t.Parallel()
 	var ctx context.Context
 	logging.CreateLogger()
 	logger := logging.GetLogger()
@@ -30,6 +31,7 @@ func TestCompareVersions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			if test.expectPanic {
 				assert.Panics(t, func() { compareVersions(ctx, test.versions, logger) })
 			} else {
@@ -41,6 +43,7 @@ func TestCompareVersions(t *testing.T) {
 
 // Test for getLatestVersion.
 func TestGetLatestVersion(t *testing.T) {
+	t.Parallel()
 	var ctx context.Context
 	logging.CreateLogger()
 	logger := logging.GetLogger()
@@ -57,12 +60,14 @@ func TestGetLatestVersion(t *testing.T) {
 	}
 
 	t.Run("Valid directory with versions", func(t *testing.T) {
+		t.Parallel()
 		latestVersion, err := getLatestVersion(ctx, tempDir, logger)
 		assert.NoError(t, err, "Expected no error")
 		assert.Equal(t, "2.3.0", latestVersion, "Expected latest version")
 	})
 
 	t.Run("Empty directory", func(t *testing.T) {
+		t.Parallel()
 		emptyDir := t.TempDir()
 		latestVersion, err := getLatestVersion(ctx, emptyDir, logger)
 		assert.Error(t, err, "Expected error for no versions found")
@@ -70,6 +75,7 @@ func TestGetLatestVersion(t *testing.T) {
 	})
 
 	t.Run("Invalid directory path", func(t *testing.T) {
+		t.Parallel()
 		latestVersion, err := getLatestVersion(ctx, "/invalid/path", logger)
 		assert.Error(t, err, "Expected error for invalid path")
 		assert.Equal(t, "", latestVersion, "Expected empty latest version")

--- a/pkg/archiver/workflow_handler.go
+++ b/pkg/archiver/workflow_handler.go
@@ -17,7 +17,6 @@ import (
 	"github.com/kdeps/kdeps/pkg/environment"
 	"github.com/kdeps/kdeps/pkg/logging"
 	"github.com/kdeps/kdeps/pkg/workflow"
-
 	pklWf "github.com/kdeps/schema/gen/workflow"
 	"github.com/spf13/afero"
 )
@@ -115,7 +114,7 @@ func PrepareRunDir(fs afero.Fs, ctx context.Context, wf pklWf.Workflow, kdepsDir
 	return runDir, nil
 }
 
-// CompileWorkflow compiles a workflow file and updates the action field
+// CompileWorkflow compiles a workflow file and updates the action field.
 func CompileWorkflow(fs afero.Fs, ctx context.Context, wf pklWf.Workflow, kdepsDir, projectDir string, logger *logging.Logger) (string, error) {
 	action := wf.GetAction()
 
@@ -218,7 +217,7 @@ func CompileWorkflow(fs afero.Fs, ctx context.Context, wf pklWf.Workflow, kdepsD
 	return compiledProjectDir, nil
 }
 
-// CompileProject orchestrates the compilation and packaging of a project
+// CompileProject orchestrates the compilation and packaging of a project.
 func CompileProject(fs afero.Fs, ctx context.Context, wf pklWf.Workflow, kdepsDir string, projectDir string, env *environment.Environment, logger *logging.Logger) (string, string, error) {
 	// Compile the workflow
 	compiledProjectDir, err := CompileWorkflow(fs, ctx, wf, kdepsDir, projectDir, logger)
@@ -307,7 +306,7 @@ func CompileProject(fs afero.Fs, ctx context.Context, wf pklWf.Workflow, kdepsDi
 	return compiledProjectDir, packageFile, nil
 }
 
-// ProcessExternalWorkflows processes each workflow and copies directories as needed
+// ProcessExternalWorkflows processes each workflow and copies directories as needed.
 func ProcessExternalWorkflows(fs afero.Fs, ctx context.Context, wf pklWf.Workflow, kdepsDir, projectDir, compiledProjectDir string, logger *logging.Logger) error {
 	if wf.GetWorkflows() == nil {
 		logger.Debug("No external workflows to process")
@@ -340,7 +339,6 @@ func ProcessExternalWorkflows(fs afero.Fs, ctx context.Context, wf pklWf.Workflo
 					return err
 				}
 			}
-
 		} else {
 			// No version present, check if there is an action
 			agentAndAction := strings.SplitN(value, "/", 2)

--- a/pkg/archiver/workflow_handler.go
+++ b/pkg/archiver/workflow_handler.go
@@ -22,7 +22,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-func PrepareRunDir(fs afero.Fs, wf pklWf.Workflow, kdepsDir, pkgFilePath string, logger *logging.Logger) (string, error) {
+func PrepareRunDir(fs afero.Fs, ctx context.Context, wf pklWf.Workflow, kdepsDir, pkgFilePath string, logger *logging.Logger) (string, error) {
 	agentName, agentVersion := wf.GetName(), wf.GetVersion()
 
 	runDir := filepath.Join(kdepsDir, "run/"+agentName+"/"+agentVersion+"/workflow")
@@ -116,7 +116,7 @@ func PrepareRunDir(fs afero.Fs, wf pklWf.Workflow, kdepsDir, pkgFilePath string,
 }
 
 // CompileWorkflow compiles a workflow file and updates the action field
-func CompileWorkflow(fs afero.Fs, wf pklWf.Workflow, kdepsDir, projectDir string, logger *logging.Logger) (string, error) {
+func CompileWorkflow(fs afero.Fs, ctx context.Context, wf pklWf.Workflow, kdepsDir, projectDir string, logger *logging.Logger) (string, error) {
 	action := wf.GetAction()
 
 	if action == "" {
@@ -208,7 +208,7 @@ func CompileWorkflow(fs afero.Fs, wf pklWf.Workflow, kdepsDir, projectDir string
 	}
 	logger.Debug("Compiled workflow file written", "path", compiledFilePath)
 
-	if err := enforcer.EnforcePklTemplateAmendsRules(fs, compiledFilePath, logger); err != nil {
+	if err := enforcer.EnforcePklTemplateAmendsRules(fs, ctx, compiledFilePath, logger); err != nil {
 		logger.Error("Validation failed for .pkl file", "file", compiledFilePath, "error", err)
 		return "", err
 	}
@@ -221,7 +221,7 @@ func CompileWorkflow(fs afero.Fs, wf pklWf.Workflow, kdepsDir, projectDir string
 // CompileProject orchestrates the compilation and packaging of a project
 func CompileProject(fs afero.Fs, ctx context.Context, wf pklWf.Workflow, kdepsDir string, projectDir string, env *environment.Environment, logger *logging.Logger) (string, string, error) {
 	// Compile the workflow
-	compiledProjectDir, err := CompileWorkflow(fs, wf, kdepsDir, projectDir, logger)
+	compiledProjectDir, err := CompileWorkflow(fs, ctx, wf, kdepsDir, projectDir, logger)
 	if err != nil {
 		logger.Error("Failed to compile workflow", "error", err)
 		return "", "", err
@@ -260,25 +260,25 @@ func CompileProject(fs afero.Fs, ctx context.Context, wf pklWf.Workflow, kdepsDi
 
 	// Compile resources
 	resourcesDir := filepath.Join(compiledProjectDir, "resources")
-	if err := CompileResources(fs, newWorkflow, resourcesDir, projectDir, logger); err != nil {
+	if err := CompileResources(fs, ctx, newWorkflow, resourcesDir, projectDir, logger); err != nil {
 		logger.Error("Failed to compile resources", "resourcesDir", resourcesDir, "projectDir", projectDir, "error", err)
 		return "", "", err
 	}
 
 	// Copy the project directory
-	if err := CopyDataDir(fs, newWorkflow, kdepsDir, projectDir, compiledProjectDir, "", "", "", false, logger); err != nil {
+	if err := CopyDataDir(fs, ctx, newWorkflow, kdepsDir, projectDir, compiledProjectDir, "", "", "", false, logger); err != nil {
 		logger.Error("Failed to copy project directory", "compiledProjectDir", compiledProjectDir, "error", err)
 		return "", "", err
 	}
 
 	// Process workflows
-	if err := ProcessExternalWorkflows(fs, newWorkflow, kdepsDir, projectDir, compiledProjectDir, logger); err != nil {
+	if err := ProcessExternalWorkflows(fs, ctx, newWorkflow, kdepsDir, projectDir, compiledProjectDir, logger); err != nil {
 		logger.Error("Failed to process workflows", "compiledProjectDir", compiledProjectDir, "error", err)
 		return "", "", err
 	}
 
 	// Package the project
-	packageFile, err := PackageProject(fs, newWorkflow, kdepsDir, compiledProjectDir, logger)
+	packageFile, err := PackageProject(fs, ctx, newWorkflow, kdepsDir, compiledProjectDir, logger)
 	if err != nil {
 		logger.Error("Failed to package project", "compiledProjectDir", compiledProjectDir, "error", err)
 		return "", "", err
@@ -298,7 +298,7 @@ func CompileProject(fs afero.Fs, ctx context.Context, wf pklWf.Workflow, kdepsDi
 	logger.Debug("Kdeps package created in system archive", "package-file", packageFile)
 
 	cwdPackage := filepath.Join(env.Pwd, filepath.Base(packageFile))
-	if err := CopyFile(fs, packageFile, cwdPackage, logger); err != nil {
+	if err := CopyFile(fs, ctx, packageFile, cwdPackage, logger); err != nil {
 		return "", "", err
 	}
 
@@ -308,7 +308,7 @@ func CompileProject(fs afero.Fs, ctx context.Context, wf pklWf.Workflow, kdepsDi
 }
 
 // ProcessExternalWorkflows processes each workflow and copies directories as needed
-func ProcessExternalWorkflows(fs afero.Fs, wf pklWf.Workflow, kdepsDir, projectDir, compiledProjectDir string, logger *logging.Logger) error {
+func ProcessExternalWorkflows(fs afero.Fs, ctx context.Context, wf pklWf.Workflow, kdepsDir, projectDir, compiledProjectDir string, logger *logging.Logger) error {
 	if wf.GetWorkflows() == nil {
 		logger.Debug("No external workflows to process")
 		return nil
@@ -330,12 +330,12 @@ func ProcessExternalWorkflows(fs afero.Fs, wf pklWf.Workflow, kdepsDir, projectD
 			if len(agentAndAction) == 2 {
 				action := agentAndAction[1]
 
-				if err := CopyDataDir(fs, wf, kdepsDir, projectDir, compiledProjectDir, agentName, version, action, true, logger); err != nil {
+				if err := CopyDataDir(fs, ctx, wf, kdepsDir, projectDir, compiledProjectDir, agentName, version, action, true, logger); err != nil {
 					logger.Error("Failed to copy directory", "agentName", agentName, "version", version, "action", action, "error", err)
 					return err
 				}
 			} else {
-				if err := CopyDataDir(fs, wf, kdepsDir, projectDir, compiledProjectDir, agentName, version, "", true, logger); err != nil {
+				if err := CopyDataDir(fs, ctx, wf, kdepsDir, projectDir, compiledProjectDir, agentName, version, "", true, logger); err != nil {
 					logger.Error("Failed to copy directory", "agentName", agentName, "version", version, "error", err)
 					return err
 				}
@@ -348,12 +348,12 @@ func ProcessExternalWorkflows(fs afero.Fs, wf pklWf.Workflow, kdepsDir, projectD
 
 			if len(agentAndAction) == 2 {
 				action := agentAndAction[1]
-				if err := CopyDataDir(fs, wf, kdepsDir, projectDir, compiledProjectDir, agentName, "", action, true, logger); err != nil {
+				if err := CopyDataDir(fs, ctx, wf, kdepsDir, projectDir, compiledProjectDir, agentName, "", action, true, logger); err != nil {
 					logger.Error("Failed to copy directory", "agentName", agentName, "action", action, "error", err)
 					return err
 				}
 			} else {
-				if err := CopyDataDir(fs, wf, kdepsDir, projectDir, compiledProjectDir, agentName, "", "", true, logger); err != nil {
+				if err := CopyDataDir(fs, ctx, wf, kdepsDir, projectDir, compiledProjectDir, agentName, "", "", true, logger); err != nil {
 					logger.Error("Failed to copy directory", "agentName", agentName, "error", err)
 					return err
 				}

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -23,7 +23,7 @@ func FindConfiguration(fs afero.Fs, ctx context.Context, env *environment.Enviro
 	logger.Debug("Finding configuration...")
 
 	// Ensure PKL binary exists before proceeding
-	if err := evaluator.EnsurePklBinaryExists(logger); err != nil {
+	if err := evaluator.EnsurePklBinaryExists(ctx, logger); err != nil {
 		return "", err
 	}
 
@@ -72,7 +72,7 @@ func GenerateConfiguration(fs afero.Fs, ctx context.Context, env *environment.En
 		url := fmt.Sprintf("package://schema.kdeps.com/core@%s#/Kdeps.pkl", schema.SchemaVersion())
 		headerSection := fmt.Sprintf("amends \"%s\"\n", url)
 
-		content, err := evaluator.EvalPkl(fs, url, headerSection, logger)
+		content, err := evaluator.EvalPkl(fs, ctx, url, headerSection, logger)
 		if err != nil {
 			return "", fmt.Errorf("failed to evaluate .pkl file: %w", err)
 		}
@@ -87,7 +87,7 @@ func GenerateConfiguration(fs afero.Fs, ctx context.Context, env *environment.En
 	return configFile, nil
 }
 
-func EditConfiguration(fs afero.Fs, env *environment.Environment, logger *logging.Logger) (string, error) {
+func EditConfiguration(fs afero.Fs, ctx context.Context, env *environment.Environment, logger *logging.Logger) (string, error) {
 	logger.Debug("Editing configuration...")
 
 	configFile := filepath.Join(env.Home, environment.SystemConfigFileName)
@@ -95,7 +95,7 @@ func EditConfiguration(fs afero.Fs, env *environment.Environment, logger *loggin
 
 	if _, err := fs.Stat(configFile); err == nil {
 		if !skipPrompts {
-			if err := texteditor.EditPkl(fs, configFile, logger); err != nil {
+			if err := texteditor.EditPkl(fs, ctx, configFile, logger); err != nil {
 				return configFile, fmt.Errorf("failed to edit configuration file: %w", err)
 			}
 		}
@@ -111,7 +111,7 @@ func ValidateConfiguration(fs afero.Fs, ctx context.Context, env *environment.En
 
 	configFile := filepath.Join(env.Home, environment.SystemConfigFileName)
 
-	if _, err := evaluator.EvalPkl(fs, configFile, "", logger); err != nil {
+	if _, err := evaluator.EvalPkl(fs, ctx, configFile, "", logger); err != nil {
 		return configFile, fmt.Errorf("configuration validation failed: %w", err)
 	}
 
@@ -122,7 +122,7 @@ func ValidateConfiguration(fs afero.Fs, ctx context.Context, env *environment.En
 func LoadConfiguration(fs afero.Fs, ctx context.Context, configFile string, logger *logging.Logger) (*kdeps.Kdeps, error) {
 	logger.Debug("Loading configuration", "config-file", configFile)
 
-	konfig, err := kdeps.LoadFromPath(context.Background(), configFile)
+	konfig, err := kdeps.LoadFromPath(ctx, configFile)
 	if err != nil {
 		return nil, fmt.Errorf("error reading config file '%s': %w", configFile, err)
 	}
@@ -130,7 +130,7 @@ func LoadConfiguration(fs afero.Fs, ctx context.Context, configFile string, logg
 	return konfig, nil
 }
 
-func GetKdepsPath(kdepsCfg kdeps.Kdeps) (string, error) {
+func GetKdepsPath(ctx context.Context, kdepsCfg kdeps.Kdeps) (string, error) {
 	kdepsDir := kdepsCfg.KdepsDir
 	p := kdepsCfg.KdepsPath
 

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -19,7 +19,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-func FindConfiguration(fs afero.Fs, env *environment.Environment, logger *logging.Logger) (string, error) {
+func FindConfiguration(fs afero.Fs, ctx context.Context, env *environment.Environment, logger *logging.Logger) (string, error) {
 	logger.Debug("Finding configuration...")
 
 	// Ensure PKL binary exists before proceeding
@@ -45,7 +45,7 @@ func FindConfiguration(fs afero.Fs, env *environment.Environment, logger *loggin
 	return "", nil
 }
 
-func GenerateConfiguration(fs afero.Fs, env *environment.Environment, logger *logging.Logger) (string, error) {
+func GenerateConfiguration(fs afero.Fs, ctx context.Context, env *environment.Environment, logger *logging.Logger) (string, error) {
 	logger.Debug("Generating configuration...")
 
 	// Set configFile path in Home directory

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -69,7 +69,7 @@ func GenerateConfiguration(fs afero.Fs, ctx context.Context, env *environment.En
 		}
 
 		// Generate configuration
-		url := fmt.Sprintf("package://schema.kdeps.com/core@%s#/Kdeps.pkl", schema.SchemaVersion())
+		url := fmt.Sprintf("package://schema.kdeps.com/core@%s#/Kdeps.pkl", schema.SchemaVersion(ctx))
 		headerSection := fmt.Sprintf("amends \"%s\"\n", url)
 
 		content, err := evaluator.EvalPkl(fs, ctx, url, headerSection, logger)

--- a/pkg/cfg/cfg_test.go
+++ b/pkg/cfg/cfg_test.go
@@ -7,10 +7,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/cucumber/godog"
 	"github.com/kdeps/kdeps/pkg/environment"
 	"github.com/kdeps/kdeps/pkg/logging"
-
-	"github.com/cucumber/godog"
 	"github.com/spf13/afero"
 )
 
@@ -208,7 +207,7 @@ func theConfigurationFailsToLoadAnyConfiguration() error {
 
 	cfgFile, err := FindConfiguration(testFs, ctx, environ, logger)
 	if err != nil {
-		return errors.New(fmt.Sprintf("An error occurred while finding configuration: %s", err))
+		return fmt.Errorf("An error occurred while finding configuration: %w", err)
 	}
 	if cfgFile != "" {
 		return errors.New("expected not finding configuration file, but found")

--- a/pkg/cfg/cfg_test.go
+++ b/pkg/cfg/cfg_test.go
@@ -20,7 +20,7 @@ var (
 	homeDirPath    string
 	testConfigFile string
 	fileThatExist  string
-	ctx            context.Context
+	ctx            = context.Background()
 	logger         *logging.Logger
 	testingT       *testing.T
 )

--- a/pkg/cfg/cfg_test.go
+++ b/pkg/cfg/cfg_test.go
@@ -127,12 +127,12 @@ func theConfigurationIsLoadedInTheCurrentDirectory() error {
 		Pwd:  currentDirPath,
 	}
 
-	environ, err := environment.NewEnvironment(testFs, env)
+	environ, err := environment.NewEnvironment(testFs, ctx, env)
 	if err != nil {
 		return err
 	}
 
-	cfgFile, err := FindConfiguration(testFs, environ, logger)
+	cfgFile, err := FindConfiguration(testFs, ctx, environ, logger)
 	if err != nil {
 		return err
 	}
@@ -150,12 +150,12 @@ func theConfigurationIsLoadedInTheHomeDirectory() error {
 		Pwd:  "",
 	}
 
-	environ, err := environment.NewEnvironment(testFs, env)
+	environ, err := environment.NewEnvironment(testFs, ctx, env)
 	if err != nil {
 		return err
 	}
 
-	cfgFile, err := FindConfiguration(testFs, environ, logger)
+	cfgFile, err := FindConfiguration(testFs, ctx, environ, logger)
 	if err != nil {
 		return err
 	}
@@ -201,12 +201,12 @@ func theConfigurationFailsToLoadAnyConfiguration() error {
 		Pwd:  currentDirPath,
 	}
 
-	environ, err := environment.NewEnvironment(testFs, env)
+	environ, err := environment.NewEnvironment(testFs, ctx, env)
 	if err != nil {
 		return err
 	}
 
-	cfgFile, err := FindConfiguration(testFs, environ, logger)
+	cfgFile, err := FindConfiguration(testFs, ctx, environ, logger)
 	if err != nil {
 		return errors.New(fmt.Sprintf("An error occurred while finding configuration: %s", err))
 	}
@@ -224,12 +224,12 @@ func theConfigurationFileWillBeGeneratedTo(arg1 string) error {
 		NonInteractive: "1",
 	}
 
-	environ, err := environment.NewEnvironment(testFs, env)
+	environ, err := environment.NewEnvironment(testFs, ctx, env)
 	if err != nil {
 		return err
 	}
 
-	cfgFile, err := GenerateConfiguration(testFs, environ, logger)
+	cfgFile, err := GenerateConfiguration(testFs, ctx, environ, logger)
 	if err != nil {
 		return err
 	}
@@ -248,12 +248,12 @@ func theConfigurationWillBeEdited() error {
 		NonInteractive: "1",
 	}
 
-	environ, err := environment.NewEnvironment(testFs, env)
+	environ, err := environment.NewEnvironment(testFs, ctx, env)
 	if err != nil {
 		return err
 	}
 
-	if _, err := EditConfiguration(testFs, environ, logger); err != nil {
+	if _, err := EditConfiguration(testFs, ctx, environ, logger); err != nil {
 		return err
 	}
 
@@ -266,7 +266,7 @@ func theConfigurationWillBeValidated() error {
 		Pwd:  "",
 	}
 
-	environ, err := environment.NewEnvironment(testFs, env)
+	environ, err := environment.NewEnvironment(testFs, ctx, env)
 	if err != nil {
 		return err
 	}

--- a/pkg/cfg/cfg_test.go
+++ b/pkg/cfg/cfg_test.go
@@ -25,6 +25,7 @@ var (
 )
 
 func TestFeatures(t *testing.T) {
+	t.Parallel()
 	suite := godog.TestSuite{
 		ScenarioInitializer: func(ctx *godog.ScenarioContext) {
 			ctx.Step(`^a file "([^"]*)" exists in the current directory$`, aFileExistsInTheCurrentDirectory)

--- a/pkg/docker/api_server.go
+++ b/pkg/docker/api_server.go
@@ -98,7 +98,7 @@ func ApiServerHandler(fs afero.Fs, ctx context.Context, route *apiserver.APIServ
 ) http.HandlerFunc {
 	allowedMethods := route.Methods
 
-	dr, err := resolver.NewGraphResolver(fs, logger, ctx, env, agentDir)
+	dr, err := resolver.NewGraphResolver(fs, ctx, env, agentDir, logger)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -294,7 +294,7 @@ filetype = "%s"
 		sections := []string{urlSection, method, headerSection, dataSection, paramSection, fileSection}
 
 		// Create and process the .pkl request file
-		if err := evaluator.CreateAndProcessPklFile(dr.Fs, sections, dr.RequestPklFile, "APIServerRequest.pkl",
+		if err := evaluator.CreateAndProcessPklFile(dr.Fs, dr.Context, sections, dr.RequestPklFile, "APIServerRequest.pkl",
 			logger, evaluator.EvalPkl, true); err != nil {
 			http.Error(w, "Failed to process request file", http.StatusInternalServerError)
 			return
@@ -524,7 +524,7 @@ func processWorkflow(dr *resolver.DependencyResolver, logger *logging.Logger) (b
 	logger.Debug("Awaiting response...")
 
 	// Wait for the response file to be ready
-	if err := utils.WaitForFileReady(dr.Fs, dr.ResponseTargetFile, logger); err != nil {
+	if err := utils.WaitForFileReady(dr.Fs, dr.Context, dr.ResponseTargetFile, logger); err != nil {
 		return false, err
 	}
 

--- a/pkg/docker/api_server.go
+++ b/pkg/docker/api_server.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -12,26 +13,25 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/charmbracelet/log"
+	"github.com/gabriel-vasile/mimetype"
 	"github.com/kdeps/kdeps/pkg/environment"
 	"github.com/kdeps/kdeps/pkg/evaluator"
 	"github.com/kdeps/kdeps/pkg/logging"
 	"github.com/kdeps/kdeps/pkg/resolver"
 	"github.com/kdeps/kdeps/pkg/utils"
-
-	"github.com/charmbracelet/log"
-	"github.com/gabriel-vasile/mimetype"
 	apiserver "github.com/kdeps/schema/gen/api_server"
 	pklWf "github.com/kdeps/schema/gen/workflow"
 	"github.com/spf13/afero"
 )
 
-// ErrorResponse defines the structure of each error
+// ErrorResponse defines the structure of each error.
 type ErrorResponse struct {
 	Code    int    `json:"code"`
 	Message string `json:"message"`
 }
 
-// DecodedResponse defines the overall response structure
+// DecodedResponse defines the overall response structure.
 type DecodedResponse struct {
 	Success  bool `json:"success"`
 	Response struct {
@@ -50,7 +50,7 @@ func StartApiServerMode(fs afero.Fs, ctx context.Context, wfCfg pklWf.Workflow, 
 	wfApiServer := wfSettings.ApiServer
 
 	if wfApiServer == nil {
-		return fmt.Errorf("API server configuration is missing")
+		return errors.New("API server configuration is missing")
 	}
 
 	// Format the server host and port
@@ -133,9 +133,9 @@ func ApiServerHandler(fs afero.Fs, ctx context.Context, route *apiserver.APIServ
 			return
 		}
 
-		var filename string = ""
-		var filetype string = ""
-		var bodyData string = ""
+		var filename = ""
+		var filetype = ""
+		var bodyData = ""
 
 		fileMap := make(map[string]struct {
 			Filename string
@@ -338,7 +338,7 @@ filetype = "%s"
 	}
 }
 
-// Helper function to detect if a string is valid JSON
+// Helper function to detect if a string is valid JSON.
 func isJSON(str string) bool {
 	var js json.RawMessage
 	return json.Unmarshal([]byte(str), &js) == nil
@@ -480,7 +480,6 @@ func formatHeaders(headers map[string][]string) string {
 		for _, value := range values {
 			encodedValue := utils.EncodeBase64String(strings.TrimSpace(value))
 			headersLines = append(headersLines, fmt.Sprintf(`["%s"] = "%s"`, name, encodedValue))
-
 		}
 	}
 

--- a/pkg/docker/api_server.go
+++ b/pkg/docker/api_server.go
@@ -133,9 +133,9 @@ func ApiServerHandler(fs afero.Fs, ctx context.Context, route *apiserver.APIServ
 			return
 		}
 
-		var filename = ""
-		var filetype = ""
-		var bodyData = ""
+		filename := ""
+		filetype := ""
+		bodyData := ""
 
 		fileMap := make(map[string]struct {
 			Filename string

--- a/pkg/docker/bootstrap.go
+++ b/pkg/docker/bootstrap.go
@@ -2,7 +2,6 @@ package docker
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -12,11 +11,10 @@ import (
 	"github.com/kdeps/kdeps/pkg/logging"
 	"github.com/kdeps/kdeps/pkg/resolver"
 	"github.com/kdeps/kdeps/pkg/workflow"
-
 	"github.com/spf13/afero"
 )
 
-// BootstrapDockerSystem initializes the Docker system and pulls models after ollama server is ready
+// BootstrapDockerSystem initializes the Docker system and pulls models after ollama server is ready.
 func BootstrapDockerSystem(fs afero.Fs, ctx context.Context, environ *environment.Environment, logger *logging.Logger) (bool, error) {
 	var apiServerMode bool
 
@@ -37,12 +35,12 @@ func BootstrapDockerSystem(fs afero.Fs, ctx context.Context, environ *environmen
 
 			dr, err := resolver.NewGraphResolver(fs, ctx, env, "/agent", logger)
 			if err != nil {
-				return false, errors.New(fmt.Sprintf("failed to create graph resolver: %s", err))
+				return false, fmt.Errorf("failed to create graph resolver: %w", err)
 			}
 
 			// Prepare workflow directory
 			if err := dr.PrepareWorkflowDir(); err != nil {
-				return false, errors.New(fmt.Sprintf("failed to prepare workflow directory: %s", err))
+				return false, fmt.Errorf("failed to prepare workflow directory: %w", err)
 			}
 		}
 
@@ -60,7 +58,7 @@ func BootstrapDockerSystem(fs afero.Fs, ctx context.Context, environ *environmen
 
 		// Start ollama server in the background
 		if err := startOllamaServer(logger); err != nil {
-			return apiServerMode, fmt.Errorf("Failed to start ollama server: %v", err)
+			return apiServerMode, fmt.Errorf("Failed to start ollama server: %w", err)
 		}
 
 		// Wait for ollama server to be fully ready (using the parsed host and port)
@@ -81,7 +79,7 @@ func BootstrapDockerSystem(fs afero.Fs, ctx context.Context, environ *environmen
 			stdout, stderr, exitCode, err := KdepsExec("ollama", []string{"pull", value}, logger)
 			if err != nil {
 				logger.Error("Error pulling model: ", value, " stdout: ", stdout, " stderr: ", stderr, " exitCode: ", exitCode, " err: ", err)
-				return apiServerMode, fmt.Errorf("Error pulling model %s: %s %s %d %v", value, stdout, stderr, exitCode, err)
+				return apiServerMode, fmt.Errorf("Error pulling model %s: %s %s %d %w", value, stdout, stderr, exitCode, err)
 			}
 		}
 

--- a/pkg/docker/bootstrap.go
+++ b/pkg/docker/bootstrap.go
@@ -35,7 +35,7 @@ func BootstrapDockerSystem(fs afero.Fs, ctx context.Context, environ *environmen
 				return false, err
 			}
 
-			dr, err := resolver.NewGraphResolver(fs, logger, ctx, env, "/agent")
+			dr, err := resolver.NewGraphResolver(fs, ctx, env, "/agent", logger)
 			if err != nil {
 				return false, errors.New(fmt.Sprintf("failed to create graph resolver: %s", err))
 			}
@@ -53,7 +53,7 @@ func BootstrapDockerSystem(fs afero.Fs, ctx context.Context, environ *environmen
 		}
 
 		// Parse OLLAMA_HOST to get the host and port
-		host, port, err := parseOLLAMAHost(logger)
+		host, port, err := parseOLLAMAHost(ctx, logger)
 		if err != nil {
 			return apiServerMode, err
 		}
@@ -103,7 +103,7 @@ func BootstrapDockerSystem(fs afero.Fs, ctx context.Context, environ *environmen
 	return apiServerMode, nil
 }
 
-func CreateFlagFile(fs afero.Fs, filename string) error {
+func CreateFlagFile(fs afero.Fs, ctx context.Context, filename string) error {
 	// Check if file exists
 	if exists, err := afero.Exists(fs, filename); err != nil {
 		return err

--- a/pkg/docker/bootstrap.go
+++ b/pkg/docker/bootstrap.go
@@ -30,7 +30,7 @@ func BootstrapDockerSystem(fs afero.Fs, ctx context.Context, environ *environmen
 
 		exists, err := afero.Exists(fs, agentWorkflow)
 		if !exists {
-			env, err := environment.NewEnvironment(fs, nil)
+			env, err := environment.NewEnvironment(fs, ctx, nil)
 			if err != nil {
 				return false, err
 			}

--- a/pkg/docker/cache.go
+++ b/pkg/docker/cache.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -94,7 +95,7 @@ func GetLatestAnacondaVersions(ctx context.Context) (map[string]string, map[stri
 	re := regexp.MustCompile(`Anaconda3-(\d+\.\d+-\d+)-Linux-(x86_64|aarch64)\.sh`)
 	matches := re.FindAllStringSubmatch(string(body), -1)
 	if len(matches) == 0 {
-		return nil, nil, fmt.Errorf("no Anaconda versions found")
+		return nil, nil, errors.New("no Anaconda versions found")
 	}
 
 	// Map to hold the latest version for each architecture.

--- a/pkg/docker/cleanup_utils.go
+++ b/pkg/docker/cleanup_utils.go
@@ -6,14 +6,13 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
 	"github.com/kdeps/kdeps/pkg/archiver"
 	"github.com/kdeps/kdeps/pkg/environment"
 	"github.com/kdeps/kdeps/pkg/logging"
 	"github.com/kdeps/kdeps/pkg/utils"
-
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/docker/client"
 	"github.com/spf13/afero"
 )
 
@@ -46,7 +45,7 @@ func CleanupDockerBuildImages(fs afero.Fs, ctx context.Context, cName string, cl
 	return nil
 }
 
-// Cleanup deletes /agent/action and /agent/workflow directories, then copies /agent/project to /agent/workflow
+// Cleanup deletes /agent/action and /agent/workflow directories, then copies /agent/project to /agent/workflow.
 func Cleanup(fs afero.Fs, ctx context.Context, environ *environment.Environment, logger *logging.Logger) {
 	if environ.DockerMode != "1" {
 		return
@@ -64,7 +63,7 @@ func Cleanup(fs afero.Fs, ctx context.Context, environ *environment.Environment,
 			return err
 		}
 
-		logger.Debug(fmt.Sprintf("%s directory deleted", dir))
+		logger.Debug(dir + " directory deleted")
 		if err := CreateFlagFile(fs, ctx, flagFile); err != nil {
 			logger.Error(fmt.Sprintf("Unable to create flag file %s: %v", flagFile, err))
 			return err
@@ -100,7 +99,7 @@ func Cleanup(fs afero.Fs, ctx context.Context, environ *environment.Environment,
 
 		if info.IsDir() {
 			if err := fs.MkdirAll(targetPath, info.Mode()); err != nil {
-				return fmt.Errorf("failed to create directory %s: %v", targetPath, err)
+				return fmt.Errorf("failed to create directory %s: %w", targetPath, err)
 			}
 		} else {
 			// Copy the file from projectDir to workflowDir
@@ -126,7 +125,7 @@ func Cleanup(fs afero.Fs, ctx context.Context, environ *environment.Environment,
 	cleanupFlagFiles(fs, ctx, removedFiles, logger)
 }
 
-// cleanupFlagFiles removes the specified flag files
+// cleanupFlagFiles removes the specified flag files.
 func cleanupFlagFiles(fs afero.Fs, ctx context.Context, files []string, logger *logging.Logger) {
 	for _, file := range files {
 		if err := fs.Remove(file); err != nil {

--- a/pkg/docker/container.go
+++ b/pkg/docker/container.go
@@ -25,7 +25,7 @@ func CreateDockerContainer(fs afero.Fs, ctx context.Context, cName, containerNam
 		Env:   envSlice, // Add the loaded environment variables (or nil)
 	}
 
-	tcpPort := fmt.Sprintf("%s/tcp", portNum)
+	tcpPort := portNum + "/tcp"
 	hostConfig := &container.HostConfig{
 		Binds: []string{
 			"ollama:/root/.ollama",
@@ -89,7 +89,7 @@ func CreateDockerContainer(fs afero.Fs, ctx context.Context, cName, containerNam
 
 	for _, resp := range containers {
 		for _, name := range resp.Names {
-			if name == fmt.Sprintf("/%s", containerNameWithGpu) {
+			if name == "/"+containerNameWithGpu {
 				// If the container exists, start it if it's not running
 				if resp.State != "running" {
 					err := cli.ContainerStart(ctx, resp.ID, container.StartOptions{})

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -123,12 +123,12 @@ dockerGPU = "%s"
 		return err
 	}
 
-	systemConfigurationFile, err := cfg.FindConfiguration(testFs, environ, logger)
+	systemConfigurationFile, err := cfg.FindConfiguration(testFs, ctx, environ, logger)
 	if err != nil {
 		return err
 	}
 
-	if err := enforcer.EnforcePklTemplateAmendsRules(testFs, systemConfigurationFile, logger); err != nil {
+	if err := enforcer.EnforcePklTemplateAmendsRules(testFs, ctx, systemConfigurationFile, logger); err != nil {
 		return err
 	}
 
@@ -247,7 +247,7 @@ description = "An action from agent %s"
 		f.Close()
 	}
 
-	if err := enforcer.EnforcePklTemplateAmendsRules(testFs, workflowConfigurationFile, logger); err != nil {
+	if err := enforcer.EnforcePklTemplateAmendsRules(testFs, ctx, workflowConfigurationFile, logger); err != nil {
 		return err
 	}
 

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -11,15 +11,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cucumber/godog"
+	"github.com/docker/docker/client"
 	"github.com/kdeps/kdeps/pkg/archiver"
 	"github.com/kdeps/kdeps/pkg/cfg"
 	"github.com/kdeps/kdeps/pkg/enforcer"
 	"github.com/kdeps/kdeps/pkg/environment"
 	"github.com/kdeps/kdeps/pkg/logging"
 	"github.com/kdeps/kdeps/pkg/workflow"
-
-	"github.com/cucumber/godog"
-	"github.com/docker/docker/client"
 	"github.com/kdeps/schema/gen/kdeps"
 	wfPkl "github.com/kdeps/schema/gen/workflow"
 	"github.com/spf13/afero"
@@ -225,7 +224,7 @@ id = "%s"
 description = "An action from agent %s"
 	`, arg1, arg1)
 
-	resourceConfigurationFile := filepath.Join(resourcesDir, fmt.Sprintf("%s.pkl", arg1))
+	resourceConfigurationFile := filepath.Join(resourcesDir, arg1+".pkl")
 	err = afero.WriteFile(testFs, resourceConfigurationFile, []byte(resourceConfigurationContent), 0o644)
 	if err != nil {
 		return err
@@ -238,7 +237,7 @@ description = "An action from agent %s"
 
 	doc := "THIS IS A TEXT FILE: "
 
-	for x := 0; x < 10; x++ {
+	for x := range 10 {
 		num := strconv.Itoa(x)
 		file := filepath.Join(dataDir, fmt.Sprintf("textfile-%s.txt", num))
 
@@ -351,7 +350,6 @@ func itShouldCreateTheDockerfile(arg1, arg2, arg3 string) error {
 		if !found {
 			return errors.New("package not found!")
 		}
-
 	}
 
 	runDirAgentRoot := filepath.Join(kdepsDir, "run/"+arg1)

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -50,10 +50,11 @@ var (
 	systemConfiguration       *kdeps.Kdeps
 	workflowConfigurationFile string
 	workflowConfiguration     *wfPkl.Workflow
-	schemaVersionFilePath     = "../../SCHEMA_VERSION"
 )
 
 func TestFeatures(t *testing.T) {
+	t.Parallel()
+
 	suite := godog.TestSuite{
 		ScenarioInitializer: func(ctx *godog.ScenarioContext) {
 			ctx.Step(`^a "([^"]*)" system configuration file with dockerGPU "([^"]*)" and runMode "([^"]*)" is defined in the "([^"]*)" directory$`, aSystemConfigurationFile)
@@ -95,7 +96,7 @@ func aSystemConfigurationFile(arg1, arg2, arg3, arg4 string) error {
 		DockerMode:     "1",
 	}
 
-	environ, err := environment.NewEnvironment(testFs, env)
+	environ, err := environment.NewEnvironment(testFs, ctx, env)
 	if err != nil {
 		return err
 	}

--- a/pkg/docker/image.go
+++ b/pkg/docker/image.go
@@ -307,7 +307,7 @@ func generateParamsSection(ctx context.Context, prefix string, items map[string]
 
 func BuildDockerfile(fs afero.Fs, ctx context.Context, kdeps *kdCfg.Kdeps, kdepsDir string, pkgProject *archiver.KdepsPackage, logger *logging.Logger) (string, bool, string, string, string, error) {
 	var portNum uint16 = 3000
-	var hostIP = "127.0.0.1"
+	hostIP := "127.0.0.1"
 
 	wfCfg, err := workflow.LoadWorkflow(ctx, pkgProject.Workflow, logger)
 	if err != nil {

--- a/pkg/docker/kdeps_exec.go
+++ b/pkg/docker/kdeps_exec.go
@@ -8,7 +8,7 @@ import (
 	"github.com/kdeps/kdeps/pkg/logging"
 )
 
-// KdepsExec executes a command and returns stdout, stderr, and the exit code using go-execute
+// KdepsExec executes a command and returns stdout, stderr, and the exit code using go-execute.
 func KdepsExec(command string, args []string, logger *logging.Logger) (string, string, int, error) {
 	// Log the command being executed
 	logger.Debug("Executing", "command", command, "args", args)

--- a/pkg/docker/ollama_utils.go
+++ b/pkg/docker/ollama_utils.go
@@ -13,7 +13,7 @@ import (
 	"github.com/kdeps/kdeps/pkg/logging"
 )
 
-// parseOLLAMAHost parses the OLLAMA_HOST environment variable into host and port
+// parseOLLAMAHost parses the OLLAMA_HOST environment variable into host and port.
 func parseOLLAMAHost(ctx context.Context, logger *logging.Logger) (string, string, error) {
 	logger.Debug("Parsing OLLAMA_HOST environment variable")
 
@@ -26,7 +26,7 @@ func parseOLLAMAHost(ctx context.Context, logger *logging.Logger) (string, strin
 	host, port, err := net.SplitHostPort(hostEnv)
 	if err != nil {
 		logger.Error("Invalid OLLAMA_HOST", "format", err)
-		return "", "", fmt.Errorf("Invalid OLLAMA_HOST format: %v", err)
+		return "", "", fmt.Errorf("Invalid OLLAMA_HOST format: %w", err)
 	}
 
 	logger.Debug("Parsed OLLAMA_HOST", "host", host, "port", port)

--- a/pkg/docker/ollama_utils.go
+++ b/pkg/docker/ollama_utils.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -13,7 +14,7 @@ import (
 )
 
 // parseOLLAMAHost parses the OLLAMA_HOST environment variable into host and port
-func parseOLLAMAHost(logger *logging.Logger) (string, string, error) {
+func parseOLLAMAHost(ctx context.Context, logger *logging.Logger) (string, string, error) {
 	logger.Debug("Parsing OLLAMA_HOST environment variable")
 
 	hostEnv := os.Getenv("OLLAMA_HOST")
@@ -32,7 +33,7 @@ func parseOLLAMAHost(logger *logging.Logger) (string, string, error) {
 	return host, port, nil
 }
 
-func generateUniqueOllamaPort(existingPort uint16) string {
+func generateUniqueOllamaPort(ctx context.Context, existingPort uint16) string {
 	rand.Seed(time.Now().UnixNano())
 	minPort, maxPort := 11435, 65535
 

--- a/pkg/docker/server_utils.go
+++ b/pkg/docker/server_utils.go
@@ -10,7 +10,7 @@ import (
 	"github.com/kdeps/kdeps/pkg/logging"
 )
 
-// isServerReady checks if ollama server is ready by attempting to connect to the specified host and port
+// isServerReady checks if ollama server is ready by attempting to connect to the specified host and port.
 func isServerReady(host string, port string, logger *logging.Logger) bool {
 	logger.Debug("Checking if ollama server is ready", "host", host, "port", port)
 
@@ -25,7 +25,7 @@ func isServerReady(host string, port string, logger *logging.Logger) bool {
 	return true
 }
 
-// waitForServer waits until ollama server is ready by polling the specified host and port
+// waitForServer waits until ollama server is ready by polling the specified host and port.
 func waitForServer(host string, port string, timeout time.Duration, logger *logging.Logger) error {
 	logger.Debug("Waiting for ollama server to be ready...")
 
@@ -46,7 +46,7 @@ func waitForServer(host string, port string, timeout time.Duration, logger *logg
 	}
 }
 
-// startOllamaServer starts the ollama server command in the background using go-execute
+// startOllamaServer starts the ollama server command in the background using go-execute.
 func startOllamaServer(logger *logging.Logger) error {
 	logger.Debug("Starting ollama server in the background...")
 

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -2,6 +2,7 @@ package download
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -113,8 +114,7 @@ func DownloadFile(fs afero.Fs, ctx context.Context, url, filePath string, logger
 	if resp.StatusCode != http.StatusOK {
 		errMsg := fmt.Sprintf("failed to download file: status code %d", resp.StatusCode)
 		logger.Error(errMsg, "url", url)
-		return fmt.Errorf(errMsg)
-
+		return errors.New(errMsg)
 	}
 
 	// Create a WriteCounter to track and display download progress

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -1,6 +1,7 @@
 package download
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -35,7 +36,7 @@ func (wc WriteCounter) PrintProgress() {
 }
 
 // Given a list of URLs, download it to a target.
-func DownloadFiles(fs afero.Fs, downloadDir string, urls []string, logger *logging.Logger) error {
+func DownloadFiles(fs afero.Fs, ctx context.Context, downloadDir string, urls []string, logger *logging.Logger) error {
 	// Create the downloads directory if it doesn't exist
 	err := os.MkdirAll(downloadDir, 0o755)
 	if err != nil {
@@ -51,7 +52,7 @@ func DownloadFiles(fs afero.Fs, downloadDir string, urls []string, logger *loggi
 		localPath := filepath.Join(downloadDir, fileName)
 
 		// Download the file
-		err := DownloadFile(fs, url, localPath, logger)
+		err := DownloadFile(fs, ctx, url, localPath, logger)
 		if err != nil {
 			logger.Error("Failed to download", "url", url, "err", err)
 		} else {
@@ -64,7 +65,7 @@ func DownloadFiles(fs afero.Fs, downloadDir string, urls []string, logger *loggi
 
 // DownloadFile downloads a file from the specified URL and saves it to the given path.
 // It skips the download if the file already exists and is non-empty.
-func DownloadFile(fs afero.Fs, url, filePath string, logger *logging.Logger) error {
+func DownloadFile(fs afero.Fs, ctx context.Context, url, filePath string, logger *logging.Logger) error {
 	logger.Debug("Checking if file exists", "destination", filePath)
 
 	if filePath == "" {

--- a/pkg/download/download_test.go
+++ b/pkg/download/download_test.go
@@ -20,6 +20,7 @@ var (
 )
 
 func TestWriteCounter_Write(t *testing.T) {
+	t.Parallel()
 	counter := &WriteCounter{}
 	data := []byte("Hello, World!")
 	n, err := counter.Write(data)
@@ -30,6 +31,7 @@ func TestWriteCounter_Write(t *testing.T) {
 }
 
 func TestWriteCounter_PrintProgress(t *testing.T) {
+	t.Parallel()
 	counter := &WriteCounter{
 		DownloadURL: "example.com/file.txt",
 	}
@@ -61,6 +63,7 @@ func TestWriteCounter_PrintProgress(t *testing.T) {
 }
 
 func TestDownloadFile(t *testing.T) {
+	t.Parallel()
 	logger = logging.GetLogger()
 	// Mock a simple HTTP server to simulate file download
 	server := http.Server{
@@ -86,6 +89,7 @@ func TestDownloadFile(t *testing.T) {
 }
 
 func TestDownloadFile_FileCreationError(t *testing.T) {
+	t.Parallel()
 	logger = logging.GetLogger()
 	fs := afero.NewMemMapFs()
 
@@ -96,6 +100,7 @@ func TestDownloadFile_FileCreationError(t *testing.T) {
 }
 
 func TestDownloadFile_HttpGetError(t *testing.T) {
+	t.Parallel()
 	fs := afero.NewMemMapFs()
 
 	// Trying to download a file from an invalid URL

--- a/pkg/download/download_test.go
+++ b/pkg/download/download_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/kdeps/kdeps/pkg/logging"
-
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/pkg/download/download_test.go
+++ b/pkg/download/download_test.go
@@ -2,6 +2,7 @@ package download
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net/http"
 	"os"
@@ -14,7 +15,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var logger *logging.Logger
+var (
+	logger *logging.Logger
+	ctx    context.Context
+)
 
 func TestWriteCounter_Write(t *testing.T) {
 	counter := &WriteCounter{}
@@ -73,7 +77,7 @@ func TestDownloadFile(t *testing.T) {
 	fs := afero.NewMemMapFs()
 
 	// Run the file download
-	err := DownloadFile(fs, "http://localhost:8080", "/testfile", logger)
+	err := DownloadFile(fs, ctx, "http://localhost:8080", "/testfile", logger)
 	require.NoError(t, err)
 
 	// Verify the downloaded content
@@ -87,7 +91,7 @@ func TestDownloadFile_FileCreationError(t *testing.T) {
 	fs := afero.NewMemMapFs()
 
 	// Invalid file path test case
-	err := DownloadFile(fs, "http://localhost:8080", "", logger)
+	err := DownloadFile(fs, ctx, "http://localhost:8080", "", logger)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid file path")
 }
@@ -96,6 +100,6 @@ func TestDownloadFile_HttpGetError(t *testing.T) {
 	fs := afero.NewMemMapFs()
 
 	// Trying to download a file from an invalid URL
-	err := DownloadFile(fs, "http://invalid-url", "/testfile", logger)
+	err := DownloadFile(fs, ctx, "http://invalid-url", "/testfile", logger)
 	assert.Error(t, err)
 }

--- a/pkg/enforcer/enforcer.go
+++ b/pkg/enforcer/enforcer.go
@@ -12,14 +12,10 @@ import (
 
 	"github.com/kdeps/kdeps/pkg/logging"
 	"github.com/kdeps/kdeps/pkg/schema"
-
 	"github.com/spf13/afero"
 )
 
-// compareVersions compares two version strings and returns:
-// -1 if v1 < v2
-// 0 if v1 == v2
-// 1 if v1 > v2
+// 1 if v1 > v2.
 func compareVersions(v1, v2 string, logger *logging.Logger) (int, error) {
 	v1Parts := strings.Split(v1, ".")
 	v2Parts := strings.Split(v2, ".")
@@ -45,7 +41,7 @@ func compareVersions(v1, v2 string, logger *logging.Logger) (int, error) {
 	return 0, nil
 }
 
-// EnforceSchemaURL checks if the "amends" line contains the correct schema.kdeps.com/core URL
+// EnforceSchemaURL checks if the "amends" line contains the correct schema.kdeps.com/core URL.
 func EnforceSchemaURL(ctx context.Context, line, filePath string, logger *logging.Logger) error {
 	if !strings.HasPrefix(line, "amends") {
 		logger.Error("The .pkl file does not start with 'amends'", "file", filePath)
@@ -60,7 +56,7 @@ func EnforceSchemaURL(ctx context.Context, line, filePath string, logger *loggin
 	return nil
 }
 
-// EnforcePklVersion extracts the version from the "amends" line and compares it with the provided schema version
+// EnforcePklVersion extracts the version from the "amends" line and compares it with the provided schema version.
 func EnforcePklVersion(ctx context.Context, line, filePath, schemaVersion string, logger *logging.Logger) error {
 	start := strings.Index(line, "@")
 	end := strings.Index(line, "#")
@@ -85,7 +81,7 @@ func EnforcePklVersion(ctx context.Context, line, filePath, schemaVersion string
 	return nil
 }
 
-// Helper function to get the keys of a map as a slice of strings
+// Helper function to get the keys of a map as a slice of strings.
 func validPklFilesKeys(validPklFiles map[string]bool) []string {
 	keys := make([]string, 0, len(validPklFiles))
 	for k := range validPklFiles {
@@ -300,7 +296,7 @@ func enforceResourcesFolder(fs afero.Fs, ctx context.Context, resourcesPath stri
 	return nil
 }
 
-// EnforcePklTemplateAmendsRules combines the three validations (schema URL, version, and .pkl file)
+// EnforcePklTemplateAmendsRules combines the three validations (schema URL, version, and .pkl file).
 func EnforcePklTemplateAmendsRules(fs afero.Fs, ctx context.Context, filePath string, logger *logging.Logger) error {
 	// Open the file containing the amends line
 	file, err := fs.Open(filePath)

--- a/pkg/enforcer/enforcer_test.go
+++ b/pkg/enforcer/enforcer_test.go
@@ -181,7 +181,7 @@ func aSystemConfigurationIsDefined() error {
 }
 
 func itDoesNotHaveAConfigAmendsLineOnTopOfTheFile() error {
-	doc = fmt.Sprintf("%s", configValues)
+	doc = configValues
 
 	return nil
 }
@@ -207,7 +207,6 @@ func itIsAnInvalidAgent() error {
 }
 
 func itIsAValidAgent() error {
-
 	if err := EnforceFolderStructure(testFs, ctx, agentPath, logger); err != nil {
 		return err
 	}
@@ -267,7 +266,7 @@ func anAgentFolderExistsInTheCurrentDirectory(arg1 string) error {
 }
 
 func itDoesNotHaveAWorkflowAmendsLineOnTopOfTheFile() error {
-	doc = fmt.Sprintf("%s", workflowValues)
+	doc = workflowValues
 
 	return nil
 }
@@ -298,7 +297,7 @@ func itHaveAResourceAmendsLineOnTopOfTheFile() error {
 }
 
 func itDoesNotHaveAResourceAmendsLineOnTopOfTheFile() error {
-	doc = fmt.Sprintf("%s", resourceValues)
+	doc = resourceValues
 
 	return nil
 }

--- a/pkg/enforcer/enforcer_test.go
+++ b/pkg/enforcer/enforcer_test.go
@@ -160,12 +160,12 @@ func aSystemConfigurationIsDefined() error {
 		NonInteractive: "1",
 	}
 
-	environ, err := environment.NewEnvironment(testFs, env)
+	environ, err := environment.NewEnvironment(testFs, ctx, env)
 	if err != nil {
 		return err
 	}
 
-	cfgFile, err := cfg.GenerateConfiguration(testFs, environ, logger)
+	cfgFile, err := cfg.GenerateConfiguration(testFs, ctx, environ, logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/enforcer/enforcer_test.go
+++ b/pkg/enforcer/enforcer_test.go
@@ -21,7 +21,7 @@ var (
 	testFs                = afero.NewOsFs()
 	homeDirPath           string
 	currentDirPath        string
-	ctx                   context.Context
+	ctx                   = context.Background()
 	systemConfiguration   *kdeps.Kdeps
 	fileThatExist         string
 	logger                *logging.Logger
@@ -199,7 +199,7 @@ func itHaveAConfigAmendsLineOnTopOfTheFile() error {
 }
 
 func itIsAnInvalidAgent() error {
-	if err := EnforceFolderStructure(testFs, agentPath, logger); err == nil {
+	if err := EnforceFolderStructure(testFs, ctx, agentPath, logger); err == nil {
 		return errors.New("expected an error, but got nil")
 	}
 
@@ -207,7 +207,8 @@ func itIsAnInvalidAgent() error {
 }
 
 func itIsAValidAgent() error {
-	if err := EnforceFolderStructure(testFs, agentPath, logger); err != nil {
+
+	if err := EnforceFolderStructure(testFs, ctx, agentPath, logger); err != nil {
 		return err
 	}
 
@@ -215,7 +216,7 @@ func itIsAValidAgent() error {
 }
 
 func itIsAnInvalidPklFile() error {
-	if err := EnforcePklTemplateAmendsRules(testFs, fileThatExist, logger); err == nil {
+	if err := EnforcePklTemplateAmendsRules(testFs, ctx, fileThatExist, logger); err == nil {
 		return errors.New("expected an error, but got nil")
 	}
 
@@ -223,11 +224,11 @@ func itIsAnInvalidPklFile() error {
 }
 
 func itIsAValidPklFile() error {
-	if err := EnforcePklTemplateAmendsRules(testFs, fileThatExist, logger); err != nil {
+	if err := EnforcePklTemplateAmendsRules(testFs, ctx, fileThatExist, logger); err != nil {
 		return err
 	}
 
-	if _, err := evaluator.EvalPkl(testFs, fileThatExist, "", logger); err != nil {
+	if _, err := evaluator.EvalPkl(testFs, ctx, fileThatExist, "", logger); err != nil {
 		return err
 	}
 

--- a/pkg/enforcer/enforcer_test.go
+++ b/pkg/enforcer/enforcer_test.go
@@ -71,6 +71,7 @@ action = "helloWorld"
 )
 
 func TestFeatures(t *testing.T) {
+	t.Parallel()
 	suite := godog.TestSuite{
 		ScenarioInitializer: func(ctx *godog.ScenarioContext) {
 			// Configuration steps

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -1,6 +1,7 @@
 package environment
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 
@@ -26,6 +27,8 @@ func checkConfig(fs afero.Fs, baseDir string) (string, error) {
 	configFile := filepath.Join(baseDir, SystemConfigFileName)
 	if exists, err := afero.Exists(fs, configFile); err == nil && exists {
 		return configFile, nil
+	} else {
+		return "", err
 	}
 	return "", nil
 }
@@ -65,7 +68,7 @@ func allDockerEnvVarsSet() bool {
 }
 
 // NewEnvironment initializes and returns a new Environment based on provided or default settings.
-func NewEnvironment(fs afero.Fs, environ *Environment) (*Environment, error) {
+func NewEnvironment(fs afero.Fs, ctx context.Context, environ *Environment) (*Environment, error) {
 	if environ != nil {
 		// If an environment is provided, prioritize overriding configurations
 		kdepsConfigFile := findKdepsConfig(fs, environ.Pwd, environ.Home)

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -23,7 +23,7 @@ type Environment struct {
 }
 
 // checkConfig checks if the .kdeps.pkl file exists in the given directory.
-func checkConfig(fs afero.Fs, baseDir string) (string, error) {
+func checkConfig(fs afero.Fs, ctx context.Context, baseDir string) (string, error) {
 	configFile := filepath.Join(baseDir, SystemConfigFileName)
 	if exists, err := afero.Exists(fs, configFile); err == nil && exists {
 		return configFile, nil
@@ -34,30 +34,30 @@ func checkConfig(fs afero.Fs, baseDir string) (string, error) {
 }
 
 // findKdepsConfig searches for the .kdeps.pkl file in both the Pwd and Home directories.
-func findKdepsConfig(fs afero.Fs, pwd, home string) string {
+func findKdepsConfig(fs afero.Fs, ctx context.Context, pwd, home string) string {
 	// Check for kdeps config in Pwd directory
-	if configFile, _ := checkConfig(fs, pwd); configFile != "" {
+	if configFile, _ := checkConfig(fs, ctx, pwd); configFile != "" {
 		return configFile
 	}
 	// Check for kdeps config in Home directory
-	if configFile, _ := checkConfig(fs, home); configFile != "" {
+	if configFile, _ := checkConfig(fs, ctx, home); configFile != "" {
 		return configFile
 	}
 	return ""
 }
 
 // isDockerEnvironment checks for the presence of Docker-related indicators.
-func isDockerEnvironment(fs afero.Fs, root string) bool {
+func isDockerEnvironment(fs afero.Fs, ctx context.Context, root string) bool {
 	dockerEnvFlag := filepath.Join(root, ".dockerenv")
 	if exists, _ := afero.Exists(fs, dockerEnvFlag); exists {
 		// Ensure all required Docker environment variables are set
-		return allDockerEnvVarsSet()
+		return allDockerEnvVarsSet(ctx)
 	}
 	return false
 }
 
 // allDockerEnvVarsSet checks if required Docker environment variables are set.
-func allDockerEnvVarsSet() bool {
+func allDockerEnvVarsSet(ctx context.Context) bool {
 	requiredVars := []string{"SCHEMA_VERSION", "OLLAMA_HOST", "KDEPS_HOST"}
 	for _, v := range requiredVars {
 		if value, exists := os.LookupEnv(v); !exists || value == "" {
@@ -71,9 +71,9 @@ func allDockerEnvVarsSet() bool {
 func NewEnvironment(fs afero.Fs, ctx context.Context, environ *Environment) (*Environment, error) {
 	if environ != nil {
 		// If an environment is provided, prioritize overriding configurations
-		kdepsConfigFile := findKdepsConfig(fs, environ.Pwd, environ.Home)
+		kdepsConfigFile := findKdepsConfig(fs, ctx, environ.Pwd, environ.Home)
 		dockerMode := "0"
-		if isDockerEnvironment(fs, environ.Root) {
+		if isDockerEnvironment(fs, ctx, environ.Root) {
 			dockerMode = "1"
 		}
 
@@ -96,9 +96,9 @@ func NewEnvironment(fs afero.Fs, ctx context.Context, environ *Environment) (*En
 	environment.Extras = extras
 
 	// Find kdepsConfig file and check if running in Docker
-	kdepsConfigFile := findKdepsConfig(fs, environment.Pwd, environment.Home)
+	kdepsConfigFile := findKdepsConfig(fs, ctx, environment.Pwd, environment.Home)
 	dockerMode := "0"
-	if isDockerEnvironment(fs, environment.Root) {
+	if isDockerEnvironment(fs, ctx, environment.Root) {
 		dockerMode = "1"
 	}
 

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -30,7 +30,6 @@ func checkConfig(fs afero.Fs, ctx context.Context, baseDir string) (string, erro
 	} else {
 		return "", err
 	}
-	return "", nil
 }
 
 // findKdepsConfig searches for the .kdeps.pkl file in both the Pwd and Home directories.

--- a/pkg/environment/environment_test.go
+++ b/pkg/environment/environment_test.go
@@ -10,9 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var (
-	ctx context.Context
-)
+var ctx context.Context
 
 func TestCheckConfig(t *testing.T) {
 	t.Parallel()

--- a/pkg/environment/environment_test.go
+++ b/pkg/environment/environment_test.go
@@ -1,6 +1,7 @@
 package environment
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,7 +10,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	ctx context.Context
+)
+
 func TestCheckConfig(t *testing.T) {
+	t.Parallel()
+
 	fs := afero.NewMemMapFs()
 	baseDir := "/test"
 	configFilePath := filepath.Join(baseDir, SystemConfigFileName)
@@ -26,6 +33,8 @@ func TestCheckConfig(t *testing.T) {
 }
 
 func TestFindKdepsConfig(t *testing.T) {
+	t.Parallel()
+
 	fs := afero.NewMemMapFs()
 	pwd := "/current"
 	home := "/home"
@@ -47,6 +56,8 @@ func TestFindKdepsConfig(t *testing.T) {
 }
 
 func TestIsDockerEnvironment(t *testing.T) {
+	t.Parallel()
+
 	fs := afero.NewMemMapFs()
 	root := "/"
 
@@ -68,6 +79,8 @@ func TestIsDockerEnvironment(t *testing.T) {
 }
 
 func TestAllDockerEnvVarsSet(t *testing.T) {
+	t.Parallel()
+
 	// Ensure environment is clean
 	os.Unsetenv("SCHEMA_VERSION")
 	os.Unsetenv("OLLAMA_HOST")
@@ -89,6 +102,8 @@ func TestAllDockerEnvVarsSet(t *testing.T) {
 }
 
 func TestNewEnvironment(t *testing.T) {
+	t.Parallel()
+
 	fs := afero.NewMemMapFs()
 
 	// Test with provided environment
@@ -97,7 +112,7 @@ func TestNewEnvironment(t *testing.T) {
 		Home: "/home",
 		Pwd:  "/current",
 	}
-	env, err := NewEnvironment(fs, providedEnv)
+	env, err := NewEnvironment(fs, ctx, providedEnv)
 	assert.NoError(t, err, "Expected no error")
 	assert.Equal(t, providedEnv.Home, env.Home, "Expected Home directory to match")
 	assert.Equal(t, "1", env.NonInteractive, "Expected NonInteractive to be prioritized")
@@ -106,7 +121,7 @@ func TestNewEnvironment(t *testing.T) {
 	os.Setenv("ROOT_DIR", "/")
 	os.Setenv("HOME", "/home")
 	os.Setenv("PWD", "/current")
-	env, err = NewEnvironment(fs, nil)
+	env, err = NewEnvironment(fs, ctx, nil)
 	assert.NoError(t, err, "Expected no error")
 	assert.Equal(t, "/home", env.Home, "Expected Home directory to match")
 	assert.Equal(t, "/current", env.Pwd, "Expected Pwd to match")

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -106,7 +106,7 @@ func CreateAndProcessPklFile(
 
 	// Prepare the sections with the relationship keyword and imports
 	// amends or extends "package://schema.kdeps.com/core@0.0.34#/Kdeps.pkl"
-	relationshipSection := fmt.Sprintf(`%s "package://schema.kdeps.com/core@%s#/%s"`, relationship, schema.SchemaVersion(), pklTemplate)
+	relationshipSection := fmt.Sprintf(`%s "package://schema.kdeps.com/core@%s#/%s"`, relationship, schema.SchemaVersion(ctx), pklTemplate)
 	fullSections := append([]string{relationshipSection}, sections...)
 
 	// Write sections to the temporary file

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -16,7 +16,7 @@ import (
 )
 
 // EnsurePklBinaryExists checks if the 'pkl' binary exists in the system PATH.
-func EnsurePklBinaryExists(logger *logging.Logger) error {
+func EnsurePklBinaryExists(ctx context.Context, logger *logging.Logger) error {
 	binaryNames := []string{"pkl", "pkl.exe"} // Support both Unix-like and Windows binary names
 	for _, binaryName := range binaryNames {
 		if _, err := exec.LookPath(binaryName); err == nil {
@@ -31,7 +31,7 @@ func EnsurePklBinaryExists(logger *logging.Logger) error {
 
 // EvalPkl evaluates the resource file at resourcePath using the 'pkl' binary.
 // It expects the resourcePath to have a .pkl extension.
-func EvalPkl(fs afero.Fs, resourcePath string, headerSection string, logger *logging.Logger) (string, error) {
+func EvalPkl(fs afero.Fs, ctx context.Context, resourcePath string, headerSection string, logger *logging.Logger) (string, error) {
 	// Validate that the file has a .pkl extension
 	if filepath.Ext(resourcePath) != ".pkl" {
 		errMsg := fmt.Sprintf("file '%s' must have a .pkl extension", resourcePath)
@@ -40,7 +40,7 @@ func EvalPkl(fs afero.Fs, resourcePath string, headerSection string, logger *log
 	}
 
 	// Ensure that the 'pkl' binary is available
-	if err := EnsurePklBinaryExists(logger); err != nil {
+	if err := EnsurePklBinaryExists(ctx, logger); err != nil {
 		return "", err
 	}
 
@@ -52,7 +52,7 @@ func EvalPkl(fs afero.Fs, resourcePath string, headerSection string, logger *log
 	}
 
 	// Execute the command
-	result, err := cmd.Execute(context.Background())
+	result, err := cmd.Execute(ctx)
 	if err != nil {
 		errMsg := "command execution failed"
 		logger.Error(errMsg, "error", err)
@@ -75,11 +75,12 @@ func EvalPkl(fs afero.Fs, resourcePath string, headerSection string, logger *log
 
 func CreateAndProcessPklFile(
 	fs afero.Fs,
+	ctx context.Context,
 	sections []string,
 	finalFileName string,
 	pklTemplate string,
 	logger *logging.Logger,
-	processFunc func(fs afero.Fs, tmpFile string, headerSection string, logger *logging.Logger) (string, error),
+	processFunc func(fs afero.Fs, ctx context.Context, tmpFile string, headerSection string, logger *logging.Logger) (string, error),
 	isExtension bool, // New parameter to control amends vs extends
 ) error {
 	// Create a temporary directory
@@ -116,7 +117,7 @@ func CreateAndProcessPklFile(
 	}
 
 	// Process the temporary file using the provided function
-	processedContent, err := processFunc(fs, tmpFile.Name(), relationshipSection, logger)
+	processedContent, err := processFunc(fs, ctx, tmpFile.Name(), relationshipSection, logger)
 	if err != nil {
 		logger.Error("Failed to process temporary file", "path", tmpFile.Name(), "error", err)
 		return fmt.Errorf("failed to process temporary file: %w", err)

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -2,16 +2,16 @@ package evaluator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 
+	"github.com/alexellis/go-execute/v2"
 	"github.com/kdeps/kdeps/pkg/logging"
 	"github.com/kdeps/kdeps/pkg/schema"
-
-	"github.com/alexellis/go-execute/v2"
 	"github.com/spf13/afero"
 )
 
@@ -36,7 +36,7 @@ func EvalPkl(fs afero.Fs, ctx context.Context, resourcePath string, headerSectio
 	if filepath.Ext(resourcePath) != ".pkl" {
 		errMsg := fmt.Sprintf("file '%s' must have a .pkl extension", resourcePath)
 		logger.Error(errMsg)
-		return "", fmt.Errorf(errMsg)
+		return "", errors.New(errMsg)
 	}
 
 	// Ensure that the 'pkl' binary is available
@@ -63,7 +63,7 @@ func EvalPkl(fs afero.Fs, ctx context.Context, resourcePath string, headerSectio
 	if result.ExitCode != 0 {
 		errMsg := fmt.Sprintf("command failed with exit code %d: %s", result.ExitCode, result.Stderr)
 		logger.Error(errMsg)
-		return "", fmt.Errorf(errMsg)
+		return "", errors.New(errMsg)
 	}
 
 	// Format the result by prepending the headerSection to the command stdout

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -1,6 +1,7 @@
 package evaluator_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -12,15 +13,17 @@ import (
 )
 
 func TestCreateAndProcessPklFile(t *testing.T) {
+	t.Parallel()
+
 	fs := afero.NewMemMapFs()
 	logging.CreateLogger()
 	logger := logging.GetLogger()
-
+	var ctx context.Context
 	sections := []string{"section1", "section2"}
 	finalFileName := "/tmp/final.pkl"
 	pklTemplate := "Kdeps.pkl"
 
-	processFunc := func(fs afero.Fs, tmpFile string, headerSection string, logger *logging.Logger) (string, error) {
+	processFunc := func(fs afero.Fs, ctx context.Context, tmpFile string, headerSection string, logger *logging.Logger) (string, error) {
 		content, err := afero.ReadFile(fs, tmpFile)
 		if err != nil {
 			return "", err
@@ -29,7 +32,7 @@ func TestCreateAndProcessPklFile(t *testing.T) {
 	}
 
 	t.Run("CreateAndProcessAmends", func(t *testing.T) {
-		err := evaluator.CreateAndProcessPklFile(fs, sections, finalFileName, pklTemplate, logger, processFunc, false)
+		err := evaluator.CreateAndProcessPklFile(fs, ctx, sections, finalFileName, pklTemplate, logger, processFunc, false)
 		assert.NoError(t, err, "CreateAndProcessPklFile should not return an error")
 		content, err := afero.ReadFile(fs, finalFileName)
 		require.NoError(t, err, "Final file should be created successfully")
@@ -38,7 +41,7 @@ func TestCreateAndProcessPklFile(t *testing.T) {
 	})
 
 	t.Run("CreateAndProcessExtends", func(t *testing.T) {
-		err := evaluator.CreateAndProcessPklFile(fs, sections, finalFileName, pklTemplate, logger, processFunc, true)
+		err := evaluator.CreateAndProcessPklFile(fs, ctx, sections, finalFileName, pklTemplate, logger, processFunc, true)
 		assert.NoError(t, err, "CreateAndProcessPklFile should not return an error")
 		content, err := afero.ReadFile(fs, finalFileName)
 		require.NoError(t, err, "Final file should be created successfully")

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -32,6 +32,7 @@ func TestCreateAndProcessPklFile(t *testing.T) {
 	}
 
 	t.Run("CreateAndProcessAmends", func(t *testing.T) {
+		t.Parallel()
 		err := evaluator.CreateAndProcessPklFile(fs, ctx, sections, finalFileName, pklTemplate, logger, processFunc, false)
 		assert.NoError(t, err, "CreateAndProcessPklFile should not return an error")
 		content, err := afero.ReadFile(fs, finalFileName)
@@ -41,6 +42,7 @@ func TestCreateAndProcessPklFile(t *testing.T) {
 	})
 
 	t.Run("CreateAndProcessExtends", func(t *testing.T) {
+		t.Parallel()
 		err := evaluator.CreateAndProcessPklFile(fs, ctx, sections, finalFileName, pklTemplate, logger, processFunc, true)
 		assert.NoError(t, err, "CreateAndProcessPklFile should not return an error")
 		content, err := afero.ReadFile(fs, finalFileName)

--- a/pkg/resolver/chat.go
+++ b/pkg/resolver/chat.go
@@ -9,11 +9,10 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/gabriel-vasile/mimetype"
 	"github.com/kdeps/kdeps/pkg/evaluator"
 	"github.com/kdeps/kdeps/pkg/schema"
 	"github.com/kdeps/kdeps/pkg/utils"
-
-	"github.com/gabriel-vasile/mimetype"
 	pklLLM "github.com/kdeps/schema/gen/llm"
 	"github.com/spf13/afero"
 	"github.com/tmc/langchaingo/llms"

--- a/pkg/resolver/chat.go
+++ b/pkg/resolver/chat.go
@@ -276,7 +276,7 @@ func (dr *DependencyResolver) AppendChatEntry(resourceId string, newChat *pklLLM
 	}
 
 	// Evaluate the PKL file using EvalPkl
-	evaluatedContent, err := evaluator.EvalPkl(dr.Fs, pklPath, fmt.Sprintf("extends \"package://schema.kdeps.com/core@%s#/LLM.pkl\"\n\n", schema.SchemaVersion()), dr.Logger)
+	evaluatedContent, err := evaluator.EvalPkl(dr.Fs, dr.Context, pklPath, fmt.Sprintf("extends \"package://schema.kdeps.com/core@%s#/LLM.pkl\"\n\n", schema.SchemaVersion()), dr.Logger)
 	if err != nil {
 		return fmt.Errorf("failed to evaluate PKL file: %w", err)
 	}

--- a/pkg/resolver/chat.go
+++ b/pkg/resolver/chat.go
@@ -224,7 +224,7 @@ func (dr *DependencyResolver) AppendChatEntry(resourceId string, newChat *pklLLM
 
 	// Build the new content for the PKL file in the specified format
 	var pklContent strings.Builder
-	pklContent.WriteString(fmt.Sprintf("extends \"package://schema.kdeps.com/core@%s#/LLM.pkl\"\n\n", schema.SchemaVersion()))
+	pklContent.WriteString(fmt.Sprintf("extends \"package://schema.kdeps.com/core@%s#/LLM.pkl\"\n\n", schema.SchemaVersion(dr.Context)))
 	pklContent.WriteString("resources {\n")
 
 	for id, resource := range existingResources {
@@ -276,7 +276,7 @@ func (dr *DependencyResolver) AppendChatEntry(resourceId string, newChat *pklLLM
 	}
 
 	// Evaluate the PKL file using EvalPkl
-	evaluatedContent, err := evaluator.EvalPkl(dr.Fs, dr.Context, pklPath, fmt.Sprintf("extends \"package://schema.kdeps.com/core@%s#/LLM.pkl\"\n\n", schema.SchemaVersion()), dr.Logger)
+	evaluatedContent, err := evaluator.EvalPkl(dr.Fs, dr.Context, pklPath, fmt.Sprintf("extends \"package://schema.kdeps.com/core@%s#/LLM.pkl\"\n\n", schema.SchemaVersion(dr.Context)), dr.Logger)
 	if err != nil {
 		return fmt.Errorf("failed to evaluate PKL file: %w", err)
 	}

--- a/pkg/resolver/data.go
+++ b/pkg/resolver/data.go
@@ -60,7 +60,7 @@ func (dr *DependencyResolver) AppendDataEntry(resourceId string, newData *pklDat
 
 	// Build the new PKL content
 	var pklContent strings.Builder
-	pklContent.WriteString(fmt.Sprintf("extends \"package://schema.kdeps.com/core@%s#/Data.pkl\"\n\n", schema.SchemaVersion()))
+	pklContent.WriteString(fmt.Sprintf("extends \"package://schema.kdeps.com/core@%s#/Data.pkl\"\n\n", schema.SchemaVersion(dr.Context)))
 	pklContent.WriteString("files {\n")
 
 	for agentName, baseFileMap := range *existingFiles {
@@ -80,7 +80,7 @@ func (dr *DependencyResolver) AppendDataEntry(resourceId string, newData *pklDat
 	}
 
 	// Evaluate the PKL file using EvalPkl
-	evaluatedContent, err := evaluator.EvalPkl(dr.Fs, dr.Context, pklPath, fmt.Sprintf("extends \"package://schema.kdeps.com/core@%s#/Data.pkl\"", schema.SchemaVersion()), dr.Logger)
+	evaluatedContent, err := evaluator.EvalPkl(dr.Fs, dr.Context, pklPath, fmt.Sprintf("extends \"package://schema.kdeps.com/core@%s#/Data.pkl\"", schema.SchemaVersion(dr.Context)), dr.Logger)
 	if err != nil {
 		return fmt.Errorf("failed to evaluate PKL file: %w", err)
 	}

--- a/pkg/resolver/data.go
+++ b/pkg/resolver/data.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -8,16 +9,15 @@ import (
 	"github.com/kdeps/kdeps/pkg/evaluator"
 	"github.com/kdeps/kdeps/pkg/schema"
 	"github.com/kdeps/kdeps/pkg/utils"
-
 	pklData "github.com/kdeps/schema/gen/data"
 	"github.com/spf13/afero"
 )
 
-// AppendDataEntry appends a data entry to the existing files map
+// AppendDataEntry appends a data entry to the existing files map.
 func (dr *DependencyResolver) AppendDataEntry(resourceId string, newData *pklData.DataImpl) error {
 	// Ensure dr.Context is not nil
 	if dr.Context == nil {
-		return fmt.Errorf("context is nil")
+		return errors.New("context is nil")
 	}
 
 	// Define the path to the PKL file
@@ -31,7 +31,7 @@ func (dr *DependencyResolver) AppendDataEntry(resourceId string, newData *pklDat
 
 	// Safeguard against nil pointers
 	if pklRes == nil || pklRes.GetFiles() == nil {
-		return fmt.Errorf("PKL data or files map is nil")
+		return errors.New("PKL data or files map is nil")
 	}
 
 	// Get the existing files map
@@ -39,7 +39,7 @@ func (dr *DependencyResolver) AppendDataEntry(resourceId string, newData *pklDat
 
 	// Ensure newData is not nil
 	if newData == nil || newData.Files == nil {
-		return fmt.Errorf("new data or its files map is nil")
+		return errors.New("new data or its files map is nil")
 	}
 
 	// Merge new data into the existing files map

--- a/pkg/resolver/data.go
+++ b/pkg/resolver/data.go
@@ -80,7 +80,7 @@ func (dr *DependencyResolver) AppendDataEntry(resourceId string, newData *pklDat
 	}
 
 	// Evaluate the PKL file using EvalPkl
-	evaluatedContent, err := evaluator.EvalPkl(dr.Fs, pklPath, fmt.Sprintf("extends \"package://schema.kdeps.com/core@%s#/Data.pkl\"", schema.SchemaVersion()), dr.Logger)
+	evaluatedContent, err := evaluator.EvalPkl(dr.Fs, dr.Context, pklPath, fmt.Sprintf("extends \"package://schema.kdeps.com/core@%s#/Data.pkl\"", schema.SchemaVersion()), dr.Logger)
 	if err != nil {
 		return fmt.Errorf("failed to evaluate PKL file: %w", err)
 	}

--- a/pkg/resolver/data_test.go
+++ b/pkg/resolver/data_test.go
@@ -8,12 +8,11 @@ import (
 
 	"github.com/kdeps/kdeps/pkg/logging"
 	"github.com/kdeps/kdeps/pkg/resolver"
-
 	"github.com/kdeps/schema/gen/data"
 	"github.com/spf13/afero"
 )
 
-// MockContext implements context.Context
+// MockContext implements context.Context.
 type MockContext struct{}
 
 func (mc *MockContext) Deadline() (deadline time.Time, ok bool) {
@@ -42,7 +41,8 @@ func TestAppendDataEntry(t *testing.T) {
 		{
 			name: "Context is nil",
 			setup: func(dr *resolver.DependencyResolver) *data.DataImpl {
-				dr.Context = nil
+				//nolint:fatcontext
+				dr.Context = ctx
 				return nil
 			},
 			expectError:   true,
@@ -51,7 +51,6 @@ func TestAppendDataEntry(t *testing.T) {
 		{
 			name: "PKL file load failure",
 			setup: func(dr *resolver.DependencyResolver) *data.DataImpl {
-				dr.Context = &MockContext{}
 				afero.WriteFile(dr.Fs, filepath.Join(dr.ActionDir, "data", dr.RequestId+"__data_output.pkl"), []byte("invalid content"), 0o644)
 				return nil
 			},
@@ -61,7 +60,6 @@ func TestAppendDataEntry(t *testing.T) {
 		{
 			name: "New data is nil",
 			setup: func(dr *resolver.DependencyResolver) *data.DataImpl {
-				dr.Context = &MockContext{}
 				return nil
 			},
 			expectError:   true,
@@ -70,7 +68,6 @@ func TestAppendDataEntry(t *testing.T) {
 		{
 			name: "Valid data merge",
 			setup: func(dr *resolver.DependencyResolver) *data.DataImpl {
-				dr.Context = &MockContext{}
 				files := map[string]map[string]string{
 					"agent1": {
 						"file1": "content1",

--- a/pkg/resolver/data_test.go
+++ b/pkg/resolver/data_test.go
@@ -32,6 +32,8 @@ func (mc *MockContext) Value(key interface{}) interface{} {
 }
 
 func TestAppendDataEntry(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name          string
 		setup         func(dr *resolver.DependencyResolver) *data.DataImpl
@@ -84,6 +86,7 @@ func TestAppendDataEntry(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			dr := &resolver.DependencyResolver{
 				Fs:        afero.NewMemMapFs(),
 				Context:   &MockContext{},

--- a/pkg/resolver/exec.go
+++ b/pkg/resolver/exec.go
@@ -7,11 +7,10 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/alexellis/go-execute/v2"
 	"github.com/kdeps/kdeps/pkg/evaluator"
 	"github.com/kdeps/kdeps/pkg/schema"
 	"github.com/kdeps/kdeps/pkg/utils"
-
-	"github.com/alexellis/go-execute/v2"
 	pklExec "github.com/kdeps/schema/gen/exec"
 	"github.com/spf13/afero"
 )

--- a/pkg/resolver/exec.go
+++ b/pkg/resolver/exec.go
@@ -210,7 +210,7 @@ func (dr *DependencyResolver) AppendExecEntry(resourceId string, newExec *pklExe
 
 	// Build the new content for the PKL file in the specified format
 	var pklContent strings.Builder
-	pklContent.WriteString(fmt.Sprintf("extends \"package://schema.kdeps.com/core@%s#/Exec.pkl\"\n\n", schema.SchemaVersion()))
+	pklContent.WriteString(fmt.Sprintf("extends \"package://schema.kdeps.com/core@%s#/Exec.pkl\"\n\n", schema.SchemaVersion(dr.Context)))
 	pklContent.WriteString("resources {\n")
 
 	for id, resource := range existingResources {
@@ -256,7 +256,7 @@ func (dr *DependencyResolver) AppendExecEntry(resourceId string, newExec *pklExe
 	}
 
 	// Evaluate the PKL file using EvalPkl
-	evaluatedContent, err := evaluator.EvalPkl(dr.Fs, dr.Context, pklPath, fmt.Sprintf("extends \"package://schema.kdeps.com/core@%s#/Exec.pkl\"", schema.SchemaVersion()), dr.Logger)
+	evaluatedContent, err := evaluator.EvalPkl(dr.Fs, dr.Context, pklPath, fmt.Sprintf("extends \"package://schema.kdeps.com/core@%s#/Exec.pkl\"", schema.SchemaVersion(dr.Context)), dr.Logger)
 	if err != nil {
 		return fmt.Errorf("failed to evaluate PKL file: %w", err)
 	}

--- a/pkg/resolver/exec.go
+++ b/pkg/resolver/exec.go
@@ -1,7 +1,6 @@
 package resolver
 
 import (
-	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -124,7 +123,7 @@ func (dr *DependencyResolver) processExecBlock(actionId string, execBlock *pklEx
 	}
 
 	// Execute the command
-	result, err := cmd.Execute(context.Background())
+	result, err := cmd.Execute(dr.Context)
 	if err != nil {
 		return err
 	}
@@ -257,7 +256,7 @@ func (dr *DependencyResolver) AppendExecEntry(resourceId string, newExec *pklExe
 	}
 
 	// Evaluate the PKL file using EvalPkl
-	evaluatedContent, err := evaluator.EvalPkl(dr.Fs, pklPath, fmt.Sprintf("extends \"package://schema.kdeps.com/core@%s#/Exec.pkl\"", schema.SchemaVersion()), dr.Logger)
+	evaluatedContent, err := evaluator.EvalPkl(dr.Fs, dr.Context, pklPath, fmt.Sprintf("extends \"package://schema.kdeps.com/core@%s#/Exec.pkl\"", schema.SchemaVersion()), dr.Logger)
 	if err != nil {
 		return fmt.Errorf("failed to evaluate PKL file: %w", err)
 	}

--- a/pkg/resolver/http.go
+++ b/pkg/resolver/http.go
@@ -2,6 +2,7 @@ package resolver
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -13,7 +14,6 @@ import (
 	"github.com/kdeps/kdeps/pkg/evaluator"
 	"github.com/kdeps/kdeps/pkg/schema"
 	"github.com/kdeps/kdeps/pkg/utils"
-
 	pklHttp "github.com/kdeps/schema/gen/http"
 	"github.com/spf13/afero"
 )
@@ -343,7 +343,7 @@ func (dr *DependencyResolver) DoRequest(client *pklHttp.ResourceHTTPClient) erro
 
 	// Validate method
 	if client.Method == "" {
-		return fmt.Errorf("HTTP method is required")
+		return errors.New("HTTP method is required")
 	}
 
 	// Append query parameters to the URL if present
@@ -369,7 +369,7 @@ func (dr *DependencyResolver) DoRequest(client *pklHttp.ResourceHTTPClient) erro
 		if client.Data == nil {
 			return fmt.Errorf("%s method requires data, but none provided", client.Method)
 		}
-		req, err = http.NewRequest(client.Method, client.Url, bytes.NewBuffer([]byte(fmt.Sprintf("%s", *client.Data))))
+		req, err = http.NewRequest(client.Method, client.Url, bytes.NewBufferString(fmt.Sprintf("%s", *client.Data)))
 	} else {
 		req, err = http.NewRequest(client.Method, client.Url, nil)
 	}

--- a/pkg/resolver/http.go
+++ b/pkg/resolver/http.go
@@ -192,7 +192,7 @@ func (dr *DependencyResolver) AppendHttpEntry(resourceId string, newHttpClient *
 
 	// Build the new content for the PKL file in the specified format
 	var pklContent strings.Builder
-	pklContent.WriteString(fmt.Sprintf("extends \"package://schema.kdeps.com/core@%s#/Http.pkl\"\n\n", schema.SchemaVersion()))
+	pklContent.WriteString(fmt.Sprintf("extends \"package://schema.kdeps.com/core@%s#/Http.pkl\"\n\n", schema.SchemaVersion(dr.Context)))
 	pklContent.WriteString("resources {\n")
 
 	for id, resource := range existingResources {
@@ -306,7 +306,7 @@ func (dr *DependencyResolver) AppendHttpEntry(resourceId string, newHttpClient *
 	}
 
 	// Evaluate the PKL file using EvalPkl
-	evaluatedContent, err := evaluator.EvalPkl(dr.Fs, dr.Context, pklPath, fmt.Sprintf("extends \"package://schema.kdeps.com/core@%s#/Http.pkl\"\n\n", schema.SchemaVersion()), dr.Logger)
+	evaluatedContent, err := evaluator.EvalPkl(dr.Fs, dr.Context, pklPath, fmt.Sprintf("extends \"package://schema.kdeps.com/core@%s#/Http.pkl\"\n\n", schema.SchemaVersion(dr.Context)), dr.Logger)
 	if err != nil {
 		return fmt.Errorf("failed to evaluate PKL file: %w", err)
 	}

--- a/pkg/resolver/http.go
+++ b/pkg/resolver/http.go
@@ -306,7 +306,7 @@ func (dr *DependencyResolver) AppendHttpEntry(resourceId string, newHttpClient *
 	}
 
 	// Evaluate the PKL file using EvalPkl
-	evaluatedContent, err := evaluator.EvalPkl(dr.Fs, pklPath, fmt.Sprintf("extends \"package://schema.kdeps.com/core@%s#/Http.pkl\"\n\n", schema.SchemaVersion()), dr.Logger)
+	evaluatedContent, err := evaluator.EvalPkl(dr.Fs, dr.Context, pklPath, fmt.Sprintf("extends \"package://schema.kdeps.com/core@%s#/Http.pkl\"\n\n", schema.SchemaVersion()), dr.Logger)
 	if err != nil {
 		return fmt.Errorf("failed to evaluate PKL file: %w", err)
 	}

--- a/pkg/resolver/imports.go
+++ b/pkg/resolver/imports.go
@@ -2,6 +2,7 @@ package resolver
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -11,7 +12,6 @@ import (
 
 	"github.com/kdeps/kdeps/pkg/data"
 	"github.com/kdeps/kdeps/pkg/schema"
-
 	pklData "github.com/kdeps/schema/gen/data"
 	pklExec "github.com/kdeps/schema/gen/exec"
 	pklHttp "github.com/kdeps/schema/gen/http"
@@ -167,7 +167,7 @@ func (dr *DependencyResolver) PrepareImportFiles() error {
 			}
 
 			// Write the block (resources or files)
-			if _, err := writer.WriteString(fmt.Sprintf("%s {\n}\n", blockType)); err != nil {
+			if _, err := writer.WriteString(blockType + " {\n}\n"); err != nil {
 				return fmt.Errorf("failed to write block for %s: %w", key, err)
 			}
 
@@ -249,7 +249,7 @@ func (dr *DependencyResolver) AddPlaceholderImports(filePath string) error {
 	// Open the file using afero file system (dr.Fs)
 	file, err := dr.Fs.Open(filePath)
 	if err != nil {
-		return fmt.Errorf("could not open file: %v", err)
+		return fmt.Errorf("could not open file: %w", err)
 	}
 	defer file.Close()
 
@@ -269,11 +269,11 @@ func (dr *DependencyResolver) AddPlaceholderImports(filePath string) error {
 	}
 
 	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("error reading file: %v", err)
+		return fmt.Errorf("error reading file: %w", err)
 	}
 
 	if actionId == "" {
-		return fmt.Errorf("action id not found in the file")
+		return errors.New("action id not found in the file")
 	}
 
 	// Create placeholder entries using the parsed actionId

--- a/pkg/resolver/imports.go
+++ b/pkg/resolver/imports.go
@@ -48,14 +48,14 @@ func (dr *DependencyResolver) PrependDynamicImports(pklFile string) error {
 		"pkl:shell":    {Alias: "", Check: false},
 		"pkl:xml":      {Alias: "", Check: false},
 		"pkl:yaml":     {Alias: "", Check: false},
-		fmt.Sprintf("package://schema.kdeps.com/core@%s#/Document.pkl", schema.SchemaVersion()): {Alias: "document", Check: false},
-		fmt.Sprintf("package://schema.kdeps.com/core@%s#/Skip.pkl", schema.SchemaVersion()):     {Alias: "skip", Check: false},
-		fmt.Sprintf("package://schema.kdeps.com/core@%s#/Utils.pkl", schema.SchemaVersion()):    {Alias: "utils", Check: false},
-		filepath.Join(dr.ActionDir, "/llm/"+dr.RequestId+"__llm_output.pkl"):                    {Alias: "llm", Check: true},
-		filepath.Join(dr.ActionDir, "/client/"+dr.RequestId+"__client_output.pkl"):              {Alias: "client", Check: true},
-		filepath.Join(dr.ActionDir, "/exec/"+dr.RequestId+"__exec_output.pkl"):                  {Alias: "exec", Check: true},
-		filepath.Join(dr.ActionDir, "/python/"+dr.RequestId+"__python_output.pkl"):              {Alias: "python", Check: true},
-		filepath.Join(dr.ActionDir, "/data/"+dr.RequestId+"__data_output.pkl"):                  {Alias: "data", Check: true},
+		fmt.Sprintf("package://schema.kdeps.com/core@%s#/Document.pkl", schema.SchemaVersion(dr.Context)): {Alias: "document", Check: false},
+		fmt.Sprintf("package://schema.kdeps.com/core@%s#/Skip.pkl", schema.SchemaVersion(dr.Context)):     {Alias: "skip", Check: false},
+		fmt.Sprintf("package://schema.kdeps.com/core@%s#/Utils.pkl", schema.SchemaVersion(dr.Context)):    {Alias: "utils", Check: false},
+		filepath.Join(dr.ActionDir, "/llm/"+dr.RequestId+"__llm_output.pkl"):                              {Alias: "llm", Check: true},
+		filepath.Join(dr.ActionDir, "/client/"+dr.RequestId+"__client_output.pkl"):                        {Alias: "client", Check: true},
+		filepath.Join(dr.ActionDir, "/exec/"+dr.RequestId+"__exec_output.pkl"):                            {Alias: "exec", Check: true},
+		filepath.Join(dr.ActionDir, "/python/"+dr.RequestId+"__python_output.pkl"):                        {Alias: "python", Check: true},
+		filepath.Join(dr.ActionDir, "/data/"+dr.RequestId+"__data_output.pkl"):                            {Alias: "data", Check: true},
 		dr.RequestPklFile: {Alias: "request", Check: true},
 	}
 
@@ -139,7 +139,7 @@ func (dr *DependencyResolver) PrepareImportFiles() error {
 			defer f.Close()
 
 			// Use packageUrl in the header writing
-			packageUrl := fmt.Sprintf("package://schema.kdeps.com/core@%s#/", schema.SchemaVersion())
+			packageUrl := fmt.Sprintf("package://schema.kdeps.com/core@%s#/", schema.SchemaVersion(dr.Context))
 			writer := bufio.NewWriter(f)
 
 			var schemaFile, blockType string

--- a/pkg/resolver/python.go
+++ b/pkg/resolver/python.go
@@ -266,7 +266,7 @@ func (dr *DependencyResolver) AppendPythonEntry(resourceId string, newPython *pk
 
 	// Build the new content for the PKL file in the specified format
 	var pklContent strings.Builder
-	pklContent.WriteString(fmt.Sprintf("extends \"package://schema.kdeps.com/core@%s#/Python.pkl\"\n\n", schema.SchemaVersion()))
+	pklContent.WriteString(fmt.Sprintf("extends \"package://schema.kdeps.com/core@%s#/Python.pkl\"\n\n", schema.SchemaVersion(dr.Context)))
 	pklContent.WriteString("resources {\n")
 
 	for id, resource := range existingResources {
@@ -312,7 +312,7 @@ func (dr *DependencyResolver) AppendPythonEntry(resourceId string, newPython *pk
 	}
 
 	// Evaluate the PKL file using EvalPkl
-	evaluatedContent, err := evaluator.EvalPkl(dr.Fs, dr.Context, pklPath, fmt.Sprintf("extends \"package://schema.kdeps.com/core@%s#/Python.pkl\"", schema.SchemaVersion()), dr.Logger)
+	evaluatedContent, err := evaluator.EvalPkl(dr.Fs, dr.Context, pklPath, fmt.Sprintf("extends \"package://schema.kdeps.com/core@%s#/Python.pkl\"", schema.SchemaVersion(dr.Context)), dr.Logger)
 	if err != nil {
 		return fmt.Errorf("failed to evaluate PKL file: %w", err)
 	}

--- a/pkg/resolver/python.go
+++ b/pkg/resolver/python.go
@@ -312,7 +312,7 @@ func (dr *DependencyResolver) AppendPythonEntry(resourceId string, newPython *pk
 	}
 
 	// Evaluate the PKL file using EvalPkl
-	evaluatedContent, err := evaluator.EvalPkl(dr.Fs, pklPath, fmt.Sprintf("extends \"package://schema.kdeps.com/core@%s#/Python.pkl\"", schema.SchemaVersion()), dr.Logger)
+	evaluatedContent, err := evaluator.EvalPkl(dr.Fs, dr.Context, pklPath, fmt.Sprintf("extends \"package://schema.kdeps.com/core@%s#/Python.pkl\"", schema.SchemaVersion()), dr.Logger)
 	if err != nil {
 		return fmt.Errorf("failed to evaluate PKL file: %w", err)
 	}

--- a/pkg/resolver/python.go
+++ b/pkg/resolver/python.go
@@ -8,11 +8,10 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/alexellis/go-execute/v2"
 	"github.com/kdeps/kdeps/pkg/evaluator"
 	"github.com/kdeps/kdeps/pkg/schema"
 	"github.com/kdeps/kdeps/pkg/utils"
-
-	"github.com/alexellis/go-execute/v2"
 	pklPython "github.com/kdeps/schema/gen/python"
 	"github.com/spf13/afero"
 )

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -2,16 +2,16 @@ package resolver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/kdeps/kartographer/graph"
 	"github.com/kdeps/kdeps/pkg/environment"
 	"github.com/kdeps/kdeps/pkg/logging"
 	"github.com/kdeps/kdeps/pkg/utils"
-
-	"github.com/google/uuid"
-	"github.com/kdeps/kartographer/graph"
 	pklRes "github.com/kdeps/schema/gen/resource"
 	pklWf "github.com/kdeps/schema/gen/workflow"
 	"github.com/spf13/afero"
@@ -58,14 +58,14 @@ func NewGraphResolver(fs afero.Fs, ctx context.Context, env *environment.Environ
 		// Check if "workflow.pkl" exists using afero.Exists
 		exists, err := afero.Exists(fs, pklWfFile)
 		if err != nil {
-			return nil, fmt.Errorf("error checking %s: %v", pklWfFile, err)
+			return nil, fmt.Errorf("error checking %s: %w", pklWfFile, err)
 		}
 
 		if !exists {
 			// If "workflow.pkl" doesn't exist, check for "../workflow.pkl"
 			existsParent, errParent := afero.Exists(fs, pklWfParentFile)
 			if errParent != nil {
-				return nil, fmt.Errorf("error checking %s: %v", pklWfParentFile, errParent)
+				return nil, fmt.Errorf("error checking %s: %w", pklWfParentFile, errParent)
 			}
 
 			if !existsParent {
@@ -94,7 +94,7 @@ func NewGraphResolver(fs afero.Fs, ctx context.Context, env *environment.Environ
 
 		// Create directories
 		if err := utils.CreateDirectories(fs, ctx, directories); err != nil {
-			return nil, fmt.Errorf("Error creating directory: %s", err)
+			return nil, fmt.Errorf("Error creating directory: %w", err)
 		} else {
 			logger.Debug("Directories created successfully")
 		}
@@ -134,7 +134,7 @@ func NewGraphResolver(fs afero.Fs, ctx context.Context, env *environment.Environ
 
 	dependencyResolver.Graph = graph.NewDependencyGraph(fs, logger.BaseLogger(), dependencyResolver.ResourceDependencies)
 	if dependencyResolver.Graph == nil {
-		return nil, fmt.Errorf("failed to initialize dependency graph")
+		return nil, errors.New("failed to initialize dependency graph")
 	}
 
 	return dependencyResolver, nil
@@ -275,7 +275,6 @@ func (dr *DependencyResolver) HandleRunAction() (bool, error) {
 							dr.Logger.Error("Http client error:", res.Id)
 							return dr.HandleAPIErrorResponse(500, fmt.Sprintf("Http client timeout awaiting for output: %s - %s", res.Id, err), false)
 						}
-
 					}
 
 					// API Response

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -45,7 +45,7 @@ type ResourceNodeEntry struct {
 	File string `pkl:"file"`
 }
 
-func NewGraphResolver(fs afero.Fs, logger *logging.Logger, ctx context.Context, env *environment.Environment, agentDir string) (*DependencyResolver, error) {
+func NewGraphResolver(fs afero.Fs, ctx context.Context, env *environment.Environment, agentDir string, logger *logging.Logger) (*DependencyResolver, error) {
 	graphId := uuid.New().String()
 
 	var dataDir, actionDir, filesDir, projectDir, pklWfFile, pklWfParentFile string
@@ -93,7 +93,7 @@ func NewGraphResolver(fs afero.Fs, logger *logging.Logger, ctx context.Context, 
 		}
 
 		// Create directories
-		if err := utils.CreateDirectories(fs, directories); err != nil {
+		if err := utils.CreateDirectories(fs, ctx, directories); err != nil {
 			return nil, fmt.Errorf("Error creating directory: %s", err)
 		} else {
 			logger.Debug("Directories created successfully")

--- a/pkg/resolver/resolver_test.go
+++ b/pkg/resolver/resolver_test.go
@@ -206,7 +206,7 @@ settings {
   }
 }
 `, methodSection, methodSection)
-	var filePath = filepath.Join(homeDirPath, "myAgentX1")
+	filePath := filepath.Join(homeDirPath, "myAgentX1")
 
 	if err := testFs.MkdirAll(filePath, 0o777); err != nil {
 		return err

--- a/pkg/resolver/resolver_test.go
+++ b/pkg/resolver/resolver_test.go
@@ -8,6 +8,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/log"
+	"github.com/cucumber/godog"
+	"github.com/docker/docker/client"
 	"github.com/kdeps/kdeps/pkg/archiver"
 	"github.com/kdeps/kdeps/pkg/cfg"
 	"github.com/kdeps/kdeps/pkg/docker"
@@ -15,10 +18,6 @@ import (
 	"github.com/kdeps/kdeps/pkg/environment"
 	"github.com/kdeps/kdeps/pkg/logging"
 	"github.com/kdeps/kdeps/pkg/resolver"
-
-	"github.com/charmbracelet/log"
-	"github.com/cucumber/godog"
-	"github.com/docker/docker/client"
 	"github.com/kdeps/schema/gen/kdeps"
 	pklRes "github.com/kdeps/schema/gen/resource"
 	wfPkl "github.com/kdeps/schema/gen/workflow"
@@ -172,10 +171,10 @@ func anAiAgentWithResources(arg1 string) error {
 		methodSection = "methods {\n" + strings.Join(methodLines, "\n") + "\n}"
 	} else {
 		// Single value case
-		methodSection = fmt.Sprintf(`
+		methodSection = `
 methods {
   "GET"
-}`)
+}`
 	}
 
 	workflowConfigurationContent := fmt.Sprintf(`
@@ -207,9 +206,7 @@ settings {
   }
 }
 `, methodSection, methodSection)
-	var filePath string
-
-	filePath = filepath.Join(homeDirPath, "myAgentX1")
+	var filePath = filepath.Join(homeDirPath, "myAgentX1")
 
 	if err := testFs.MkdirAll(filePath, 0o777); err != nil {
 		return err
@@ -243,7 +240,7 @@ settings {
 		return err
 	}
 
-	llmResponsesContent := fmt.Sprintf(`
+	llmResponsesContent := `
 amends "package://schema.kdeps.com/core@0.1.1#/LLM.pkl"
 
 chat {
@@ -255,7 +252,7 @@ response
 """
   }
 }
-`)
+`
 
 	llmDirFile := filepath.Join(llmDir, "llm_output.pkl")
 	err = afero.WriteFile(testFs, llmDirFile, []byte(llmResponsesContent), 0o644)
@@ -606,7 +603,7 @@ func iWasAbleToSeeTheTopdownDependencies(arg1 string) error {
 // description = "default action"
 // category = "category"
 // %s
-// `, num, num, requiresContent)
+// `, num, requiresContent)
 
 //		// Define the file path
 //		resourceConfigurationFile := filepath.Join(resourcesDir, fmt.Sprintf("resource%d.pkl", num))

--- a/pkg/resolver/resolver_test.go
+++ b/pkg/resolver/resolver_test.go
@@ -87,7 +87,7 @@ func anAiAgentWithResources(arg1 string) error {
 		return err
 	}
 
-	if err = docker.CreateFlagFile(testFs, filepath.Join(tmpRoot, ".dockerenv")); err != nil {
+	if err = docker.CreateFlagFile(testFs, ctx, filepath.Join(tmpRoot, ".dockerenv")); err != nil {
 		return err
 	}
 
@@ -122,7 +122,7 @@ func anAiAgentWithResources(arg1 string) error {
 		DockerMode:     "1",
 	}
 
-	env, err := environment.NewEnvironment(testFs, envStruct)
+	env, err := environment.NewEnvironment(testFs, ctx, envStruct)
 	if err != nil {
 		return err
 	}
@@ -143,12 +143,12 @@ func anAiAgentWithResources(arg1 string) error {
 		return err
 	}
 
-	systemConfigurationFile, err = cfg.FindConfiguration(testFs, environ, logger)
+	systemConfigurationFile, err = cfg.FindConfiguration(testFs, ctx, environ, logger)
 	if err != nil {
 		return err
 	}
 
-	if err = enforcer.EnforcePklTemplateAmendsRules(testFs, systemConfigurationFile, logger); err != nil {
+	if err = enforcer.EnforcePklTemplateAmendsRules(testFs, ctx, systemConfigurationFile, logger); err != nil {
 		return err
 	}
 
@@ -396,7 +396,7 @@ func iLoadTheWorkflowResources() error {
 	logger := logging.GetLogger()
 	ctx = context.Background()
 
-	dr, err := resolver.NewGraphResolver(testFs, logger, ctx, environ, agentDir)
+	dr, err := resolver.NewGraphResolver(testFs, ctx, environ, agentDir, logger)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/resolver/resolver_test.go
+++ b/pkg/resolver/resolver_test.go
@@ -56,6 +56,7 @@ var (
 )
 
 func TestFeatures(t *testing.T) {
+	t.Parallel()
 	suite := godog.TestSuite{
 		ScenarioInitializer: func(ctx *godog.ScenarioContext) {
 			ctx.Step(`^an ai agent with "([^"]*)" resources$`, anAiAgentWithResources)

--- a/pkg/resolver/resources.go
+++ b/pkg/resolver/resources.go
@@ -6,11 +6,10 @@ import (
 	"path/filepath"
 
 	"github.com/kdeps/kdeps/pkg/resource"
-
 	"github.com/spf13/afero"
 )
 
-// LoadResourceEntries loads .pkl resource files from the resources directory
+// LoadResourceEntries loads .pkl resource files from the resources directory.
 func (dr *DependencyResolver) LoadResourceEntries() error {
 	workflowDir := filepath.Join(dr.AgentDir, "resources")
 	var pklFiles []string
@@ -50,7 +49,7 @@ func (dr *DependencyResolver) LoadResourceEntries() error {
 	return nil
 }
 
-// handleFileImports handles dynamic and placeholder imports for a given file
+// handleFileImports handles dynamic and placeholder imports for a given file.
 func (dr *DependencyResolver) handleFileImports(path string) error {
 	// Prepend dynamic imports
 	if err := dr.PrependDynamicImports(path); err != nil {
@@ -65,7 +64,7 @@ func (dr *DependencyResolver) handleFileImports(path string) error {
 	return nil
 }
 
-// processPklFile processes an individual .pkl file and updates dependencies
+// processPklFile processes an individual .pkl file and updates dependencies.
 func (dr *DependencyResolver) processPklFile(file string) error {
 	// Load the resource file
 	pklRes, err := resource.LoadResource(dr.Context, file, dr.Logger)

--- a/pkg/resolver/response.go
+++ b/pkg/resolver/response.go
@@ -30,7 +30,7 @@ func (dr *DependencyResolver) CreateResponsePklFile(apiResponseBlock apiserverre
 	sections := dr.buildResponseSections(apiResponseBlock)
 	dr.Logger.Debug("Built response sections", "sections", sections)
 
-	if err := evaluator.CreateAndProcessPklFile(dr.Fs, sections, dr.ResponsePklFile, "APIServerResponse.pkl", dr.Logger, evaluator.EvalPkl, false); err != nil {
+	if err := evaluator.CreateAndProcessPklFile(dr.Fs, dr.Context, sections, dr.ResponsePklFile, "APIServerResponse.pkl", dr.Logger, evaluator.EvalPkl, false); err != nil {
 		dr.Logger.Error("Failed to create/process PKL file", "error", err)
 		return fmt.Errorf("failed to create/process PKL file: %w", err)
 	}

--- a/pkg/resolver/response.go
+++ b/pkg/resolver/response.go
@@ -66,7 +66,7 @@ func (dr *DependencyResolver) buildResponseSections(apiResponseBlock apiserverre
 	dr.Logger.Debug("Building response sections from API response", "response", apiResponseBlock)
 
 	sections := []string{
-		fmt.Sprintf(`import "package://schema.kdeps.com/core@%s#/Document.pkl" as document`, schema.SchemaVersion()),
+		fmt.Sprintf(`import "package://schema.kdeps.com/core@%s#/Document.pkl" as document`, schema.SchemaVersion(dr.Context)),
 		fmt.Sprintf("success = %v", apiResponseBlock.GetSuccess()),
 		formatResponseData(apiResponseBlock.GetResponse()),
 		formatErrors(apiResponseBlock.GetErrors(), dr.Logger),
@@ -271,7 +271,7 @@ func (dr *DependencyResolver) EvalPklFormattedResponseFile() (string, error) {
 	}
 
 	// Check if the PKL binary exists
-	if err := evaluator.EnsurePklBinaryExists(dr.Logger); err != nil {
+	if err := evaluator.EnsurePklBinaryExists(dr.Context, dr.Logger); err != nil {
 		dr.Logger.Error("PKL binary not found", "error", err)
 		return "", err
 	}

--- a/pkg/resolver/response.go
+++ b/pkg/resolver/response.go
@@ -2,18 +2,18 @@ package resolver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"reflect"
 	"strings"
 
+	"github.com/alexellis/go-execute/v2"
+	"github.com/google/uuid"
 	"github.com/kdeps/kdeps/pkg/evaluator"
 	"github.com/kdeps/kdeps/pkg/logging"
 	"github.com/kdeps/kdeps/pkg/schema"
 	"github.com/kdeps/kdeps/pkg/utils"
-
-	"github.com/alexellis/go-execute/v2"
-	"github.com/google/uuid"
 	apiserverresponse "github.com/kdeps/schema/gen/api_server_response"
 	"github.com/spf13/afero"
 )
@@ -159,7 +159,7 @@ func structToMap(s interface{}) map[interface{}]interface{} {
 	if val.Kind() == reflect.Ptr {
 		val = val.Elem() // Dereference if pointer
 	}
-	for i := 0; i < val.NumField(); i++ {
+	for i := range val.NumField() {
 		fieldName := val.Type().Field(i).Name
 		fieldValue := val.Field(i).Interface()
 		result[fieldName] = fieldValue
@@ -293,7 +293,7 @@ func (dr *DependencyResolver) validatePklFileExtension() error {
 	if filepath.Ext(dr.ResponsePklFile) != ".pkl" {
 		errMsg := fmt.Sprintf("file '%s' must have a .pkl extension", dr.ResponsePklFile)
 		dr.Logger.Error(errMsg)
-		return fmt.Errorf(errMsg)
+		return errors.New(errMsg)
 	}
 	return nil
 }
@@ -339,7 +339,7 @@ func (dr *DependencyResolver) executePklEvalCommand() (execute.ExecResult, error
 	if result.ExitCode != 0 {
 		errMsg := fmt.Sprintf("Command failed with exit code %d: %s", result.ExitCode, result.Stderr)
 		dr.Logger.Error(errMsg)
-		return execute.ExecResult{}, fmt.Errorf(errMsg)
+		return execute.ExecResult{}, errors.New(errMsg)
 	}
 
 	dr.Logger.Debug("Command executed successfully", "stdout", result.Stdout)

--- a/pkg/resolver/timestamps.go
+++ b/pkg/resolver/timestamps.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"time"
@@ -79,7 +80,7 @@ func getResourceTimestamp(resourceId string, pklRes interface{}) (*uint32, error
 			return resource.Timestamp, nil
 		}
 	default:
-		return nil, fmt.Errorf("unknown PKL result type")
+		return nil, errors.New("unknown PKL result type")
 	}
 
 	// If the resource does not exist, return an error

--- a/pkg/resource/resource_test.go
+++ b/pkg/resource/resource_test.go
@@ -115,7 +115,7 @@ func aKdepsContainerWithEndpointAPI(arg1, arg2, arg3 string) error {
 		NonInteractive: "1",
 	}
 
-	environ, err := environment.NewEnvironment(testFs, env)
+	environ, err := environment.NewEnvironment(testFs, ctx, env)
 	if err != nil {
 		return err
 	}
@@ -134,12 +134,12 @@ func aKdepsContainerWithEndpointAPI(arg1, arg2, arg3 string) error {
 		return err
 	}
 
-	systemConfigurationFile, err = cfg.FindConfiguration(testFs, environ, logger)
+	systemConfigurationFile, err = cfg.FindConfiguration(testFs, ctx, environ, logger)
 	if err != nil {
 		return err
 	}
 
-	if err = enforcer.EnforcePklTemplateAmendsRules(testFs, systemConfigurationFile, logger); err != nil {
+	if err = enforcer.EnforcePklTemplateAmendsRules(testFs, ctx, systemConfigurationFile, logger); err != nil {
 		return err
 	}
 
@@ -397,7 +397,7 @@ run {
 		f.Close()
 	}
 
-	if err := enforcer.EnforcePklTemplateAmendsRules(testFs, workflowConfigurationFile, logger); err != nil {
+	if err := enforcer.EnforcePklTemplateAmendsRules(testFs, ctx, workflowConfigurationFile, logger); err != nil {
 		return err
 	}
 

--- a/pkg/resource/resource_test.go
+++ b/pkg/resource/resource_test.go
@@ -191,7 +191,7 @@ settings {
   }
 }
 `, methodSection)
-	var filePath = filepath.Join(homeDirPath, "myAgentX")
+	filePath := filepath.Join(homeDirPath, "myAgentX")
 
 	if err := testFs.MkdirAll(filePath, 0o777); err != nil {
 		return err

--- a/pkg/resource/resource_test.go
+++ b/pkg/resource/resource_test.go
@@ -57,6 +57,7 @@ var (
 )
 
 func TestFeatures(t *testing.T) {
+	t.Parallel()
 	suite := godog.TestSuite{
 		ScenarioInitializer: func(ctx *godog.ScenarioContext) {
 			ctx.Step(`^a kdeps container with "([^"]*)" endpoint "([^"]*)" API and "([^"]*)"$`, aKdepsContainerWithEndpointAPI)

--- a/pkg/resource/resource_test.go
+++ b/pkg/resource/resource_test.go
@@ -13,6 +13,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cucumber/godog"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
 	"github.com/kdeps/kdeps/pkg/archiver"
 	"github.com/kdeps/kdeps/pkg/cfg"
 	"github.com/kdeps/kdeps/pkg/docker"
@@ -20,10 +23,6 @@ import (
 	"github.com/kdeps/kdeps/pkg/environment"
 	"github.com/kdeps/kdeps/pkg/logging"
 	"github.com/kdeps/kdeps/pkg/workflow"
-
-	"github.com/cucumber/godog"
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/client"
 	"github.com/kdeps/schema/gen/kdeps"
 	wfPkl "github.com/kdeps/schema/gen/workflow"
 	"github.com/spf13/afero"
@@ -192,9 +191,7 @@ settings {
   }
 }
 `, methodSection)
-	var filePath string
-
-	filePath = filepath.Join(homeDirPath, "myAgentX")
+	var filePath = filepath.Join(homeDirPath, "myAgentX")
 
 	if err := testFs.MkdirAll(filePath, 0o777); err != nil {
 		return err
@@ -388,7 +385,7 @@ run {
 
 	doc := "THIS IS A TEXT FILE: "
 
-	for x := 0; x < 10; x++ {
+	for x := range 10 {
 		num := strconv.Itoa(x)
 		file := filepath.Join(dataDir, fmt.Sprintf("textfile-%s.txt", num))
 
@@ -487,7 +484,7 @@ func iGETRequestToWithDataAndHeaderNameThatMapsTo(arg1, arg2, arg3, arg4 string)
 	reqBody := strings.NewReader(arg2)
 
 	// Create a new GET request
-	req, err := http.NewRequest("GET", baseURL, reqBody)
+	req, err := http.NewRequest(http.MethodGet, baseURL, reqBody)
 	if err != nil {
 		fmt.Println("Error creating request:", err)
 		return err

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"sync"
@@ -15,12 +16,12 @@ var (
 	UseLatest        bool   = false
 )
 
-// SchemaVersion fetches and returns the schema version based on the cmd.Latest flag.
-func SchemaVersion() string {
+// SchemaVersion(ctx) fetches and returns the schema version based on the cmd.Latest flag.
+func SchemaVersion(ctx context.Context) string {
 	if UseLatest { // Reference the global Latest flag from cmd package
 		once.Do(func() {
 			var err error
-			cachedVersion, err = utils.GitHubReleaseFetcher("kdeps/schema", "")
+			cachedVersion, err = utils.GitHubReleaseFetcher(ctx, "kdeps/schema", "")
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error: Unable to fetch the latest schema version for 'kdeps/schema': %v\n", err)
 				os.Exit(1)

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -9,15 +9,18 @@ import (
 )
 
 func TestSchemaVersion(t *testing.T) {
+	t.Parallel()
 	var ctx context.Context
 
 	t.Run("returns specified version when UseLatest is false", func(t *testing.T) {
+		t.Parallel()
 		UseLatest = false
 		result := SchemaVersion(ctx)
 		assert.Equal(t, "0.1.46", result, "expected the specified version to be returned")
 	})
 
 	t.Run("returns latest version when UseLatest is true", func(t *testing.T) {
+		t.Parallel()
 		// Mock GitHubReleaseFetcher to return a fixed version
 		utils.GitHubReleaseFetcher = func(ctx context.Context, repo, baseURL string) (string, error) {
 			return "0.1.46", nil

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"context"
 	"testing"
 
 	"github.com/kdeps/kdeps/pkg/utils"
@@ -9,21 +10,23 @@ import (
 )
 
 func TestSchemaVersion(t *testing.T) {
+	var ctx context.Context
+
 	t.Run("returns specified version when UseLatest is false", func(t *testing.T) {
 		UseLatest = false
-		result := SchemaVersion()
+		result := SchemaVersion(ctx)
 		assert.Equal(t, "0.1.46", result, "expected the specified version to be returned")
 	})
 
 	t.Run("returns latest version when UseLatest is true", func(t *testing.T) {
 		// Mock GitHubReleaseFetcher to return a fixed version
-		utils.GitHubReleaseFetcher = func(repo, baseURL string) (string, error) {
+		utils.GitHubReleaseFetcher = func(ctx context.Context, repo, baseURL string) (string, error) {
 			return "0.1.46", nil
 		}
 		defer func() { utils.GitHubReleaseFetcher = utils.GetLatestGitHubRelease }()
 
 		UseLatest = true
-		result := SchemaVersion()
+		result := SchemaVersion(ctx)
 		assert.Equal(t, "0.1.46", result, "expected the latest version to be returned")
 	})
 }

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/kdeps/kdeps/pkg/utils"
-
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -86,18 +86,18 @@ func generateWorkflowFile(fs afero.Fs, ctx context.Context, logger *logging.Logg
 
 	// Template data for dynamic replacement
 	templateData := map[string]string{
-		"Header": fmt.Sprintf(`amends "package://schema.kdeps.com/core@%s#/Workflow.pkl"`, schema.SchemaVersion()),
+		"Header": fmt.Sprintf(`amends "package://schema.kdeps.com/core@%s#/Workflow.pkl"`, schema.SchemaVersion(ctx)),
 		"Name":   name,
 	}
 
 	// Load and process the template
-	content, err := loadTemplate(templatePath, ctx, templateData)
+	content, err := loadTemplate(ctx, templatePath, templateData)
 	if err != nil {
 		logger.Error("Failed to load workflow template: ", err)
 		return err
 	}
 
-	return createFile(fs, logger, outputPath, content)
+	return createFile(fs, ctx, logger, outputPath, content)
 }
 
 func loadTemplate(ctx context.Context, templatePath string, data map[string]string) (string, error) {
@@ -128,7 +128,7 @@ func generateResourceFiles(fs afero.Fs, ctx context.Context, logger *logging.Log
 
 	// Common template data
 	templateData := map[string]string{
-		"Header": fmt.Sprintf(`amends "package://schema.kdeps.com/core@%s#/Resource.pkl"`, schema.SchemaVersion()),
+		"Header": fmt.Sprintf(`amends "package://schema.kdeps.com/core@%s#/Resource.pkl"`, schema.SchemaVersion(ctx)),
 		"Name":   name,
 	}
 
@@ -150,14 +150,14 @@ func generateResourceFiles(fs afero.Fs, ctx context.Context, logger *logging.Log
 		}
 
 		templatePath := filepath.Join("templates", file.Name())
-		content, err := loadTemplate(templatePath, ctx, templateData)
+		content, err := loadTemplate(ctx, templatePath, templateData)
 		if err != nil {
 			logger.Error("Failed to process template: ", err)
 			return err
 		}
 
 		outputPath := filepath.Join(resourceDir, file.Name())
-		if err := createFile(fs, logger, outputPath, content); err != nil {
+		if err := createFile(fs, ctx, logger, outputPath, content); err != nil {
 			return err
 		}
 	}
@@ -179,12 +179,12 @@ func generateSpecificFile(fs afero.Fs, ctx context.Context, logger *logging.Logg
 
 	templatePath := filepath.Join("templates", fileName)
 	templateData := map[string]string{
-		"Header": fmt.Sprintf(headerTemplate, schema.SchemaVersion()),
+		"Header": fmt.Sprintf(headerTemplate, schema.SchemaVersion(ctx)),
 		"Name":   agentName,
 	}
 
 	// Load the template
-	content, err := loadTemplate(templatePath, ctx, templateData)
+	content, err := loadTemplate(ctx, templatePath, templateData)
 	if err != nil {
 		logger.Error("Failed to load specific template: ", err)
 		return err
@@ -205,7 +205,7 @@ func generateSpecificFile(fs afero.Fs, ctx context.Context, logger *logging.Logg
 
 	// Write the generated file
 	filePath := filepath.Join(outputDir, fileName)
-	if err := createFile(fs, logger, filePath, content); err != nil {
+	if err := createFile(fs, ctx, logger, filePath, content); err != nil {
 		return err
 	}
 
@@ -242,7 +242,7 @@ func GenerateSpecificAgentFile(fs afero.Fs, ctx context.Context, logger *logging
 		return err
 	}
 
-	if err := generateSpecificFile(fs, logger, mainDir, fileName, name); err != nil {
+	if err := generateSpecificFile(fs, ctx, logger, mainDir, fileName, name); err != nil {
 		logger.Error("Failed to generate specific file: ", err)
 		return err
 	}
@@ -289,7 +289,7 @@ func GenerateAgent(fs afero.Fs, ctx context.Context, logger *logging.Logger, age
 		}
 		name = agentName
 	} else {
-		name, err = promptForAgentName()
+		name, err = promptForAgentName(ctx)
 		if err != nil {
 			logger.Error("Failed to prompt for agent name: ", err)
 			return err
@@ -333,7 +333,7 @@ func GenerateAgent(fs afero.Fs, ctx context.Context, logger *logging.Logger, age
 
 	if openWorkflow {
 		workflowFilePath := fmt.Sprintf("%s/workflow.pkl", mainDir)
-		if err := texteditor.EditPkl(fs, workflowFilePath, logger); err != nil {
+		if err := texteditor.EditPkl(fs, ctx, workflowFilePath, logger); err != nil {
 			logger.Error("Failed to edit workflow file: ", err)
 			return fmt.Errorf("failed to edit workflow file: %w", err)
 		}

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -61,7 +61,7 @@ func promptForAgentName(ctx context.Context) (string, error) {
 }
 
 func createDirectory(fs afero.Fs, ctx context.Context, logger *logging.Logger, path string) error {
-	printWithDots(fmt.Sprintf("Creating directory: %s", lightGreen.Render(path)))
+	printWithDots("Creating directory: " + lightGreen.Render(path))
 	if err := fs.MkdirAll(path, os.ModePerm); err != nil {
 		logger.Error(err)
 		return err
@@ -71,7 +71,7 @@ func createDirectory(fs afero.Fs, ctx context.Context, logger *logging.Logger, p
 }
 
 func createFile(fs afero.Fs, ctx context.Context, logger *logging.Logger, path string, content string) error {
-	printWithDots(fmt.Sprintf("Creating file: %s", lightGreen.Render(path)))
+	printWithDots("Creating file: " + lightGreen.Render(path))
 	if err := afero.WriteFile(fs, path, []byte(content), 0o644); err != nil {
 		logger.Error(err)
 		return err
@@ -236,7 +236,7 @@ func GenerateSpecificAgentFile(fs afero.Fs, ctx context.Context, logger *logging
 		}
 	}
 
-	mainDir := fmt.Sprintf("./%s", name)
+	mainDir := "./" + name
 	if err := createDirectory(fs, ctx, logger, mainDir); err != nil {
 		logger.Error("Failed to create main directory: ", err)
 		return err
@@ -296,7 +296,7 @@ func GenerateAgent(fs afero.Fs, ctx context.Context, logger *logging.Logger, age
 		}
 	}
 
-	mainDir := fmt.Sprintf("./%s", name)
+	mainDir := "./" + name
 	if err := createDirectory(fs, ctx, logger, mainDir); err != nil {
 		logger.Error("Failed to create main directory: ", err)
 		return err
@@ -332,7 +332,7 @@ func GenerateAgent(fs afero.Fs, ctx context.Context, logger *logging.Logger, age
 	}
 
 	if openWorkflow {
-		workflowFilePath := fmt.Sprintf("%s/workflow.pkl", mainDir)
+		workflowFilePath := mainDir + "/workflow.pkl"
 		if err := texteditor.EditPkl(fs, ctx, workflowFilePath, logger); err != nil {
 			logger.Error("Failed to edit workflow file: ", err)
 			return fmt.Errorf("failed to edit workflow file: %w", err)

--- a/pkg/texteditor/texteditor.go
+++ b/pkg/texteditor/texteditor.go
@@ -1,6 +1,7 @@
 package texteditor
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,7 +12,7 @@ import (
 )
 
 // EditPkl opens the file at filePath with the 'kdeps' editor if the file exists and has a .pkl extension.
-func EditPkl(fs afero.Fs, filePath string, logger *logging.Logger) error {
+func EditPkl(fs afero.Fs, ctx context.Context, filePath string, logger *logging.Logger) error {
 	// Ensure the file has a .pkl extension
 	if filepath.Ext(filePath) != ".pkl" {
 		err := fmt.Sprintf("file '%s' does not have a .pkl extension", filePath)

--- a/pkg/texteditor/texteditor.go
+++ b/pkg/texteditor/texteditor.go
@@ -2,6 +2,7 @@ package texteditor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -17,7 +18,7 @@ func EditPkl(fs afero.Fs, ctx context.Context, filePath string, logger *logging.
 	if filepath.Ext(filePath) != ".pkl" {
 		err := fmt.Sprintf("file '%s' does not have a .pkl extension", filePath)
 		logger.Error(err)
-		return fmt.Errorf(err)
+		return errors.New(err)
 	}
 
 	// Check if the file exists
@@ -25,11 +26,11 @@ func EditPkl(fs afero.Fs, ctx context.Context, filePath string, logger *logging.
 		if os.IsNotExist(err) {
 			errMsg := fmt.Sprintf("file '%s' does not exist", filePath)
 			logger.Error(errMsg)
-			return fmt.Errorf(errMsg)
+			return errors.New(errMsg)
 		}
 		errMsg := fmt.Sprintf("failed to stat file '%s': %v", filePath, err)
 		logger.Error(errMsg)
-		return fmt.Errorf(errMsg)
+		return errors.New(errMsg)
 	}
 
 	// Prepare the editor command
@@ -37,7 +38,7 @@ func EditPkl(fs afero.Fs, ctx context.Context, filePath string, logger *logging.
 	if err != nil {
 		errMsg := fmt.Sprintf("failed to create editor command: %v", err)
 		logger.Error(errMsg)
-		return fmt.Errorf(errMsg)
+		return errors.New(errMsg)
 	}
 
 	cmd.Stdin = os.Stdin
@@ -48,7 +49,7 @@ func EditPkl(fs afero.Fs, ctx context.Context, filePath string, logger *logging.
 	if err := cmd.Run(); err != nil {
 		errMsg := fmt.Sprintf("editor command failed: %v", err)
 		logger.Error(errMsg)
-		return fmt.Errorf(errMsg)
+		return errors.New(errMsg)
 	}
 
 	return nil

--- a/pkg/utils/api_response.go
+++ b/pkg/utils/api_response.go
@@ -4,7 +4,7 @@ import (
 	apiserverresponse "github.com/kdeps/schema/gen/api_server_response"
 )
 
-// Persistent slice to hold error blocks
+// Persistent slice to hold error blocks.
 var persistentErrors []*apiserverresponse.APIServerErrorsBlock
 
 func NewAPIServerResponse(success bool, data []any, errorCode int, errorMessage string) *apiserverresponse.APIServerResponseImpl {

--- a/pkg/utils/api_response_test.go
+++ b/pkg/utils/api_response_test.go
@@ -7,10 +7,13 @@ import (
 )
 
 func TestNewAPIServerResponse(t *testing.T) {
+	t.Parallel()
+
 	// Reset persistentErrors for a clean test state
 	persistentErrors = nil
 
 	t.Run("SuccessfulResponseWithoutErrors", func(t *testing.T) {
+		t.Parallel()
 		response := NewAPIServerResponse(true, []any{"data1", "data2"}, 0, "")
 
 		assert.True(t, response.Success, "Expected success to be true")
@@ -20,6 +23,7 @@ func TestNewAPIServerResponse(t *testing.T) {
 	})
 
 	t.Run("ResponseWithError", func(t *testing.T) {
+		t.Parallel()
 		response := NewAPIServerResponse(false, nil, 404, "Resource not found")
 
 		assert.False(t, response.Success, "Expected success to be false")
@@ -33,6 +37,7 @@ func TestNewAPIServerResponse(t *testing.T) {
 	})
 
 	t.Run("PersistentErrorStorage", func(t *testing.T) {
+		t.Parallel()
 		// Add another error
 		NewAPIServerResponse(false, nil, 500, "Internal server error")
 
@@ -46,6 +51,7 @@ func TestNewAPIServerResponse(t *testing.T) {
 	})
 
 	t.Run("ClearPersistentErrors", func(t *testing.T) {
+		t.Parallel()
 		// Manually clear persistentErrors
 		persistentErrors = nil
 

--- a/pkg/utils/base64.go
+++ b/pkg/utils/base64.go
@@ -6,7 +6,7 @@ import (
 	"unicode/utf8"
 )
 
-// Helper function to check if a string is already Base64 encoded
+// Helper function to check if a string is already Base64 encoded.
 func IsBase64Encoded(str string) bool {
 	// Return false for empty strings
 	if str == "" {
@@ -36,7 +36,7 @@ func IsBase64Encoded(str string) bool {
 	return utf8.Valid(decoded)
 }
 
-// Helper function to decode a Base64-encoded string
+// Helper function to decode a Base64-encoded string.
 func DecodeBase64String(encodedStr string) (string, error) {
 	if !IsBase64Encoded(encodedStr) {
 		return encodedStr, nil
@@ -48,7 +48,7 @@ func DecodeBase64String(encodedStr string) (string, error) {
 	return string(decodedBytes), nil
 }
 
-// Helper function to Base64 encode a string
+// Helper function to Base64 encode a string.
 func EncodeBase64String(data string) string {
 	return base64.StdEncoding.EncodeToString([]byte(data))
 }

--- a/pkg/utils/base64_test.go
+++ b/pkg/utils/base64_test.go
@@ -7,41 +7,51 @@ import (
 )
 
 func TestIsBase64Encoded(t *testing.T) {
+	t.Parallel()
 	t.Run("ValidBase64String", func(t *testing.T) {
+		t.Parallel()
 		assert.True(t, IsBase64Encoded("U29tZSB2YWxpZCBzdHJpbmc=")) // "Some valid string"
 	})
 
 	t.Run("InvalidBase64String", func(t *testing.T) {
+		t.Parallel()
 		assert.False(t, IsBase64Encoded("InvalidString!!!"))
 	})
 
 	t.Run("EmptyString", func(t *testing.T) {
+		t.Parallel()
 		assert.False(t, IsBase64Encoded(""))
 	})
 
 	t.Run("NonBase64Characters", func(t *testing.T) {
+		t.Parallel()
 		assert.False(t, IsBase64Encoded("Hello@World"))
 	})
 
 	t.Run("ValidBase64ButInvalidUTF8", func(t *testing.T) {
+		t.Parallel()
 		assert.False(t, IsBase64Encoded("////")) // Decodes to invalid UTF-8
 	})
 }
 
 func TestDecodeBase64String(t *testing.T) {
+	t.Parallel()
 	t.Run("DecodeValidBase64String", func(t *testing.T) {
+		t.Parallel()
 		decoded, err := DecodeBase64String("U29tZSB2YWxpZCBzdHJpbmc=") // "Some valid string"
 		assert.NoError(t, err)
 		assert.Equal(t, "Some valid string", decoded)
 	})
 
 	t.Run("DecodeInvalidBase64String", func(t *testing.T) {
+		t.Parallel()
 		decoded, err := DecodeBase64String("InvalidString!!!")
 		assert.NoError(t, err)
 		assert.Equal(t, "InvalidString!!!", decoded) // Should return the original string
 	})
 
 	t.Run("DecodeEmptyString", func(t *testing.T) {
+		t.Parallel()
 		decoded, err := DecodeBase64String("")
 		assert.NoError(t, err)
 		assert.Equal(t, "", decoded)
@@ -49,19 +59,24 @@ func TestDecodeBase64String(t *testing.T) {
 }
 
 func TestEncodeBase64String(t *testing.T) {
+	t.Parallel()
 	t.Run("EncodeString", func(t *testing.T) {
+		t.Parallel()
 		encoded := EncodeBase64String("Some valid string")
 		assert.Equal(t, "U29tZSB2YWxpZCBzdHJpbmc=", encoded)
 	})
 
 	t.Run("EncodeEmptyString", func(t *testing.T) {
+		t.Parallel()
 		encoded := EncodeBase64String("")
 		assert.Equal(t, "", encoded)
 	})
 }
 
 func TestRoundTripBase64Encoding(t *testing.T) {
+	t.Parallel()
 	t.Run("EncodeAndDecode", func(t *testing.T) {
+		t.Parallel()
 		original := "Some valid string"
 		encoded := EncodeBase64String(original)
 		decoded, err := DecodeBase64String(encoded)

--- a/pkg/utils/conditions_test.go
+++ b/pkg/utils/conditions_test.go
@@ -7,31 +7,37 @@ import (
 )
 
 func TestShouldSkip(t *testing.T) {
+	t.Parallel()
 	t.Run("NoConditions", func(t *testing.T) {
+		t.Parallel()
 		conditions := []any{}
 		result := ShouldSkip(&conditions)
 		assert.False(t, result, "Expected ShouldSkip to return false when there are no conditions")
 	})
 
 	t.Run("AllFalseConditions", func(t *testing.T) {
+		t.Parallel()
 		conditions := []any{false, "false", false}
 		result := ShouldSkip(&conditions)
 		assert.False(t, result, "Expected ShouldSkip to return false when all conditions are false or 'false'")
 	})
 
 	t.Run("SomeTrueConditions", func(t *testing.T) {
+		t.Parallel()
 		conditions := []any{false, "true", false}
 		result := ShouldSkip(&conditions)
 		assert.True(t, result, "Expected ShouldSkip to return true when at least one condition is true or 'true'")
 	})
 
 	t.Run("AllTrueConditions", func(t *testing.T) {
+		t.Parallel()
 		conditions := []any{true, "true", true}
 		result := ShouldSkip(&conditions)
 		assert.True(t, result, "Expected ShouldSkip to return true when all conditions are true or 'true'")
 	})
 
 	t.Run("MixedInvalidConditions", func(t *testing.T) {
+		t.Parallel()
 		conditions := []any{"maybe", 123, false}
 		result := ShouldSkip(&conditions)
 		assert.False(t, result, "Expected ShouldSkip to return false for unsupported types and false conditions")
@@ -39,31 +45,37 @@ func TestShouldSkip(t *testing.T) {
 }
 
 func TestAllConditionsMet(t *testing.T) {
+	t.Parallel()
 	t.Run("NoConditions", func(t *testing.T) {
+		t.Parallel()
 		conditions := []any{}
 		result := AllConditionsMet(&conditions)
 		assert.True(t, result, "Expected AllConditionsMet to return true when there are no conditions")
 	})
 
 	t.Run("AllTrueConditions", func(t *testing.T) {
+		t.Parallel()
 		conditions := []any{true, "true", true}
 		result := AllConditionsMet(&conditions)
 		assert.True(t, result, "Expected AllConditionsMet to return true when all conditions are true or 'true'")
 	})
 
 	t.Run("SomeFalseConditions", func(t *testing.T) {
+		t.Parallel()
 		conditions := []any{true, "false", true}
 		result := AllConditionsMet(&conditions)
 		assert.False(t, result, "Expected AllConditionsMet to return false when at least one condition is false or 'false'")
 	})
 
 	t.Run("AllFalseConditions", func(t *testing.T) {
+		t.Parallel()
 		conditions := []any{"false", false, "false"}
 		result := AllConditionsMet(&conditions)
 		assert.False(t, result, "Expected AllConditionsMet to return false when all conditions are false or 'false'")
 	})
 
 	t.Run("MixedInvalidConditions", func(t *testing.T) {
+		t.Parallel()
 		conditions := []any{true, "maybe", 123}
 		result := AllConditionsMet(&conditions)
 		assert.False(t, result, "Expected AllConditionsMet to return false for unsupported types or non-true conditions")

--- a/pkg/utils/files.go
+++ b/pkg/utils/files.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strings"
@@ -10,7 +11,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-func WaitForFileReady(fs afero.Fs, filepath string, logger *logging.Logger) error {
+func WaitForFileReady(fs afero.Fs, ctx context.Context, filepath string, logger *logging.Logger) error {
 	logger.Debug("Waiting for file to be ready...", "file", filepath)
 
 	ticker := time.NewTicker(500 * time.Millisecond)
@@ -47,7 +48,7 @@ func ConvertToFilenameFriendly(input string) string {
 	return strings.TrimPrefix(sanitized, "_")
 }
 
-func CreateDirectories(fs afero.Fs, dirs []string) error {
+func CreateDirectories(fs afero.Fs, ctx context.Context, dirs []string) error {
 	for _, dir := range dirs {
 		// Use fs.MkdirAll to create the directory and its parents if they don't exist
 		err := fs.MkdirAll(dir, 0o755)

--- a/pkg/utils/files_test.go
+++ b/pkg/utils/files_test.go
@@ -25,7 +25,9 @@ func (e *errorFs) Stat(name string) (os.FileInfo, error) {
 }
 
 func TestWaitForFileReady(t *testing.T) {
+	t.Parallel()
 	t.Run("FileExists", func(t *testing.T) {
+		t.Parallel()
 		// Arrange
 		fs := afero.NewMemMapFs()
 		filepath := "/testfile.txt"
@@ -42,6 +44,7 @@ func TestWaitForFileReady(t *testing.T) {
 	})
 
 	t.Run("FileDoesNotExist", func(t *testing.T) {
+		t.Parallel()
 		// Arrange
 		fs := afero.NewMemMapFs()
 		filepath := "/nonexistent.txt"
@@ -58,6 +61,7 @@ func TestWaitForFileReady(t *testing.T) {
 	})
 
 	t.Run("ErrorCheckingFile", func(t *testing.T) {
+		t.Parallel()
 		// Arrange
 		fs := &errorFs{Fs: afero.NewMemMapFs()} // Wrap with error-inducing Fs
 		filepath := "/cannotcreate.txt"

--- a/pkg/utils/files_test.go
+++ b/pkg/utils/files_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"errors"
 	"os"
 	"testing"
@@ -12,6 +13,8 @@ import (
 )
 
 var logger = logging.GetLogger()
+
+var ctx context.Context
 
 type errorFs struct {
 	afero.Fs
@@ -32,7 +35,7 @@ func TestWaitForFileReady(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Act
-		err = WaitForFileReady(fs, filepath, logger)
+		err = WaitForFileReady(fs, ctx, filepath, logger)
 
 		// Assert
 		assert.NoError(t, err)
@@ -48,7 +51,7 @@ func TestWaitForFileReady(t *testing.T) {
 			time.Sleep(1 * time.Second)
 			fs.Create(filepath) // Create the file after a delay
 		}()
-		err := WaitForFileReady(fs, filepath, logger)
+		err := WaitForFileReady(fs, ctx, filepath, logger)
 
 		// Assert
 		assert.NoError(t, err)
@@ -60,7 +63,7 @@ func TestWaitForFileReady(t *testing.T) {
 		filepath := "/cannotcreate.txt"
 
 		// Act
-		err := WaitForFileReady(fs, filepath, logger)
+		err := WaitForFileReady(fs, ctx, filepath, logger)
 
 		// Assert
 		assert.Error(t, err)

--- a/pkg/utils/github.go
+++ b/pkg/utils/github.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -21,7 +22,7 @@ func GetLatestGitHubRelease(ctx context.Context, repo string, baseURL string) (s
 	}
 	url := fmt.Sprintf("%s/repos/%s/releases/latest", baseURL, repo)
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return "", fmt.Errorf("failed to create request: %w", err)
 	}
@@ -40,10 +41,10 @@ func GetLatestGitHubRelease(ctx context.Context, repo string, baseURL string) (s
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		return "", fmt.Errorf("unauthorized: check your GITHUB_TOKEN")
+		return "", errors.New("unauthorized: check your GITHUB_TOKEN")
 	}
 	if resp.StatusCode == http.StatusForbidden {
-		return "", fmt.Errorf("rate limit exceeded: ensure your GITHUB_TOKEN has appropriate permissions")
+		return "", errors.New("rate limit exceeded: ensure your GITHUB_TOKEN has appropriate permissions")
 	}
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("unexpected status code: %d, response: %s", resp.StatusCode, http.StatusText(resp.StatusCode))

--- a/pkg/utils/github.go
+++ b/pkg/utils/github.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -14,7 +15,7 @@ import (
 var GitHubReleaseFetcher = GetLatestGitHubRelease
 
 // GetLatestGitHubRelease fetches the latest release version from a GitHub repository.
-func GetLatestGitHubRelease(repo string, baseURL string) (string, error) {
+func GetLatestGitHubRelease(ctx context.Context, repo string, baseURL string) (string, error) {
 	if baseURL == "" {
 		baseURL = "https://api.github.com"
 	}

--- a/pkg/utils/github_test.go
+++ b/pkg/utils/github_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestGetLatestGitHubRelease(t *testing.T) {
+	t.Parallel()
 	var ctx context.Context
 
 	// Mock GitHub API server

--- a/pkg/utils/github_test.go
+++ b/pkg/utils/github_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +11,8 @@ import (
 )
 
 func TestGetLatestGitHubRelease(t *testing.T) {
+	var ctx context.Context
+
 	// Mock GitHub API server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -18,7 +21,7 @@ func TestGetLatestGitHubRelease(t *testing.T) {
 	}))
 	defer server.Close()
 
-	result, err := GetLatestGitHubRelease("kdeps/schema", server.URL)
+	result, err := GetLatestGitHubRelease(ctx, "kdeps/schema", server.URL)
 	assert.NoError(t, err)
 	assert.Equal(t, "2.1.0", result)
 }

--- a/pkg/utils/sigterm.go
+++ b/pkg/utils/sigterm.go
@@ -7,7 +7,7 @@ import (
 	"github.com/kdeps/kdeps/pkg/logging"
 )
 
-// sendSigterm sends a SIGTERM signal to the current process
+// sendSigterm sends a SIGTERM signal to the current process.
 func SendSigterm(logger *logging.Logger) {
 	process, err := os.FindProcess(os.Getpid()) // Get the current process
 	if err != nil {

--- a/pkg/utils/sigterm_test.go
+++ b/pkg/utils/sigterm_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestSendSigterm(t *testing.T) {
+	t.Parallel()
 	// Create a logger that outputs to os.Stderr for visibility in tests
 	logging.CreateLogger()
 

--- a/pkg/utils/sigterm_test.go
+++ b/pkg/utils/sigterm_test.go
@@ -33,7 +33,7 @@ func TestSendSigterm(t *testing.T) {
 	}
 }
 
-// timeout provides a channel that sends a signal after 1 second to prevent hangs
+// timeout provides a channel that sends a signal after 1 second to prevent hangs.
 func timeout() <-chan struct{} {
 	ch := make(chan struct{})
 	go func() {


### PR DESCRIPTION
This PR fix lint issues in multiple files using golangci

Manual fixes
    - Pass context around from main to downstream functions
    - Parallelize all the tests
 
Auto fixes
    - Resolved linting issues across many files using automated fixes from golangci.
    - Adjustments include formatting, static analysis improvements, and adherence to linter rules.
