### PR TITLE
added session memory operations for ephemeral memory

### DIFF
--- a/docs/getting-started/introduction/quickstart.md
+++ b/docs/getting-started/introduction/quickstart.md
@@ -279,11 +279,6 @@ chat {
 The `model` we use here is the same model that we define in the `workflow.pkl`. If you want to use multiple LLMs. You
 need to create new `llm` resource file to use the defined LLM model there.
 
-> *Note:*
-> Kdeps executes resource in a top-down queue manner. By design, Kdeps does not allow multiple resource actions to be
-> executed in a single resource file. If you need to perform a new resource action, you have to create a new resource
-> file with a unique ID, then define it as a dependency.
-
 In the `prompt`, we use the function `@(request.data())`, which inserts the request data into the prompt. Referring back
 to the route configuration, the `curl` command can send request data using the `-d` flag, as shown:
 
@@ -293,7 +288,7 @@ curl 'http://localhost:3000/api/v1/whois' -X GET -d "Neil Armstrong"
 
 Additionally, we have set `JSONResponse` to `true`, enabling the use of `JSONResponseKeys`. To ensure the output
 conforms to specific data types, you can define the keys with their corresponding types. For example:
-`first_name__string`, `famous_quotes__array`, `details__markdown`, or `age__integer`.
+`first_name__string`, `famous_quotes__array`, `details__string`, or `age__integer`.
 
 > **Important:**
 > To accomplish defining the corresponding data types to keys, you'll need to adjust your LLM model, as the default
@@ -304,10 +299,6 @@ conforms to specific data types, you can define the keys with their correspondin
 
 After finalizing our AI agent, we can then proceed on packaging the AI agent. Packaged AI agents are single file that
 ends in `.kdeps` extension. With a single file, we can distribute it, reuse, sell and remix it in your AI agents.
-
-> *Note:*
-> At the moment, Kdeps does not have the capability to upload the `.kdeps` file. This is planned in the future, along
-> with the marketplace for AI agents, and an online dashboard to testing, debugging and deploying AI agents.
 
 To package an AI agent, simply run with `package` specifying the folder.
 

--- a/docs/getting-started/resources/expr.md
+++ b/docs/getting-started/resources/expr.md
@@ -4,10 +4,10 @@ outline: deep
 
 # Expr Block
 
-The `expr` is resource block for evaluating standard PKL expressions. It is primarily used to execute
+The `expr` block is space for evaluating standard PKL expressions. It is primarily used to execute
 expressions that produce side effects, such as updating resources or triggering actions, but also supports
-general-purpose evaluation of any valid PKL expression, making it a versatile tool for inline logic and scripting within
-a configuration.
+general-purpose evaluation of any valid PKL expression, making it a place for inline logic and
+scripting within a configuration.
 
 ## Overview of the `expr` Block
 
@@ -41,5 +41,4 @@ expr {
 }
 ```
 
-In this example, the memory store is updated to indicate an active status. The `memory.setItem` function is executed as
-a side effect, and no return value is required. This also applies to `memory.clear()`.
+In this example, the memory store is updated to indicate an active status. The `memory.setItem` function is executed as a side effect, and no return value is required. This also applies to `memory.clear()`.

--- a/docs/getting-started/resources/global-functions.md
+++ b/docs/getting-started/resources/global-functions.md
@@ -34,13 +34,18 @@ Below is a list of the global functions available for each resource:
 
 ## Memory Operation Functions
 
-| **Function**                   | **Description**                                           |
-|:-------------------------------|:----------------------------------------------------------|
-| memory.getItem("key")          | Fetches the value of key from persistent AI Agent memory  |
-| memory.setItem("key", "value") | Stores the value of key to the persistent AI Agent memory |
-| memory.clear()                 | Clears all persistent memory (CAUTION!)                   |
+| **Function**                    | **Description**                                   |
+|:--------------------------------|:--------------------------------------------------|
+| memory.getItem("key")           | Fetches the value of key from persistent memory   |
+| memory.deleteItem("key")        | Delete the memory item from the persistent memory |
+| memory.setItem("key", "value")  | Stores the value of key to the persistent memory  |
+| memory.clear()                  | Clears all persistent memory (CAUTION!)           |
+| session.getItem("key")          | Fetches the value of key from session memory      |
+| session.deleteItem("key")       | Delete the memory item from the session memory    |
+| session.setItem("key", "value") | Stores the value of key to the session memory     |
+| session.clear()                 | Clears all session memory (CAUTION!)              |
 
-> *Note:* The `setItem` and `clear` are side-effecting functions—it performs an action but doesn't return a
+> *Note:* The `setItem`, `deleteItem` and `clear` are side-effecting functions—it performs an action but doesn't return a
 > meaningful value. That is why it is recommended to placed them inside an `expr` block: to ensure the expression is
 > evaluated for its effect.
 

--- a/docs/getting-started/resources/kartographer.md
+++ b/docs/getting-started/resources/kartographer.md
@@ -45,3 +45,8 @@ within the same workflow. This avoids complex dependency problems such as circul
 resource, it should be under a unique ID, as shown below:
 
 `LLMResourceJSON -> PythonResource -> LLMResourceJSON2 -> JSONResponder`
+
+> *Note:*
+> Kdeps executes resource in a top-down queue manner. By design, Kdeps does not allow multiple resource actions to be
+> executed in a single resource file. If you need to perform a new resource action, you have to create a new resource
+> file with a unique ID, then define it as a dependency.

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/kdeps/kartographer v0.0.0-20240808015651-b2afd5d97715
-	github.com/kdeps/schema v0.2.23
+	github.com/kdeps/schema v0.2.24
 	github.com/kr/pretty v0.3.1
 	github.com/mattn/go-sqlite3 v1.14.28
 	github.com/spf13/afero v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -152,10 +152,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kdeps/kartographer v0.0.0-20240808015651-b2afd5d97715 h1:CxUIVGV6VdgZo62Q84pOVJwUa0ONNqJIH3/rvWsAiUs=
 github.com/kdeps/kartographer v0.0.0-20240808015651-b2afd5d97715/go.mod h1:DYSCAer2OsX5F3Jne82p4P1LCIu42DQFfL5ypZYcUbk=
-github.com/kdeps/schema v0.2.22 h1:UIOfmy5gIgMInvi5snhsfifzjfHc6KoBwY7sJq2yEvA=
-github.com/kdeps/schema v0.2.22/go.mod h1:jcI+1Q8GAor+pW+RxPG9EJDM5Ji+GUORirTCSslfH0M=
-github.com/kdeps/schema v0.2.23 h1:NbwlJL5tEEOVcCnYWL6yiTe/ZjULrWWluOB0/0zLjpA=
-github.com/kdeps/schema v0.2.23/go.mod h1:jcI+1Q8GAor+pW+RxPG9EJDM5Ji+GUORirTCSslfH0M=
+github.com/kdeps/schema v0.2.24 h1:EKbazDiV6i2pW9HjUbtfRTc8M4dTVL5gpMd6KazOukQ=
+github.com/kdeps/schema v0.2.24/go.mod h1:jcI+1Q8GAor+pW+RxPG9EJDM5Ji+GUORirTCSslfH0M=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=

--- a/pkg/resolver/imports.go
+++ b/pkg/resolver/imports.go
@@ -49,6 +49,7 @@ func (dr *DependencyResolver) PrependDynamicImports(pklFile string) error {
 		"pkl:yaml":     {Alias: "", Check: false},
 		fmt.Sprintf("package://schema.kdeps.com/core@%s#/Document.pkl", schema.SchemaVersion(dr.Context)): {Alias: "document", Check: false},
 		fmt.Sprintf("package://schema.kdeps.com/core@%s#/Memory.pkl", schema.SchemaVersion(dr.Context)):   {Alias: "memory", Check: false},
+		fmt.Sprintf("package://schema.kdeps.com/core@%s#/Session.pkl", schema.SchemaVersion(dr.Context)):  {Alias: "session", Check: false},
 		fmt.Sprintf("package://schema.kdeps.com/core@%s#/Skip.pkl", schema.SchemaVersion(dr.Context)):     {Alias: "skip", Check: false},
 		fmt.Sprintf("package://schema.kdeps.com/core@%s#/Utils.pkl", schema.SchemaVersion(dr.Context)):    {Alias: "utils", Check: false},
 		filepath.Join(dr.ActionDir, "/llm/"+dr.RequestID+"__llm_output.pkl"):                              {Alias: "llm", Check: true},

--- a/pkg/resolver/resource_response.go
+++ b/pkg/resolver/resource_response.go
@@ -53,6 +53,7 @@ func (dr *DependencyResolver) buildResponseSections(requestID string, apiRespons
 	sections := []string{
 		fmt.Sprintf(`import "package://schema.kdeps.com/core@%s#/Document.pkl" as document`, schema.SchemaVersion(dr.Context)),
 		fmt.Sprintf(`import "package://schema.kdeps.com/core@%s#/Memory.pkl" as memory`, schema.SchemaVersion(dr.Context)),
+		fmt.Sprintf(`import "package://schema.kdeps.com/core@%s#/Session.pkl" as session`, schema.SchemaVersion(dr.Context)),
 		fmt.Sprintf("success = %v", apiResponseBlock.GetSuccess()),
 		formatResponseMeta(requestID, apiResponseBlock.GetMeta()),
 		formatResponseData(apiResponseBlock.GetResponse()),

--- a/pkg/resolver/resources.go
+++ b/pkg/resolver/resources.go
@@ -125,9 +125,11 @@ func (dr *DependencyResolver) LoadResource(ctx context.Context, resourceFile str
 		options.Logger = pkl.NoopLogger
 		options.ResourceReaders = []pkl.ResourceReader{
 			dr.MemoryReader,
+			dr.SessionReader,
 		}
 		options.AllowedResources = []string{
 			"memory:/",
+			"session:/",
 			"package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.uri@1.0.3",
 			"https://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.uri@1.0.3",
 			"https://github.com/apple/pkl-pantry/releases/download/pkl.experimental.uri@1.0.3/pkl.experimental.uri@1.0.3.zip",

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -12,7 +12,7 @@ import (
 var (
 	cachedVersion    string
 	once             sync.Once
-	specifiedVersion string = "0.2.23" // Default specified version
+	specifiedVersion string = "0.2.24" // Default specified version
 	UseLatest        bool   = false
 )
 

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -12,8 +12,8 @@ func TestSchemaVersion(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	const mockLockedVersion = "0.2.23" // Define the version once and reuse it
-	const mockVersion = "0.2.23"       // Define the version once and reuse it
+	const mockLockedVersion = "0.2.24" // Define the version once and reuse it
+	const mockVersion = "0.2.24"       // Define the version once and reuse it
 
 	// Save the original value of UseLatest to avoid test interference
 	originalUseLatest := UseLatest

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -1,4 +1,4 @@
-package memory
+package session
 
 import (
 	"database/sql"
@@ -21,7 +21,7 @@ type PklResourceReader struct {
 
 // Scheme returns the URI scheme for this reader.
 func (r *PklResourceReader) Scheme() string {
-	return "memory"
+	return "session"
 }
 
 // IsGlobbable indicates whether the reader supports globbing (not needed here).
@@ -44,7 +44,7 @@ func (r *PklResourceReader) Read(uri url.URL) ([]byte, error) {
 	// Check if receiver is nil and initialize with fixed DBPath
 	if r == nil {
 		log.Printf("Warning: PklResourceReader is nil for URI: %s, initializing with DBPath", uri.String())
-		newReader, err := InitializeMemory(r.DBPath)
+		newReader, err := InitializeSession(r.DBPath)
 		if err != nil {
 			log.Printf("Failed to initialize PklResourceReader in Read: %v", err)
 			return nil, fmt.Errorf("failed to initialize PklResourceReader: %w", err)
@@ -233,8 +233,8 @@ func InitializeDatabase(dbPath string) (*sql.DB, error) {
 	return nil, fmt.Errorf("failed to initialize database after %d attempts", maxAttempts)
 }
 
-// InitializeMemory creates a new PklResourceReader with an initialized SQLite database.
-func InitializeMemory(dbPath string) (*PklResourceReader, error) {
+// InitializeSession creates a new PklResourceReader with an initialized SQLite database.
+func InitializeSession(dbPath string) (*PklResourceReader, error) {
 	db, err := InitializeDatabase(dbPath)
 	if err != nil {
 		return nil, fmt.Errorf("error initializing database: %w", err)

--- a/pkg/template/templates/client.pkl
+++ b/pkg/template/templates/client.pkl
@@ -55,13 +55,14 @@ run {
                 }
         }
 
-        // The expr block is a dedicated resource for evaluating standard PKL expressions. It is primarily used to execute
+        // The expr block is space for evaluating standard PKL expressions. It is primarily used to execute
         // expressions that produce side effects, such as updating resources or triggering actions, but also supports
-        // general-purpose evaluation of any valid PKL expression, making it a versatile tool for inline logic and
+        // general-purpose evaluation of any valid PKL expression, making it a place for inline logic and
         // scripting within a configuration.
         expr {
-                // "@(memory.setItem("foo", "bar"))"
+                // "@(memory.setItem("foo", "bar"))" // Persistent data
                 // "@(memory.clear())"
+                // "@(session.setItem("foo", "bar"))" // Temporary data only for this request
         }
 
         // Initiates an HTTP client request for this resource.

--- a/pkg/template/templates/exec.pkl
+++ b/pkg/template/templates/exec.pkl
@@ -57,13 +57,14 @@ run {
                 }
         }
 
-        // The expr block is a dedicated resource for evaluating standard PKL expressions. It is primarily used to execute
+        // The expr block is space for evaluating standard PKL expressions. It is primarily used to execute
         // expressions that produce side effects, such as updating resources or triggering actions, but also supports
-        // general-purpose evaluation of any valid PKL expression, making it a versatile tool for inline logic and
+        // general-purpose evaluation of any valid PKL expression, making it a place for inline logic and
         // scripting within a configuration.
         expr {
-                // "@(memory.setItem("foo", "bar"))"
+                // "@(memory.setItem("foo", "bar"))" // Persistent data
                 // "@(memory.clear())"
+                // "@(session.setItem("foo", "bar"))" // Temporary data only for this request
         }
 
         // Initiates a shell session for executing commands within this resource. Any packages

--- a/pkg/template/templates/llm.pkl
+++ b/pkg/template/templates/llm.pkl
@@ -54,13 +54,14 @@ run {
                 }
         }
 
-        // The expr block is a dedicated resource for evaluating standard PKL expressions. It is primarily used to execute
+        // The expr block is space for evaluating standard PKL expressions. It is primarily used to execute
         // expressions that produce side effects, such as updating resources or triggering actions, but also supports
-        // general-purpose evaluation of any valid PKL expression, making it a versatile tool for inline logic and
+        // general-purpose evaluation of any valid PKL expression, making it a place for inline logic and
         // scripting within a configuration.
         expr {
-                // "@(memory.setItem("foo", "bar"))"
+                // "@(memory.setItem("foo", "bar"))" // Persistent data
                 // "@(memory.clear())"
+                // "@(session.setItem("foo", "bar"))" // Temporary data only for this request
         }
 
         // Initializes a chat session with the LLM for this resource.

--- a/pkg/template/templates/python.pkl
+++ b/pkg/template/templates/python.pkl
@@ -57,13 +57,14 @@ run {
                 }
         }
 
-        // The expr block is a dedicated resource for evaluating standard PKL expressions. It is primarily used to execute
+        // The expr block is space for evaluating standard PKL expressions. It is primarily used to execute
         // expressions that produce side effects, such as updating resources or triggering actions, but also supports
-        // general-purpose evaluation of any valid PKL expression, making it a versatile tool for inline logic and
+        // general-purpose evaluation of any valid PKL expression, making it a place for inline logic and
         // scripting within a configuration.
         expr {
-                // "@(memory.setItem("foo", "bar"))"
+                // "@(memory.setItem("foo", "bar"))" // Persistent data
                 // "@(memory.clear())"
+                // "@(session.setItem("foo", "bar"))" // Temporary data only for this request
         }
 
         // Initiates a shell session for executing commands within this resource. Any packages

--- a/pkg/template/templates/response.pkl
+++ b/pkg/template/templates/response.pkl
@@ -60,13 +60,14 @@ run {
                 }
         }
 
-        // The expr block is a dedicated resource for evaluating standard PKL expressions. It is primarily used to execute
+        // The expr block is space for evaluating standard PKL expressions. It is primarily used to execute
         // expressions that produce side effects, such as updating resources or triggering actions, but also supports
-        // general-purpose evaluation of any valid PKL expression, making it a versatile tool for inline logic and
+        // general-purpose evaluation of any valid PKL expression, making it a place for inline logic and
         // scripting within a configuration.
         expr {
-                // "@(memory.setItem("foo", "bar"))"
+                // "@(memory.setItem("foo", "bar"))" // Persistent data
                 // "@(memory.clear())"
+                // "@(session.setItem("foo", "bar"))" // Temporary data only for this request
         }
 
         // Initializes an api response for this agent.


### PR DESCRIPTION
Session operations do the same as memory but are temporary, lasting only for a single request (e.g., an API call or process)