### PR TITLE
use native PKL types for duration on timestamps

### DIFF
--- a/docs/getting-started/introduction/quickstart.md
+++ b/docs/getting-started/introduction/quickstart.md
@@ -272,7 +272,7 @@ chat {
         "famous_quotes"
         "known_for"
     }
-    timeoutSeconds = 60
+    timeoutDuration = 60.s
 }
 ```
 

--- a/docs/getting-started/resources/client.md
+++ b/docs/getting-started/resources/client.md
@@ -43,7 +43,7 @@ HTTPClient {
     headers {
         ["X-API-KEY"] = "@(request.header("X-API-KEY"))"
     }
-    timeoutSeconds = 60
+    timeoutDuration = 60.s
 }
 ```
 
@@ -53,7 +53,7 @@ Key elements of the `HTTPClient` block include:
 - **`url`**: Defines the API endpoint.
 - **`data`**: Specifies all the request data to be submitted with this request.
 - **`headers`**: Specifies all the request headers to be submitted with this request.
-- **`timeoutSeconds`**: Determines the execution timeout in seconds, after which the request will be terminated.
+- **`timeoutDuration`**: Determines the exectuion timeout in s (seconds), min (minutes), etc., after which the request will be terminated.
 
 When the resource is executed, you can use client functions like `client.responseBody("id")` to access the response
 body. For further details, refer to the [HTTP Client

--- a/docs/getting-started/resources/exec.md
+++ b/docs/getting-started/resources/exec.md
@@ -45,7 +45,7 @@ exec {
         ["ENVVAR"] = "XYZ"  // Example environment variable
     }
     // Specifies the timeout duration (in seconds) for the shell execution
-    timeoutSeconds = 60
+    timeoutDuration = 60.s
 }
 ```
 
@@ -53,7 +53,7 @@ Key elements of the `exec` block includes:
 
 - **`command`**: Specifies the shell command(s) to execute, enclosed in triple double-quotes (`"""`) for multi-line support.
 - **`env`**: Defines environment variables to be available during execution.
-- **`timeoutSeconds`**: Determines the execution timeout in seconds, after which the shell command will be terminated.
+- **`timeoutDuration`**: Determines the exectuion timeout in s (seconds), min (minutes), etc., after which the shell command will be terminated.
 
 When the resource is executed, you can leverage Exec functions like `exec.stdout("id")` to access the output. For
 further details, refer to the [Exec Functions](../resources/functions.md#exec-resource-functions) documentation.

--- a/docs/getting-started/resources/image-generators.md
+++ b/docs/getting-started/resources/image-generators.md
@@ -227,7 +227,7 @@ exec {
     env {
         ["HF_TOKEN"] = "\(read("env:HF_TOKEN"))"                                                 // [!code ++]
     }
-    timeoutSeconds = 0
+    timeoutDuration = 0.s
 }
 ```
 

--- a/docs/getting-started/resources/llm.md
+++ b/docs/getting-started/resources/llm.md
@@ -57,7 +57,7 @@ chat {
     }
 
     // Timeout duration in seconds, specifying when to terminate the LLM session.
-    timeoutSeconds = 60
+    timeoutDuration = 60.s
 }
 ```
 
@@ -71,7 +71,7 @@ Key Elements of the `chat` Block
 - **`JSONResponseKeys`**: Lists the required keys for the structured JSON response. To ensure the output conforms to
   specific data types, you can define the keys with their corresponding types. For example: `first_name__string`,
   `famous_quotes__array`, `details__markdown`, or `age__integer`.
-- **`timeoutSeconds`**: Sets the execution timeout in seconds, after which the session is terminated.
+- **`timeoutDuration`**: Sets the exectuion timeout in s (seconds), min (minutes), etc., after which the session is terminated.
 
 When the resource is executed, you can leverage LLM functions like `llm.response("id")` to retrieve the generated
 response. For further details, refer to the [LLM Functions](../resources/functions.md#llm-resource-functions)

--- a/docs/getting-started/resources/python.md
+++ b/docs/getting-started/resources/python.md
@@ -48,7 +48,7 @@ python {
         ["ENVVAR"] = "XYZ"  // Example environment variable
     }
     // Specifies the timeout duration (in seconds) for script execution
-    timeoutSeconds = 60
+    timeoutDuration = 60.s
 
     // Specifies the Conda environment for isolation
     condaEnvironment = "my-conda-env"
@@ -59,7 +59,7 @@ Key elements of the `python` block include:
 
 - **`script`**: Specifies the Python script to execute, enclosed in triple double-quotes (`"""`) for multi-line support.
 - **`env`**: Defines environment variables to be available during execution.
-- **`timeoutSeconds`**: Determines the execution timeout in seconds, after which the script execution will be terminated.
+- **`timeoutDuration`**: Determines the exectuion timeout in s (seconds), min (minutes), etc., after which the script execution will be terminated.
 - **`condaEnvironment`**: Specifies the Conda environment to use, ensuring the script runs in an isolated environment
   with defined dependencies.
 

--- a/docs/getting-started/resources/response.md
+++ b/docs/getting-started/resources/response.md
@@ -78,4 +78,4 @@ Key Elements of the `APIResponse` Block:
   `client`.
 - **`errors`**: Defines custom error codes and messages to handle various error cases. Multiple errors can be defined
   and returned.
-- **`timeoutSeconds`**: Sets the timeout duration in seconds, after which the execution will be terminated.
+- **`timeoutDuration`**: Sets the timeout duration in seconds, after which the execution will be terminated.

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,14 @@
 module github.com/kdeps/kdeps
 
-go 1.23
+go 1.23.0
 
-toolchain go1.23.1
+toolchain go1.23.6
 
 require (
 	github.com/Netflix/go-env v0.1.2
 	github.com/adrg/xdg v0.5.3
 	github.com/alexellis/go-execute/v2 v2.2.1
+	github.com/apple/pkl-go v0.9.0
 	github.com/charmbracelet/huh v0.6.0
 	github.com/charmbracelet/lipgloss v1.0.0
 	github.com/charmbracelet/log v0.4.0
@@ -21,34 +22,32 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/kdeps/kartographer v0.0.0-20240808015651-b2afd5d97715
-	github.com/kdeps/schema v0.2.7
+	github.com/kdeps/schema v0.2.10
 	github.com/kr/pretty v0.3.1
 	github.com/spf13/afero v1.12.0
-	github.com/spf13/cobra v1.8.1
+	github.com/spf13/cobra v1.9.0
 	github.com/stretchr/testify v1.10.0
 	github.com/tmc/langchaingo v0.1.12
-	github.com/zerjioang/time32 v0.0.0-20211102104504-b756043b9843
 )
 
 require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
-	github.com/apple/pkl-go v0.9.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/bytedance/sonic v1.12.8 // indirect
 	github.com/bytedance/sonic/loader v0.2.3 // indirect
 	github.com/catppuccin/go v0.3.0 // indirect
 	github.com/charmbracelet/bubbles v0.20.0 // indirect
-	github.com/charmbracelet/bubbletea v1.3.2 // indirect
+	github.com/charmbracelet/bubbletea v1.3.3 // indirect
 	github.com/charmbracelet/x/ansi v0.8.0 // indirect
-	github.com/charmbracelet/x/exp/strings v0.0.0-20250210215829-6aa2bddf6f72 // indirect
+	github.com/charmbracelet/x/exp/strings v0.0.0-20250213125511-a0c32e22e4fc // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/cloudwego/base64x v0.1.5 // indirect
 	github.com/cucumber/gherkin/go/v26 v26.2.0 // indirect
 	github.com/cucumber/messages/go/v21 v21.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
-	github.com/dlclark/regexp2 v1.11.4 // indirect
+	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
@@ -58,7 +57,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/go-playground/validator/v10 v10.24.0 // indirect
+	github.com/go-playground/validator/v10 v10.25.0 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/gofrs/uuid v4.3.1+incompatible // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
@@ -102,7 +101,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.34.0 // indirect
 	golang.org/x/arch v0.14.0 // indirect
 	golang.org/x/crypto v0.33.0 // indirect
-	golang.org/x/exp v0.0.0-20250210185358-939b2ce775ac // indirect
+	golang.org/x/exp v0.0.0-20250215185904-eff6e970281f // indirect
 	golang.org/x/net v0.35.0 // indirect
 	golang.org/x/sync v0.11.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK3
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/charmbracelet/bubbles v0.20.0 h1:jSZu6qD8cRQ6k9OMfR1WlM+ruM8fkPWkHvQWD9LIutE=
 github.com/charmbracelet/bubbles v0.20.0/go.mod h1:39slydyswPy+uVOHZ5x/GjwVAFkCsV8IIVy+4MhzwwU=
-github.com/charmbracelet/bubbletea v1.3.2 h1:nc+gDivH0P8ii8CUcf3zCN/PiUz7LKbp3Iz+vYPScNY=
-github.com/charmbracelet/bubbletea v1.3.2/go.mod h1:dtcUCyCGEX3g9tosuYiut3MXgY/Jsv9nKVdibKKRRXo=
+github.com/charmbracelet/bubbletea v1.3.3 h1:WpU6fCY0J2vDWM3zfS3vIDi/ULq3SYphZhkAGGvmEUY=
+github.com/charmbracelet/bubbletea v1.3.3/go.mod h1:dtcUCyCGEX3g9tosuYiut3MXgY/Jsv9nKVdibKKRRXo=
 github.com/charmbracelet/huh v0.6.0 h1:mZM8VvZGuE0hoDXq6XLxRtgfWyTI3b2jZNKh0xWmax8=
 github.com/charmbracelet/huh v0.6.0/go.mod h1:GGNKeWCeNzKpEOh/OJD8WBwTQjV3prFAtQPpLv+AVwU=
 github.com/charmbracelet/lipgloss v1.0.0 h1:O7VkGDvqEdGi93X+DeqsQ7PKHDgtQfF8j8/O2qFMQNg=
@@ -40,8 +40,8 @@ github.com/charmbracelet/x/ansi v0.8.0 h1:9GTq3xq9caJW8ZrBTe0LIe2fvfLR/bYXKTx2ll
 github.com/charmbracelet/x/ansi v0.8.0/go.mod h1:wdYl/ONOLHLIVmQaxbIYEC/cRKOQyjTkowiI4blgS9Q=
 github.com/charmbracelet/x/editor v0.1.0 h1:p69/dpvlwRTs9uYiPeAWruwsHqTFzHhTvQOd/WVSX98=
 github.com/charmbracelet/x/editor v0.1.0/go.mod h1:oivrEbcP/AYt/Hpvk5pwDXXrQ933gQS6UzL6fxqAGSA=
-github.com/charmbracelet/x/exp/strings v0.0.0-20250210215829-6aa2bddf6f72 h1:XQTYi5aatUL+/p71ueG202+GJa8KDGBcVmUc3TjAKWI=
-github.com/charmbracelet/x/exp/strings v0.0.0-20250210215829-6aa2bddf6f72/go.mod h1:pBhA0ybfXv6hDjQUZ7hk1lVxBiUbupdw5R31yPUViVQ=
+github.com/charmbracelet/x/exp/strings v0.0.0-20250213125511-a0c32e22e4fc h1:k2jFXp3mIsJ1lqGzpABadj9sGInRyk7kTxXfM/Lo1d0=
+github.com/charmbracelet/x/exp/strings v0.0.0-20250213125511-a0c32e22e4fc/go.mod h1:pBhA0ybfXv6hDjQUZ7hk1lVxBiUbupdw5R31yPUViVQ=
 github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQaGIAQ=
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/cloudwego/base64x v0.1.5 h1:XPciSp1xaq2VCSt6lF0phncD4koWyULpl5bUxbfCyP4=
@@ -50,7 +50,7 @@ github.com/cloudwego/iasm v0.2.0/go.mod h1:8rXZaNYT2n95jn+zTI1sDr+IgcD2GVs0nlbbQ
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
-github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cucumber/gherkin/go/v26 v26.2.0 h1:EgIjePLWiPeslwIWmNQ3XHcypPsWAHoMCz/YEBKP4GI=
 github.com/cucumber/gherkin/go/v26 v26.2.0/go.mod h1:t2GAPnB8maCT4lkHL99BDCVNzCh1d7dBhCLt150Nr/0=
@@ -64,8 +64,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/dlclark/regexp2 v1.11.4 h1:rPYF9/LECdNymJufQKmri9gV604RvvABwgOA8un7yAo=
-github.com/dlclark/regexp2 v1.11.4/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
+github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/docker/docker v27.5.1+incompatible h1:4PYU5dnBYqRQi0294d1FBECqT9ECWeQAIfE8q4YnPY8=
 github.com/docker/docker v27.5.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=
@@ -97,8 +97,8 @@ github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/o
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
 github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
-github.com/go-playground/validator/v10 v10.24.0 h1:KHQckvo8G6hlWnrPX4NJJ+aBfWNAE/HH+qdL2cBpCmg=
-github.com/go-playground/validator/v10 v10.24.0/go.mod h1:GGzBIJMuE98Ic/kJsBXbz1x/7cByt++cQ+YOuDM5wus=
+github.com/go-playground/validator/v10 v10.25.0 h1:5Dh7cjvzR7BRZadnsVOzPhWsrwUr0nmsZJxEAnFLNO8=
+github.com/go-playground/validator/v10 v10.25.0/go.mod h1:GGzBIJMuE98Ic/kJsBXbz1x/7cByt++cQ+YOuDM5wus=
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
 github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/gofrs/uuid v4.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
@@ -132,8 +132,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kdeps/kartographer v0.0.0-20240808015651-b2afd5d97715 h1:CxUIVGV6VdgZo62Q84pOVJwUa0ONNqJIH3/rvWsAiUs=
 github.com/kdeps/kartographer v0.0.0-20240808015651-b2afd5d97715/go.mod h1:DYSCAer2OsX5F3Jne82p4P1LCIu42DQFfL5ypZYcUbk=
-github.com/kdeps/schema v0.2.7 h1:b2ZOxrDfziB9xMObdoeVrrVFiqmaTxk6JOIrUAdi5Cw=
-github.com/kdeps/schema v0.2.7/go.mod h1:ovks1qmUtREjcCREAwKnuD06WlKZ1QeqjsBhGn4nL8s=
+github.com/kdeps/schema v0.2.10 h1:gDTEXsLZg21aAqxRFQiyGahkERmGtso72SfWp5iSFC0=
+github.com/kdeps/schema v0.2.10/go.mod h1:jcI+1Q8GAor+pW+RxPG9EJDM5Ji+GUORirTCSslfH0M=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
@@ -201,8 +201,8 @@ github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVs
 github.com/spf13/afero v1.12.0 h1:UcOPyRBYczmFn6yvphxkn9ZEOY65cpwGKb5mL36mrqs=
 github.com/spf13/afero v1.12.0/go.mod h1:ZTlWwG4/ahT8W7T0WQ5uYmjI9duaLQGy3Q2OAl4sk/4=
 github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
-github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
-github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
+github.com/spf13/cobra v1.9.0 h1:Py5fIuq/lJsRYxcxfOtsJqpmwJWCMOUy2tMJYV8TNHE=
+github.com/spf13/cobra v1.9.0/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
@@ -231,8 +231,6 @@ github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAh
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-github.com/zerjioang/time32 v0.0.0-20211102104504-b756043b9843 h1:dIZPPzWOOn3cYndYeyWb2jksBneRxRHI/dbXQtmfrFw=
-github.com/zerjioang/time32 v0.0.0-20211102104504-b756043b9843/go.mod h1:sAmrbsWp/xHWkXRi2/iueMYZEmm4hF8elMhcTK0hmRg=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.59.0 h1:CV7UdSGJt/Ao6Gp4CXckLxVRRsRgDHoI8XjbL3PDl8s=
@@ -258,8 +256,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.33.0 h1:IOBPskki6Lysi0lo9qQvbxiQ+FvsCC/YWOecCHAixus=
 golang.org/x/crypto v0.33.0/go.mod h1:bVdXmD7IV/4GdElGPozy6U7lWdRXA4qyRVGJV57uQ5M=
-golang.org/x/exp v0.0.0-20250210185358-939b2ce775ac h1:l5+whBCLH3iH2ZNHYLbAe58bo7yrN4mVcnkHDYz5vvs=
-golang.org/x/exp v0.0.0-20250210185358-939b2ce775ac/go.mod h1:hH+7mtFmImwwcMvScyxUhjuVHR3HGaDPMn9rMSUUbxo=
+golang.org/x/exp v0.0.0-20250215185904-eff6e970281f h1:oFMYAjX0867ZD2jcNiLBrI9BdpmEkvPyi5YrBGXbamg=
+golang.org/x/exp v0.0.0-20250215185904-eff6e970281f/go.mod h1:BHOTPb3L19zxehTsLoJXVaTktb06DFgmdW6Wb9s8jqk=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/apple/pkl-go/pkl"
 	"github.com/kdeps/kartographer/graph"
 	"github.com/kdeps/kdeps/pkg/environment"
 	"github.com/kdeps/kdeps/pkg/logging"
@@ -124,7 +125,7 @@ func NewGraphResolver(fs afero.Fs, ctx context.Context, env *environment.Environ
 
 // processResourceStep consolidates the pattern of: get timestamp, run a handler, adjust timeout (if provided),
 // then wait for the timestamp change.
-func (dr *DependencyResolver) processResourceStep(resourceID, step string, timeoutPtr *int, handler func() error) error {
+func (dr *DependencyResolver) processResourceStep(resourceID, step string, timeoutPtr *pkl.Duration, handler func() error) error {
 	timestamp, err := dr.GetCurrentTimestamp(resourceID, step)
 	if err != nil {
 		return fmt.Errorf("%s error: %w", step, err)
@@ -132,7 +133,7 @@ func (dr *DependencyResolver) processResourceStep(resourceID, step string, timeo
 
 	timeout := 60 * time.Second
 	if timeoutPtr != nil {
-		timeout = time.Duration(*timeoutPtr) * time.Second
+		timeout = timeoutPtr.GoDuration()
 		dr.Logger.Infof("Timeout duration for '%s' is set to '%.0f' seconds", resourceID, timeout.Seconds())
 	}
 

--- a/pkg/resolver/timestamps.go
+++ b/pkg/resolver/timestamps.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/apple/pkl-go/pkl"
 	pklExec "github.com/kdeps/schema/gen/exec"
 	pklHTTP "github.com/kdeps/schema/gen/http"
 	pklLLM "github.com/kdeps/schema/gen/llm"
@@ -45,7 +46,7 @@ func (dr *DependencyResolver) loadPKLFile(resourceType, pklPath string) (interfa
 }
 
 // getResourceTimestamp retrieves the timestamp for a specific resource from the given PKL result.
-func getResourceTimestamp(resourceID string, pklRes interface{}) (*uint32, error) {
+func getResourceTimestamp(resourceID string, pklRes interface{}) (*pkl.Duration, error) {
 	switch res := pklRes.(type) {
 	case *pklExec.ExecImpl:
 		// ExecImpl resources are of type *ResourceExec
@@ -88,20 +89,20 @@ func getResourceTimestamp(resourceID string, pklRes interface{}) (*uint32, error
 }
 
 // GetCurrentTimestamp retrieves the current timestamp for the given resourceID and resourceType.
-func (dr *DependencyResolver) GetCurrentTimestamp(resourceID, resourceType string) (uint32, error) {
+func (dr *DependencyResolver) GetCurrentTimestamp(resourceID, resourceType string) (pkl.Duration, error) {
 	pklPath, err := dr.getResourceFilePath(resourceType)
 	if err != nil {
-		return 0, err
+		return pkl.Duration{}, err
 	}
 
 	pklRes, err := dr.loadPKLFile(resourceType, pklPath)
 	if err != nil {
-		return 0, fmt.Errorf("failed to load %s PKL file: %w", resourceType, err)
+		return pkl.Duration{}, fmt.Errorf("failed to load %s PKL file: %w", resourceType, err)
 	}
 
 	timestamp, err := getResourceTimestamp(resourceID, pklRes)
 	if err != nil {
-		return 0, err
+		return pkl.Duration{}, err
 	}
 
 	return *timestamp, nil
@@ -126,7 +127,7 @@ func formatDuration(d time.Duration) string {
 }
 
 // WaitForTimestampChange waits until the timestamp for the specified resourceID changes from the provided previous timestamp.
-func (dr *DependencyResolver) WaitForTimestampChange(resourceID string, previousTimestamp uint32, timeout time.Duration, resourceType string) error {
+func (dr *DependencyResolver) WaitForTimestampChange(resourceID string, previousTimestamp pkl.Duration, timeout time.Duration, resourceType string) error {
 	startTime := time.Now()
 	lastSeenTimestamp := previousTimestamp
 

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -12,7 +12,7 @@ import (
 var (
 	cachedVersion    string
 	once             sync.Once
-	specifiedVersion string = "0.2.7" // Default specified version
+	specifiedVersion string = "0.2.10" // Default specified version
 	UseLatest        bool   = false
 )
 

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -12,8 +12,8 @@ func TestSchemaVersion(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	const mockLockedVersion = "0.2.7" // Define the version once and reuse it
-	const mockVersion = "0.2.7"       // Define the version once and reuse it
+	const mockLockedVersion = "0.2.10" // Define the version once and reuse it
+	const mockVersion = "0.2.10"       // Define the version once and reuse it
 
 	// Save the original value of UseLatest to avoid test interference
 	originalUseLatest := UseLatest

--- a/pkg/template/templates/client.pkl
+++ b/pkg/template/templates/client.pkl
@@ -55,6 +55,6 @@ run {
                         ["X-API-KEY"] = "@(request.header("X-API-KEY"))"  // Example header.
                 }
                 // Timeout duration in seconds. This specifies when to terminate the request.
-                timeoutDuration = 60
+                timeoutDuration = 60.s
         }
 }

--- a/pkg/template/templates/exec.pkl
+++ b/pkg/template/templates/exec.pkl
@@ -60,6 +60,6 @@ run {
                         ["ENVVAR"] = "XYZ"  // Example ENVVAR.
                 }
                 // Timeout duration in seconds. This specifies when to terminate the shell exec.
-                timeoutDuration = 60
+                timeoutDuration = 60.s
         }
 }

--- a/pkg/template/templates/llm.pkl
+++ b/pkg/template/templates/llm.pkl
@@ -66,6 +66,6 @@ run {
                 }
 
                 // Timeout duration in seconds. This specifies when to terminate the llm session.
-                timeoutDuration = 60
+                timeoutDuration = 60.s
         }
 }

--- a/pkg/template/templates/python.pkl
+++ b/pkg/template/templates/python.pkl
@@ -69,6 +69,6 @@ if __name__ == "__main__":
                         ["ENVVAR"] = "XYZ"  // Example ENVVAR.
                 }
                 // Timeout duration in seconds. This specifies when to terminate the shell exec.
-                timeoutDuration = 60
+                timeoutDuration = 60.s
         }
 }


### PR DESCRIPTION
This PR  uses the native PKL types for timestamp duration settings in the resources.

With this new settings, a duration can be suffixed with PKL duration helpers (i.e. 60.s of 60 seconds and so on).