### PR TITLE
Open-source LLMs tool execution feature (aka MCP / A2A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,28 +5,33 @@ open-source LLM models out-of-the-box.
 
 ## Key Features
 
-Kdeps is loaded with features to streamline AI app development:
+Kdeps is loaded with powerful features to streamline AI app development. Here are the top highlights, sorted by desirability:
 
-- 🐳 Build [Dockerized full-stack AI apps](https://kdeps.com/getting-started/introduction/quickstart.html#quickstart) with [batteries included](https://kdeps.com/getting-started/configuration/workflow.html#ai-agent-settings).
-- 🔌 Create custom [AI APIs](https://kdeps.com/getting-started/configuration/workflow.html#api-server-settings) that serve [open-source LLMs](https://kdeps.com/getting-started/configuration/workflow.html#llm-models).
-- 🌐 Pair APIs with [frontend apps](https://kdeps.com/getting-started/configuration/workflow.html#web-server-settings) like Streamlit, NodeJS, and more.
+- 🛠️ **Let LLMs run tools automatically (aka MCP or A2A) with [external tools and chained tool workflows](https://kdeps.com/getting-started/resources/llm.html#tools-configuration)** to enhance functionality through scripts and sequential tool pipelines.
+- 🧩 **Low-code/no-code capabilities for building [operational full-stack AI apps](https://kdeps.com/getting-started/configuration/workflow.html)**, enabling accessible development for non-technical users and production-ready applications.
+- 🐳 **Build [Dockerized full-stack AI apps](https://kdeps.com/getting-started/introduction/quickstart.html#quickstart)** with [batteries included](https://kdeps.com/getting-started/configuration/workflow.html#ai-agent-settings) for seamless development and deployment.
+- 🌐 **Pair APIs with [frontend apps](https://kdeps.com/getting-started/configuration/workflow.html#web-server-settings)** like Streamlit, NodeJS, and more for interactive AI-driven user interfaces.
+- 🔌 **Create custom [AI APIs](https://kdeps.com/getting-started/configuration/workflow.html#api-server-settings)** that serve [open-source LLMs](https://kdeps.com/getting-started/configuration/workflow.html#llm-models) for robust AI-driven applications.
+- 🖼️ Support for [vision or multimodal LLMs](https://kdeps.com/getting-started/resources/multimodal.html), enabling processing of text, images, and other data types in a single workflow.
+
+## Additional Features
+
+- 📊 Generate [structured outputs](https://kdeps.com/getting-started/resources/llm.html#chat-block) from LLMs for consistent, machine-readable responses.
+- 📈 Enable context-aware [RAG workflows](https://kdeps.com/getting-started/resources/kartographer.html) for accurate, knowledge-intensive tasks.
+- 🗂️ Upload [documents or files](https://kdeps.com/getting-started/tutorials/files.html) for LLM processing, ideal for document analysis.
+- 🤖 Leverage multiple open-source LLMs from [Ollama](https://kdeps.com/getting-started/configuration/workflow.html#llm-models) and [Huggingface](https://github.com/kdeps/examples/tree/main/huggingface_imagegen_api).
+- 🔄 Use [reusable AI agents](https://kdeps.com/getting-started/resources/remix.html) for flexible workflows.
+- 🐍 Execute Python in isolated environments using [Anaconda](https://kdeps.com/getting-started/resources/python.html).
+- 🌍 Make [API calls](https://kdeps.com/getting-started/resources/client.html) directly from configuration.
+- 🖥️ Run [shell scripts](https://kdeps.com/getting-started/resources/exec.html) seamlessly.
+- 💾 Manage state with [memory operations](https://kdeps.com/getting-started/resources/memory.html) to store, retrieve, and clear persistent data.
+- ✅ Built-in [API request validations](https://kdeps.com/getting-started/resources/api-request-validations.html#api-request-validations), [custom validation checks](https://kdeps.com/getting-started/resources/validations.html), and [skip conditions](https://kdeps.com/getting-started/resources/skip.html).
 - 📁 Serve [static websites](https://kdeps.com/getting-started/configuration/workflow.html#static-file-serving) or [reverse-proxied apps](https://kdeps.com/getting-started/configuration/workflow.html#reverse-proxying).
 - 🔒 Configure [CORS rules](https://kdeps.com/getting-started/configuration/workflow.html#cors-configuration) directly in the workflow.
 - 🛡️ Set [trusted proxies](https://kdeps.com/getting-started/configuration/workflow.html#trustedproxies) for enhanced API and frontend security.
 - 🚀 Run in [Lambda mode](https://kdeps.com/getting-started/configuration/workflow.html#lambda-mode) or [API mode](https://kdeps.com/getting-started/configuration/workflow.html#api-server-settings).
-- 🤖 Leverage multiple open-source LLMs from [Ollama](https://kdeps.com/getting-started/configuration/workflow.html#llm-models) and [Huggingface](https://github.com/kdeps/examples/tree/main/huggingface_imagegen_api).
-- 🐍 Execute Python in isolated environments using [Anaconda](https://kdeps.com/getting-started/resources/python.html).
-- 🖼️ Support for [multimodal LLMs](https://kdeps.com/getting-started/resources/multimodal.html).
-- ✅ Built-in [API request validations](https://kdeps.com/getting-started/resources/api-request-validations.html#api-request-validations), [custom validation checks](https://kdeps.com/getting-started/resources/validations.html), and [skip conditions](https://kdeps.com/getting-started/resources/skip.html).
-- 🔄 Use [reusable AI agents](https://kdeps.com/getting-started/resources/remix.html) for flexible workflows.
-- 🖥️ Run [shell scripts](https://kdeps.com/getting-started/resources/exec.html) seamlessly.
-- 🌍 Make [API calls](https://kdeps.com/getting-started/resources/client.html) directly from configuration.
-- 💾 Manage state with [memory operations](https://kdeps.com/getting-started/resources/memory.html) to store, retrieve, and clear persistent data.
-- 📊 Generate [structured outputs](https://kdeps.com/getting-started/resources/llm.html#chat-block) from LLMs.
 - 📦 Install [Ubuntu packages](https://kdeps.com/getting-started/configuration/workflow.html#ubuntu-packages) via configuration.
 - 📜 Define [Ubuntu repositories or PPAs](https://kdeps.com/getting-started/configuration/workflow.html#ubuntu-repositories).
-- 📈 Enable context-aware [RAG workflows](https://kdeps.com/getting-started/resources/kartographer.html).
-- 🗂️ Upload [documents or files](https://kdeps.com/getting-started/tutorials/files.html) for LLM processing.
 - ⚡ Written in high-performance Golang.
 - 📥 [Easy to install](https://kdeps.com/getting-started/introduction/installation.html) and use with a single command.
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -201,6 +201,7 @@ export default defineConfig({
       {
         text: "Reference",
         items: [
+          { text: "Open-source LLM Tool Calling (aka MCP)", link: "/getting-started/resources/tools" },
           {
             text: "Graph Dependency",
             link: "/getting-started/resources/kartographer",

--- a/docs/getting-started/resources/llm.md
+++ b/docs/getting-started/resources/llm.md
@@ -4,41 +4,35 @@ outline: deep
 
 # LLM Resource
 
-The `llm` resource facilitates the creation of a Large Language Model (LLM) session to interact with AI models
-effectively.
+The `llm` resource facilitates the creation of a Large Language Model (LLM) session to interact with AI models effectively.
 
-Multiple LLM models can be declared and used across multiple LLM resources. For more information, see the
-[Workflow](../configuration/workflow.md) documentation.
-
+Multiple LLM models can be declared and used across multiple LLM resources. For more information, see the [Workflow](../configuration/workflow.md) documentation.
 
 ## Creating a New LLM Resource
 
-To create a new `llm` chat resource, you can either generate a new AI agent using the `kdeps new` command or scaffold
-the resource directly.
+To create a new `llm` chat resource, you can either generate a new AI agent using the `kdeps new` command or scaffold the resource directly.
 
-Here’s how to scaffold an `llm` resource:
+Here's how to scaffold an `llm` resource:
 
-```bash
+``` bash
 kdeps scaffold [aiagent] llm
 ```
 
 This command will add an `llm` resource to the `aiagent/resources` folder, generating the following folder structure:
 
-```bash
+``` bash
 aiagent
 └── resources
     └── llm.pkl
 ```
 
-The file includes essential metadata and common configurations, such as [Skip Conditions](../resources/skip) and
-[Preflight Validations](../resources/validations). For more details, refer to the [Common Resource
-Configurations](../resources/resources#common-resource-configurations) documentation.
+The file includes essential metadata and common configurations, such as [Skip Conditions](../resources/skip) and [Preflight Validations](../resources/validations). For more details, refer to the [Common Resource Configurations](../resources/resources#common-resource-configurations) documentation.
 
 ## Chat Block
 
-Within the file, you’ll find the `chat` block, structured as follows:
+Within the file, you'll find the `chat` block, structured as follows:
 
-```apl
+``` apl
 chat {
     model = "tinydolphin" // Specifies the LLM model to use, defined in the workflow.
 
@@ -54,9 +48,24 @@ chat {
             role = "assistant"
             prompt = "You are a knowledgeable and supportive AI assistant with expertise in general information."
         }
-        new {
+o        new {
             role = "system"
             prompt = "Ensure responses are concise and accurate, prioritizing user satisfaction."
+        }
+        new {
+            role = "system"
+            prompt = "If you are unsure and will just hallucinate your response, just lookup the DB"
+        }
+    }
+
+    tools {
+        new {
+            name = "lookup_db"
+            script = "@(data.filepath("tools/1.0.0", "lookup.py"))"
+            description = "Lookup information in the DB"
+            parameters {
+                ["keyword"] { required = true; type = "string"; description = "The string keyword to query the DB" }
+            }
         }
     }
 
@@ -88,6 +97,7 @@ chat {
 - **`model`**: Specifies the LLM model to be used, as defined in the workflow configuration.
 - **`role`**: Defines the role context for the prompt, such as `user`, `assistant`, or `system`. Defaults to `human` if not specified.
 - **`prompt`**: The input query sent to the LLM for processing.
+- **`tools`**: Available tools for open-source LLMs to automatically use.
 - **`scenario`**: Enables the inclusion of multiple prompts and roles to shape the LLM session's context. Each `new` block within `scenario` specifies a role (e.g., `assistant` or `system`) and a corresponding prompt to guide the LLM’s behavior or response.
 - **`files`**: Lists files to be processed by the LLM, particularly useful for vision-based LLM models.
 - **`JSONResponse`**: Indicates whether the LLM response should be formatted as structured JSON.
@@ -102,7 +112,7 @@ When the resource is executed, you can leverage LLM functions like `llm.response
 
 The `scenario` block is particularly useful for setting up complex interactions with the LLM. By defining multiple roles and prompts, you can create a conversational context that guides the LLM’s responses. For example:
 
-```apl
+``` apl
 scenario {
     new {
         role = "system"
@@ -125,7 +135,7 @@ This setup allows the LLM to maintain a consistent context across multiple inter
 
 The `files` block supports processing of various file types, such as images or documents, which is particularly beneficial for multimodal LLMs. For example:
 
-```apl
+``` apl
 files {
     "@(request.files()[0])" // Processes the first uploaded file
     "data/document.pdf"     // Processes a specific PDF file
@@ -138,7 +148,7 @@ Ensure that the files are accessible within the resource’s context and compati
 
 When `JSONResponse` is set to `true`, the LLM response is formatted as a JSON object with the keys specified in `JSONResponseKeys`. Type annotations can be used to enforce data types, ensuring the output meets specific requirements. For example:
 
-```apl
+``` apl
 JSONResponseKeys {
     "name__string"
     "age__integer"
@@ -148,6 +158,84 @@ JSONResponseKeys {
 ```
 
 This configuration ensures that the response contains a `name` (string), `age` (integer), `quotes` (array), and `bio` (markdown-formatted text).
+
+### Tools Configuration
+
+The `tools` block allows open-source LLMs to utilize external tools to enhance their functionality, such as querying databases or executing scripts. Each tool is defined within a `new` block, specifying its name, script, description, and parameters. Tools can be chained, where the output of one tool is used as the input parameters for the next tool in the sequence.
+
+For example:
+
+``` apl
+tools {
+    new {
+        name = "lookup_db"
+        script = "@(data.filepath("tools/1.0.0", "lookup.py"))"
+        description = "Lookup information in the DB"
+        parameters {
+            ["keyword"] { required = true; type = "string"; description = "The string keyword to query the DB" }
+        }
+    }
+    new {
+        name = "process_results"
+        script = "@(data.filepath("tools/1.0.0", "process.py"))"
+        description = "Process DB lookup results"
+        parameters {
+            ["lookup_data"] { required = true; type = "object"; description = "The output data from lookup_db tool" }
+        }
+    }
+}
+```
+
+#### Key Elements of the `tools` Block
+
+- **`name`**: A unique identifier for the tool, used by the LLM to reference it.
+- **`script`She's the path to the script or executable that the tool runs, often using a dynamic filepath like `@(data.filepath("tools/1.0.0", "lookup.py"))`.
+- **`description`**: A clear description of the tool’s purpose, helping the LLM decide when to use it.
+- **`parameters`**: Defines the input parameters the tool accepts, including:
+  - `required`: Whether the parameter is mandatory (`true` or `false`).
+  - `type`: The data type of the parameter (e.g., `string`, `integer`, `object`, `boolean`).
+  - `description`: A brief explanation of the parameter’s purpose.
+
+#### Tool Chaining
+
+Tools can be chained to create a pipeline where the output of one tool serves as the input for the next. The LLM automatically passes the output of a tool as the parameters for the subsequent tool, based on the order defined in the `tools` block. For instance, in the example above, the `lookup_db` tool’s output (e.g., a JSON object containing query results) is passed as the `lookup_data` parameter to the `process_results` tool.
+
+To enable chaining:
+- Ensure the output format of the first tool matches the expected input parameter type of the next tool (e.g., `object` for JSON data).
+- Define tools in the order of execution, as the LLM processes them sequentially.
+- Use clear `description` fields to guide the LLM on when to initiate the chain.
+
+#### Best Practices for Tools
+
+- **Clear Descriptions**: Provide detailed descriptions to ensure the LLM understands when and how to use each tool.
+- **Parameter Validation**: Specify parameter types and requirements to prevent errors, especially when chaining tools.
+- **Script Accessibility**: Verify that script paths are correct and accessible within the resource’s context.
+- **Minimal Tools**: Include only necessary tools to avoid complexity, and order them logically for chaining.
+- **Chaining Compatibility**: Ensure the output of one tool aligns with the input requirements of the next, using consistent data types.
+
+For example, a chained weather data pipeline might look like:
+
+``` apl
+tools {
+    new {
+        name = "get_weather"
+        script = "@(data.filepath("tools/1.0.0", "weather.py"))"
+        description = "Fetches current weather data for a location"
+        parameters {
+            ["location"] { required = true; type = "string"; description = "The city or region to fetch weather for" }
+            ["unit"] { required = false; type = "string"; description = "Temperature unit (e.g., Celsius or Fahrenheit)" }
+        }
+    }
+    new {
+        name = "format_weather"
+        script = "@(data.filepath("tools/1.0.0", "format_weather.py"))"
+        description = "Formats weather data into a user-friendly summary"
+        parameters {
+            ["weather_data"] { required = true; type = "object"; description = "The weather data from get_weather tool" }
+        }
+    }
+}
+```
 
 ## Error Handling and Timeouts
 
@@ -162,12 +250,13 @@ Additionally, you can implement error handling using [Preflight Validations](../
 - **File Management**: Verify that files listed in the `files` block are accessible and compatible with the LLM model.
 - **Structured Outputs**: Use `JSONResponse` and `JSONResponseKeys` for applications requiring structured data, and validate the output format in downstream processes.
 - **Timeout Configuration**: Set a reasonable `timeoutDuration` to balance performance and resource usage, especially for complex queries.
+- **Tool Usage**: Configure tools with precise descriptions and parameters to ensure the LLM uses them effectively when needed.
 
 ## Example Use Case
 
-Suppose you want to create an LLM resource to retrieve structured information about a historical figure based on user input. The `chat` block might look like this:
+Suppose you want to create an LLM resource to retrieve structured information about a history figure based on user input, with a tool to query a database for additional details. The `chat` block might look like this:
 
-```apl
+``` apl
 chat {
     model = "tinydolphin"
     role = "user"
@@ -176,6 +265,16 @@ chat {
         new {
             role = "assistant"
             prompt = "You are a history expert AI, providing accurate and concise information about historical figures."
+        }
+    }
+    tools {
+        new {
+            name = "lookup_db"
+            script = "@(data.filepath("tools/1.0.0", "lookup.py"))"
+            description = "Lookup historical figure details in the database"
+            parameters {
+                ["name"] { required = true; type = "string"; description = "The name of the historical figure" }
+            }
         }
     }
     JSONResponse = true
@@ -189,6 +288,9 @@ chat {
 }
 ```
 
-This configuration ensures that the LLM returns a structured JSON response with details about the requested historical figure, formatted according to the specified keys and types.
+This configuration ensures that the LLM returns a structured JSON response with details about the requested historical
+figure, formatted according to the specified keys and types, and can use the `lookup_db` tool to fetch additional data
+if needed.
 
-For more advanced configurations and use cases, refer to the [Workflow](../configuration/workflow.md) and [LLM Functions](../resources/functions.md#llm-resource-functions) documentation.
+For more advanced configurations and use cases, refer to the [Workflow](../configuration/workflow.md) and [LLM
+Functions](../resources/functions.md#llm-resource-functions) documentation.

--- a/docs/getting-started/resources/tools.md
+++ b/docs/getting-started/resources/tools.md
@@ -1,0 +1,199 @@
+---
+outline: deep
+---
+
+# Tools
+
+The `tools` block lets open-source AI models (like LLaMA or Mistral) run scripts for tasks like math or file
+operations. It supports Python (`.py`), TypeScript (`.ts`), JavaScript (`.js`), Ruby (`.rb`), or shell scripts (e.g.,
+`.sh`), with inputs passed via `argv` (e.g., `sys.argv` in Python) or `$1`, `$2`, etc., for shell scripts. Scripts run
+with: `.py` uses `python3`, `.ts` uses `ts-node`, `.js` uses `node`, `.rb` uses `ruby`, others use `sh`. The LLM can
+automatically pick and chain multiple tools based on a prompt, using one tool’s output as input for the next. With
+and `JSONResponseKeys`, tool outputs are structured as JSON for easier parsing. Tools are triggered via prompts or
+manually with `@(tools.getItem(id))`, `runScript`, or `history`. This is like Anthropic’s MCP or Google’s A2A but for
+open-source models only.
+
+
+## What It Does
+
+Inside a `chat` resource, the `tools` block lets the AI call scripts automatically via prompts or manually. The LLM can
+chain tools, passing outputs as inputs, and with `JSONResponseKeys` structures results as JSON. It’s kdeps’ open-source
+tool-calling system, similar to MCP or A2A but simpler.
+
+## How It Looks
+
+Create a `chat` resource:
+
+```bash
+kdeps scaffold [aiagent] llm
+```
+
+Define the `tools` block in the `chat` block. Here’s an excerpt:
+
+```apl
+chat {
+    model = "llama3.2" // Open-source AI model
+    role = "user"
+    prompt = "Run the task using tools: @(request.params("q"))"
+    JSONResponse = true
+    JSONResponseKeys {
+        "sum"      // Maps calculate_sum output to "result"
+        "squared"  // Maps square_number output
+        "saved"    // Maps write_result output
+    }
+    tools {
+        new {
+            name = "calculate_sum"
+            script = "@(data.filepath("tools/1.0.0", "calculate_sum.py"))"
+            description = "Add two numbers"
+            parameters {
+                ["a"] { required = true; type = "number"; description = "First number" }
+                ["b"] { required = true; type = "number"; description = "Second number" }
+            }
+        }
+        new {
+            name = "square_number"
+            script = "@(data.filepath("tools/1.0.0", "square_number.js"))"
+            description = "Square a number"
+            parameters {
+                ["num"] { required = true; type = "number"; description = "Number to square" }
+            }
+        }
+        new {
+            name = "write_result"
+            script = "@(data.filepath("tools/1.0.0", "write_result.sh"))"
+            description = "Write a number to a file"
+            parameters {
+                ["path"] { required = true; type = "string"; description = "File path" }
+                ["content"] { required = true; type = "string"; description = "Number to write" }
+            }
+        }
+    }
+    // Other settings like scenario, files, timeoutDuration...
+}
+```
+
+## Sample Scripts
+
+Stored in `tools/1.0.0/`:
+
+### Python (calculate_sum.py)
+Runs with `python3`, inputs via `sys.argv`.
+```python
+import sys
+print(float(sys.argv[1]) + float(sys.argv[2]))
+```
+
+### JavaScript (square_number.js)
+Runs with `node`, inputs via `process.argv`.
+```javascript
+const num = parseFloat(process.argv[2]);
+console.log(num * num);
+```
+
+### Shell (write_result.sh)
+Runs with `sh`, inputs via `$1`, `$2`.
+```bash
+echo "$2" > "$1"
+```
+
+## Key Pieces
+
+- **new**: Defines a tool.
+- **name**: Unique name, like `calculate_sum`.
+- **script**: Script absolute path or using `@(data.filepath(...))`.
+- **description**: Tool’s purpose.
+- **parameters**:
+  - **Key**: Parameter name, like `a`.
+  - **required**: If needed.
+  - **type**: Type, like `number` or `string`.
+  - **description**: Parameter’s role.
+
+## Schema Functions
+
+- **getItem(id)**: Gets JSON output via `@(tools.getItem("id"))`. Returns text or empty string.
+- **runScript(id, script, params)**: Runs a script with comma-separated parameters, returns JSON output.
+- **history(id)**: Returns output history.
+
+## Running Scripts
+
+kdeps picks the program by file extension:
+- `.py`: `python3`, inputs via `sys.argv`.
+- `.ts`: `ts-node`, inputs via `process.argv`.
+- `.js`: `node`, inputs via `process.argv`.
+- `.rb`: `ruby`, inputs via `ARGV`.
+- Others (e.g., `.sh`): `sh`, inputs as `$1`, `$2`, etc.
+
+## Sample Prompts with Multi-Tool Chaining
+
+The LLM selects and chains tools, structuring outputs as JSON. Prompts don’t name tools:
+
+1. **Prompt**: “Add 6 and 4, square the result, and save it to ‘output.txt’.”
+   - **Flow**:
+     - LLM picks `calculate_sum` for 6 + 4 = 10.
+     - Uses `square_number` for 10² = 100.
+     - Calls `write_result` to save 100 to `output.txt`.
+   - **JSON Output**:
+     ```json
+     {
+       "result": 10,
+       "squared_result": 100,
+       "file_path": "output.txt"
+     }
+     ```
+
+2. **Prompt**: “Sum 8 and 2, then write the sum to ‘sum.txt’.”
+   - **Flow**:
+     - LLM uses `calculate_sum` for 8 + 2 = 10.
+     - Uses `write_result` to save 10 to `sum.txt`.
+   - **JSON Output**:
+     ```json
+     {
+       "result": 10,
+       "file_path": "sum.txt"
+     }
+     ```
+
+3. **Prompt**: “Add 5 and 5, square it twice, and save to ‘final.txt’.”
+   - **Flow**:
+     - LLM uses `calculate_sum` for 5 + 5 = 10.
+     - Uses `square_number` for 10² = 100.
+     - Uses `square_number` again for 100² = 10000.
+     - Uses `write_result` to save 10000 to ‘final.txt’.
+   - **JSON Output**:
+     ```json
+     {
+       "result": 10,
+       "squared_result": 10000,
+       "file_path": "final.txt"
+     }
+     ```
+
+## Manual Invocation
+
+Run or get JSON results:
+```apl
+local result = "@(tools.runScript("square_number_123", "<path_to_script>", "10"))"
+local output = "@(tools.getItem(\"square_number_123\"))"
+```
+
+## How It’s Like MCP or A2A
+
+- **MCP**: Claude’s tool-calling, not supported in kdeps (open-source only).
+- **A2A**: Google’s agent-connection system, unrelated to kdeps’ tool focus.
+- **Kdeps**: Tool-calling with JSON outputs for open-source AI, like MCP but simpler.
+
+## Tips
+
+- Use unique `name` values.
+- Write clear `description` fields for LLM tool selection.
+- Define `JSONResponseKeys` for structured outputs.
+- Check inputs with `required` and `type`.
+- Secure scripts with `@(data.filepath(...))`.
+- Set higher `timeoutDuration` in `chat` for longer tool chains.
+
+## Open-Source Only
+
+kdeps only supports open-source AI models, not Claude or MCP.
+
+See [LLM Resource Functions](../resources/functions.md#llm-resource-functions) for more.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,40 +9,38 @@ open-source LLM models out-of-the-box.
 
 ## Key Features
 
-Kdeps is loaded with features to streamline AI app development:
+Kdeps is loaded with powerful features to streamline AI app development. Here are the top highlights, sorted by desirability:
 
-- 🐳 Build [Dockerized full-stack AI apps](/getting-started/introduction/quickstart.md#quickstart) with [batteries included](/getting-started/configuration/workflow.md#ai-agent-settings).
-- 🔌 Create custom [AI APIs](/getting-started/configuration/workflow.md#api-server-settings) that serve [open-source LLMs](/getting-started/configuration/workflow.md#llm-models).
-- 🌐 Pair APIs with [frontend apps](/getting-started/configuration/workflow.md#web-server-settings) like Streamlit, NodeJS, and more.
-- 📁 Serve [static websites](/getting-started/configuration/workflow.md#static-file-serving) or [reverse-proxied apps](/getting-started/configuration/workflow.md#reverse-proxying).
-- 🔒 Configure [CORS rules](/getting-started/configuration/workflow.md#cors-configuration) directly in the workflow.
-- 🛡️ Set [trusted proxies](/getting-started/configuration/workflow.md#trustedproxies) for enhanced API and frontend security.
-- 🚀 Run in [Lambda mode](/getting-started/configuration/workflow.md#lambda-mode) or [API mode](/getting-started/configuration/workflow.md#api-server-settings).
-- 🤖 Leverage multiple open-source LLMs from [Ollama](/getting-started/configuration/workflow.md#llm-models) and [Huggingface](https://github.com/kdeps/examples/tree/main/huggingface_imagegen_api).
-- 🐍 Execute Python in isolated environments using [Anaconda](/getting-started/resources/python.md).
-- 🖼️ Support for [multimodal LLMs](/getting-started/resources/multimodal.md).
-- ✅ Built-in [API request validations](/getting-started/resources/api-request-validations.md#api-request-validations), [custom validation checks](/getting-started/resources/validations.md), and [skip conditions](/getting-started/resources/skip.md).
-- 🔄 Use [reusable AI agents](/getting-started/resources/remix.md) for flexible workflows.
-- 🖥️ Run [shell scripts](/getting-started/resources/exec.md) seamlessly.
-- 🌍 Make [API calls](/getting-started/resources/client.md) directly from configuration.
-- 💾 Manage state with [memory operations](/getting-started/resources/memory.md) to store, retrieve, and clear persistent data.
-- 📊 Generate [structured outputs](/getting-started/resources/llm.md#chat-block) from LLMs.
-- 📦 Install [Ubuntu packages](/getting-started/configuration/workflow.md#ubuntu-packages) via configuration.
-- 📜 Define [Ubuntu repositories or PPAs](/getting-started/configuration/workflow.md#ubuntu-repositories).
-- 📈 Enable context-aware [RAG workflows](/getting-started/resources/kartographer.md).
-- 🗂️ Upload [documents or files](/getting-started/tutorials/files.md) for LLM processing.
+- 🛠️ **Let LLMs run tools automatically (aka MCP or A2A) with [external tools and chained tool workflows](https://kdeps.com/getting-started/resources/llm.html#tools-configuration)** to enhance functionality through scripts and sequential tool pipelines.
+- 🧩 **Low-code/no-code capabilities for building [operational full-stack AI apps](https://kdeps.com/getting-started/configuration/workflow.html)**, enabling accessible development for non-technical users and production-ready applications.
+- 🐳 **Build [Dockerized full-stack AI apps](https://kdeps.com/getting-started/introduction/quickstart.html#quickstart)** with [batteries included](https://kdeps.com/getting-started/configuration/workflow.html#ai-agent-settings) for seamless development and deployment.
+- 🌐 **Pair APIs with [frontend apps](https://kdeps.com/getting-started/configuration/workflow.html#web-server-settings)** like Streamlit, NodeJS, and more for interactive AI-driven user interfaces.
+- 🔌 **Create custom [AI APIs](https://kdeps.com/getting-started/configuration/workflow.html#api-server-settings)** that serve [open-source LLMs](https://kdeps.com/getting-started/configuration/workflow.html#llm-models) for robust AI-driven applications.
+- 🖼️ Support for [vision or multimodal LLMs](https://kdeps.com/getting-started/resources/multimodal.html), enabling processing of text, images, and other data types in a single workflow.
+
+## Additional Features
+
+- 📊 Generate [structured outputs](https://kdeps.com/getting-started/resources/llm.html#chat-block) from LLMs for consistent, machine-readable responses.
+- 📈 Enable context-aware [RAG workflows](https://kdeps.com/getting-started/resources/kartographer.html) for accurate, knowledge-intensive tasks.
+- 🗂️ Upload [documents or files](https://kdeps.com/getting-started/tutorials/files.html) for LLM processing, ideal for document analysis.
+- 🤖 Leverage multiple open-source LLMs from [Ollama](https://kdeps.com/getting-started/configuration/workflow.html#llm-models) and [Huggingface](https://github.com/kdeps/examples/tree/main/huggingface_imagegen_api).
+- 🔄 Use [reusable AI agents](https://kdeps.com/getting-started/resources/remix.html) for flexible workflows.
+- 🐍 Execute Python in isolated environments using [Anaconda](https://kdeps.com/getting-started/resources/python.html).
+- 🌍 Make [API calls](https://kdeps.com/getting-started/resources/client.html) directly from configuration.
+- 🖥️ Run [shell scripts](https://kdeps.com/getting-started/resources/exec.html) seamlessly.
+- 💾 Manage state with [memory operations](https://kdeps.com/getting-started/resources/memory.html) to store, retrieve, and clear persistent data.
+- ✅ Built-in [API request validations](https://kdeps.com/getting-started/resources/api-request-validations.html#api-request-validations), [custom validation checks](https://kdeps.com/getting-started/resources/validations.html), and [skip conditions](https://kdeps.com/getting-started/resources/skip.html).
+- 📁 Serve [static websites](https://kdeps.com/getting-started/configuration/workflow.html#static-file-serving) or [reverse-proxied apps](https://kdeps.com/getting-started/configuration/workflow.html#reverse-proxying).
+- 🔒 Configure [CORS rules](https://kdeps.com/getting-started/configuration/workflow.html#cors-configuration) directly in the workflow.
+- 🛡️ Set [trusted proxies](https://kdeps.com/getting-started/configuration/workflow.html#trustedproxies) for enhanced API and frontend security.
+- 🚀 Run in [Lambda mode](https://kdeps.com/getting-started/configuration/workflow.html#lambda-mode) or [API mode](https://kdeps.com/getting-started/configuration/workflow.html#api-server-settings).
+- 📦 Install [Ubuntu packages](https://kdeps.com/getting-started/configuration/workflow.html#ubuntu-packages) via configuration.
+- 📜 Define [Ubuntu repositories or PPAs](https://kdeps.com/getting-started/configuration/workflow.html#ubuntu-repositories).
 - ⚡ Written in high-performance Golang.
-- 📥 [Easy to install](/getting-started/introduction/installation.md) and use with a single command.
+- 📥 [Easy to install](https://kdeps.com/getting-started/introduction/installation.html) and use with a single command.
 
 ## Getting Started
 
-Ready to explore Kdeps? Install it with a single command: [Installation Guide](/getting-started/introduction/installation.md).
+Ready to explore Kdeps? Install it with a single command: [Installation Guide](https://kdeps.com/getting-started/introduction/installation.html).
 
 Check out practical [examples](https://github.com/kdeps/examples) to jumpstart your projects.
-
-<script setup>
-import { withBase } from 'vitepress'
-import { useSidebar } from 'vitepress/theme'
-
-const { sidebarGroups } = useSidebar()
-</script>

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/apple/pkl-go v0.10.0
 	github.com/charmbracelet/huh v0.7.0
 	github.com/charmbracelet/lipgloss v1.1.0
-	github.com/charmbracelet/log v0.4.1
+	github.com/charmbracelet/log v0.4.2
 	github.com/charmbracelet/x/editor v0.1.0
 	github.com/cucumber/godog v0.14.1
 	github.com/docker/docker v28.1.1+incompatible
@@ -23,7 +23,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/kdeps/kartographer v0.0.0-20240808015651-b2afd5d97715
-	github.com/kdeps/schema v0.2.24
+	github.com/kdeps/schema v0.2.27
 	github.com/kr/pretty v0.3.1
 	github.com/mattn/go-sqlite3 v1.14.28
 	github.com/spf13/afero v1.14.0
@@ -44,7 +44,7 @@ require (
 	github.com/charmbracelet/colorprofile v0.3.1 // indirect
 	github.com/charmbracelet/x/ansi v0.9.2 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
-	github.com/charmbracelet/x/exp/strings v0.0.0-20250505150409-97991a1f17d1 // indirect
+	github.com/charmbracelet/x/exp/strings v0.0.0-20250512155337-1597d732b701 // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/cloudwego/base64x v0.1.5 // indirect
 	github.com/cucumber/gherkin/go/v26 v26.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/charmbracelet/huh v0.7.0 h1:W8S1uyGETgj9Tuda3/JdVkc3x7DBLZYPZc4c+/rnR
 github.com/charmbracelet/huh v0.7.0/go.mod h1:UGC3DZHlgOKHvHC07a5vHag41zzhpPFj34U92sOmyuk=
 github.com/charmbracelet/lipgloss v1.1.0 h1:vYXsiLHVkK7fp74RkV7b2kq9+zDLoEU4MZoFqR/noCY=
 github.com/charmbracelet/lipgloss v1.1.0/go.mod h1:/6Q8FR2o+kj8rz4Dq0zQc3vYf7X+B0binUUBwA0aL30=
-github.com/charmbracelet/log v0.4.1 h1:6AYnoHKADkghm/vt4neaNEXkxcXLSV2g1rdyFDOpTyk=
-github.com/charmbracelet/log v0.4.1/go.mod h1:pXgyTsqsVu4N9hGdHmQ0xEA4RsXof402LX9ZgiITn2I=
+github.com/charmbracelet/log v0.4.2 h1:hYt8Qj6a8yLnvR+h7MwsJv/XvmBJXiueUcI3cIxsyig=
+github.com/charmbracelet/log v0.4.2/go.mod h1:qifHGX/tc7eluv2R6pWIpyHDDrrb/AG71Pf2ysQu5nw=
 github.com/charmbracelet/x/ansi v0.9.2 h1:92AGsQmNTRMzuzHEYfCdjQeUzTrgE1vfO5/7fEVoXdY=
 github.com/charmbracelet/x/ansi v0.9.2/go.mod h1:3RQDQ6lDnROptfpWuUVIUG64bD2g2BgntdxH0Ya5TeE=
 github.com/charmbracelet/x/cellbuf v0.0.13 h1:/KBBKHuVRbq1lYx5BzEHBAFBP8VcQzJejZ/IA3iR28k=
@@ -52,8 +52,8 @@ github.com/charmbracelet/x/errors v0.0.0-20240508181413-e8d8b6e2de86 h1:JSt3B+U9
 github.com/charmbracelet/x/errors v0.0.0-20240508181413-e8d8b6e2de86/go.mod h1:2P0UgXMEa6TsToMSuFqKFQR+fZTO9CNGUNokkPatT/0=
 github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91 h1:payRxjMjKgx2PaCWLZ4p3ro9y97+TVLZNaRZgJwSVDQ=
 github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91/go.mod h1:wDlXFlCrmJ8J+swcL/MnGUuYnqgQdW9rhSD61oNMb6U=
-github.com/charmbracelet/x/exp/strings v0.0.0-20250505150409-97991a1f17d1 h1:EFaxes9CfsRKhJZeQHBhTYu7sZubVs9RO5roVdPZlDc=
-github.com/charmbracelet/x/exp/strings v0.0.0-20250505150409-97991a1f17d1/go.mod h1:Rgw3/F+xlcUc5XygUtimVSxAqCOsqyvJjqF5UHRvc5k=
+github.com/charmbracelet/x/exp/strings v0.0.0-20250512155337-1597d732b701 h1:O4k9kHFwC+pOyzMRNiP5R+y8XMx6Mb//gS8BkMdMdS8=
+github.com/charmbracelet/x/exp/strings v0.0.0-20250512155337-1597d732b701/go.mod h1:Rgw3/F+xlcUc5XygUtimVSxAqCOsqyvJjqF5UHRvc5k=
 github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQaGIAQ=
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/charmbracelet/x/termios v0.1.1 h1:o3Q2bT8eqzGnGPOYheoYS8eEleT5ZVNYNy8JawjaNZY=
@@ -152,8 +152,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kdeps/kartographer v0.0.0-20240808015651-b2afd5d97715 h1:CxUIVGV6VdgZo62Q84pOVJwUa0ONNqJIH3/rvWsAiUs=
 github.com/kdeps/kartographer v0.0.0-20240808015651-b2afd5d97715/go.mod h1:DYSCAer2OsX5F3Jne82p4P1LCIu42DQFfL5ypZYcUbk=
-github.com/kdeps/schema v0.2.24 h1:EKbazDiV6i2pW9HjUbtfRTc8M4dTVL5gpMd6KazOukQ=
-github.com/kdeps/schema v0.2.24/go.mod h1:jcI+1Q8GAor+pW+RxPG9EJDM5Ji+GUORirTCSslfH0M=
+github.com/kdeps/schema v0.2.27 h1:8GTEik6csbtxV71m71b/UGbLsAzhn0khgWxp36UYi/4=
+github.com/kdeps/schema v0.2.27/go.mod h1:jcI+1Q8GAor+pW+RxPG9EJDM5Ji+GUORirTCSslfH0M=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=

--- a/pkg/resolver/imports.go
+++ b/pkg/resolver/imports.go
@@ -50,6 +50,7 @@ func (dr *DependencyResolver) PrependDynamicImports(pklFile string) error {
 		fmt.Sprintf("package://schema.kdeps.com/core@%s#/Document.pkl", schema.SchemaVersion(dr.Context)): {Alias: "document", Check: false},
 		fmt.Sprintf("package://schema.kdeps.com/core@%s#/Memory.pkl", schema.SchemaVersion(dr.Context)):   {Alias: "memory", Check: false},
 		fmt.Sprintf("package://schema.kdeps.com/core@%s#/Session.pkl", schema.SchemaVersion(dr.Context)):  {Alias: "session", Check: false},
+		fmt.Sprintf("package://schema.kdeps.com/core@%s#/Tool.pkl", schema.SchemaVersion(dr.Context)):     {Alias: "tool", Check: false},
 		fmt.Sprintf("package://schema.kdeps.com/core@%s#/Skip.pkl", schema.SchemaVersion(dr.Context)):     {Alias: "skip", Check: false},
 		fmt.Sprintf("package://schema.kdeps.com/core@%s#/Utils.pkl", schema.SchemaVersion(dr.Context)):    {Alias: "utils", Check: false},
 		filepath.Join(dr.ActionDir, "/llm/"+dr.RequestID+"__llm_output.pkl"):                              {Alias: "llm", Check: true},

--- a/pkg/resolver/resource_chat.go
+++ b/pkg/resolver/resource_chat.go
@@ -55,12 +55,12 @@ func (dr *DependencyResolver) HandleLLMChat(actionID string, chatBlock *pklLLM.R
 // decodeChatBlock decodes fields in the chat block, handling Base64 decoding where necessary.
 func (dr *DependencyResolver) decodeChatBlock(chatBlock *pklLLM.ResourceChat) error {
 	// Decode Prompt
-	if err := decodeField(&chatBlock.Prompt, "Prompt", utils.SafeDerefString); err != nil {
+	if err := decodeField(&chatBlock.Prompt, "Prompt", utils.SafeDerefString, ""); err != nil {
 		return err
 	}
 
 	// Decode Role
-	if err := decodeField(&chatBlock.Role, "Role", utils.SafeDerefString); err != nil {
+	if err := decodeField(&chatBlock.Role, "Role", utils.SafeDerefString, RoleHuman); err != nil {
 		return err
 	}
 
@@ -91,11 +91,12 @@ func (dr *DependencyResolver) decodeChatBlock(chatBlock *pklLLM.ResourceChat) er
 	return nil
 }
 
-// decodeField decodes a single field, handling Base64 if needed.
-func decodeField(field **string, fieldName string, deref func(*string) string) error {
+// decodeField decodes a single field, handling Base64 if needed, and uses a default value if the field is nil.
+func decodeField(field **string, fieldName string, deref func(*string) string, defaultValue string) error {
 	if field == nil || *field == nil {
-		return fmt.Errorf("field %s is nil", fieldName)
+		*field = &defaultValue
 	}
+	// Field is non-nil, proceed with decoding
 	decoded, err := utils.DecodeBase64IfNeeded(deref(*field))
 	if err != nil {
 		return fmt.Errorf("failed to decode %s: %w", fieldName, err)
@@ -201,21 +202,21 @@ func decodeToolEntry(entry *pklLLM.Tool, index int, logger *logging.Logger) (*pk
 
 	// Decode Name
 	if entry.Name != nil {
-		if err := decodeField(&decodedTool.Name, fmt.Sprintf("Tools[%d].Name", index), utils.SafeDerefString); err != nil {
+		if err := decodeField(&decodedTool.Name, fmt.Sprintf("Tools[%d].Name", index), utils.SafeDerefString, ""); err != nil {
 			return nil, err
 		}
 	}
 
 	// Decode Script
 	if entry.Script != nil {
-		if err := decodeField(&decodedTool.Script, fmt.Sprintf("Tools[%d].Script", index), utils.SafeDerefString); err != nil {
+		if err := decodeField(&decodedTool.Script, fmt.Sprintf("Tools[%d].Script", index), utils.SafeDerefString, ""); err != nil {
 			return nil, err
 		}
 	}
 
 	// Decode Description
 	if entry.Description != nil {
-		if err := decodeField(&decodedTool.Description, fmt.Sprintf("Tools[%d].Description", index), utils.SafeDerefString); err != nil {
+		if err := decodeField(&decodedTool.Description, fmt.Sprintf("Tools[%d].Description", index), utils.SafeDerefString, ""); err != nil {
 			return nil, err
 		}
 	}
@@ -244,14 +245,14 @@ func decodeToolParameters(params *map[string]*pklLLM.ToolProperties, index int, 
 
 		// Decode Type
 		if param.Type != nil {
-			if err := decodeField(&decodedParam.Type, fmt.Sprintf("Tools[%d].Parameters[%s].Type", index, paramName), utils.SafeDerefString); err != nil {
+			if err := decodeField(&decodedParam.Type, fmt.Sprintf("Tools[%d].Parameters[%s].Type", index, paramName), utils.SafeDerefString, ""); err != nil {
 				return nil, err
 			}
 		}
 
 		// Decode Description
 		if param.Description != nil {
-			if err := decodeField(&decodedParam.Description, fmt.Sprintf("Tools[%d].Parameters[%s].Description", index, paramName), utils.SafeDerefString); err != nil {
+			if err := decodeField(&decodedParam.Description, fmt.Sprintf("Tools[%d].Parameters[%s].Description", index, paramName), utils.SafeDerefString, ""); err != nil {
 				return nil, err
 			}
 		}

--- a/pkg/resolver/resource_chat.go
+++ b/pkg/resolver/resource_chat.go
@@ -576,7 +576,6 @@ func generateChatResponse(ctx context.Context, fs afero.Fs, llm *ollama.LLM, cha
 	// First GenerateContent call with tools
 	opts := []llms.CallOption{
 		llms.WithModel(chatBlock.Model),
-		llms.WithTemperature(0.3), // More deterministic output
 	}
 
 	if chatBlock.JSONResponse != nil && *chatBlock.JSONResponse {
@@ -586,7 +585,8 @@ func generateChatResponse(ctx context.Context, fs afero.Fs, llm *ollama.LLM, cha
 	if len(availableTools) > 0 {
 		opts = append(opts,
 			llms.WithTools(availableTools),
-			llms.WithToolChoice("auto")) // Let model decide when to use tools
+			llms.WithToolChoice("auto"), // Let model decide when to use tools
+			llms.WithTemperature(0.3))   // More deterministic output
 	}
 
 	logger.Info("Calling LLM with options",

--- a/pkg/resolver/resource_response.go
+++ b/pkg/resolver/resource_response.go
@@ -54,6 +54,7 @@ func (dr *DependencyResolver) buildResponseSections(requestID string, apiRespons
 		fmt.Sprintf(`import "package://schema.kdeps.com/core@%s#/Document.pkl" as document`, schema.SchemaVersion(dr.Context)),
 		fmt.Sprintf(`import "package://schema.kdeps.com/core@%s#/Memory.pkl" as memory`, schema.SchemaVersion(dr.Context)),
 		fmt.Sprintf(`import "package://schema.kdeps.com/core@%s#/Session.pkl" as session`, schema.SchemaVersion(dr.Context)),
+		fmt.Sprintf(`import "package://schema.kdeps.com/core@%s#/Tool.pkl" as tool`, schema.SchemaVersion(dr.Context)),
 		fmt.Sprintf("success = %v", apiResponseBlock.GetSuccess()),
 		formatResponseMeta(requestID, apiResponseBlock.GetMeta()),
 		formatResponseData(apiResponseBlock.GetResponse()),

--- a/pkg/resolver/resources.go
+++ b/pkg/resolver/resources.go
@@ -126,14 +126,10 @@ func (dr *DependencyResolver) LoadResource(ctx context.Context, resourceFile str
 		options.ResourceReaders = []pkl.ResourceReader{
 			dr.MemoryReader,
 			dr.SessionReader,
+			dr.ToolReader,
 		}
-		options.AllowedResources = []string{
-			"memory:/",
-			"session:/",
-			"package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.uri@1.0.3",
-			"https://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.uri@1.0.3",
-			"https://github.com/apple/pkl-pantry/releases/download/pkl.experimental.uri@1.0.3/pkl.experimental.uri@1.0.3.zip",
-		}
+		options.AllowedModules = []string{".*"}
+		options.AllowedResources = []string{".*"}
 	}
 
 	// Create evaluator with custom options

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -12,7 +12,7 @@ import (
 var (
 	cachedVersion    string
 	once             sync.Once
-	specifiedVersion string = "0.2.24" // Default specified version
+	specifiedVersion string = "0.2.27" // Default specified version
 	UseLatest        bool   = false
 )
 

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -12,8 +12,8 @@ func TestSchemaVersion(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	const mockLockedVersion = "0.2.24" // Define the version once and reuse it
-	const mockVersion = "0.2.24"       // Define the version once and reuse it
+	const mockLockedVersion = "0.2.27" // Define the version once and reuse it
+	const mockVersion = "0.2.27"       // Define the version once and reuse it
 
 	// Save the original value of UseLatest to avoid test interference
 	originalUseLatest := UseLatest

--- a/pkg/template/templates/client.pkl
+++ b/pkg/template/templates/client.pkl
@@ -50,8 +50,8 @@ run {
                 }
                 // Custom error message and code to be used if the preflight check fails.
                 error {
-                        code = 404
-                        message = "Header X-API-KEY not found in request!"
+                        // code = 404
+                        // message = "Header X-API-KEY not found in request!"
                 }
         }
 

--- a/pkg/template/templates/exec.pkl
+++ b/pkg/template/templates/exec.pkl
@@ -52,8 +52,8 @@ run {
                 }
                 // Custom error message and code to be used if the preflight check fails.
                 error {
-                        code = 500
-                        message = "Data file file.txt not found!"
+                        // code = 500
+                        // message = "Data file file.txt not found!"
                 }
         }
 

--- a/pkg/template/templates/llm.pkl
+++ b/pkg/template/templates/llm.pkl
@@ -49,8 +49,8 @@ run {
                 }
                 // Custom error message and code to be used if the preflight check fails.
                 error {
-                        code = 0
-                        message = ""
+                        // code = 0
+                        // message = ""
                 }
         }
 
@@ -88,7 +88,7 @@ run {
                 // This LLM role context for this prompt. For example, "user", "assistant" or "system".
                 // If none is provided, "human" will be used.
                 role = "user"
-                prompt = "Who is @(request.data())?"
+                prompt = "Who is @(request.params("q"))?"
 
                 // Scenario block can take multiple prompts and roles to be added to this LLM session.
                 scenario {
@@ -96,6 +96,23 @@ run {
                                 role = "assistant"
                                 prompt = "You are a helpful and informative AI assistant that specializes in general knowledge."
                         }
+                        // new {
+                        //         role = "system"
+                        //         prompt = "If you are unsure, please just lookup the DB."
+                        // }
+                }
+
+                // Tools block enables LLMs to autonomously execute scripts and chain outputs across multiple tool calls
+                // for complex workflows.
+                tools {
+                        // new {
+                        //     name = "lookup_db"
+                        //     script = "@(data.filepath(\"tools/1.0.0\", \"lookup.py\"))"
+                        //     description = "Queries a database for details about a historical figure"
+                        //     parameters {
+                        //         ["name"] { required = true; type = "string"; description = "Name of the historical figure to query" }
+                        //     }
+                        // }
                 }
 
                 // Specify if the LLM response should be a structured JSON

--- a/pkg/template/templates/python.pkl
+++ b/pkg/template/templates/python.pkl
@@ -52,8 +52,8 @@ run {
                 }
                 // Custom error message and code to be used if the preflight check fails.
                 error {
-                        code = 500
-                        message = "Data file file.txt not found!"
+                        // code = 500
+                        // message = "Data file file.txt not found!"
                 }
         }
 

--- a/pkg/template/templates/response.pkl
+++ b/pkg/template/templates/response.pkl
@@ -55,8 +55,8 @@ run {
                 }
                 // Custom error message and code to be used if the preflight check fails.
                 error {
-                        code = 0
-                        message = ""
+                        // code = 0
+                        // message = ""
                 }
         }
 

--- a/pkg/template/templates/workflow.pkl
+++ b/pkg/template/templates/workflow.pkl
@@ -219,7 +219,7 @@ settings {
                 }
 
                 // The Ollama image tag version to be used as a base Docker image for this AI agent.
-                ollamaImageTag = "0.6.5"
+                ollamaImageTag = "0.6.8"
 
                 // A mapping of build argument variable names.
                 args {}

--- a/pkg/tool/tool.go
+++ b/pkg/tool/tool.go
@@ -1,0 +1,302 @@
+package tool
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"log"
+	"net/url"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/apple/pkl-go/pkl"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// PklResourceReader implements the pkl.ResourceReader interface for SQLite.
+type PklResourceReader struct {
+	DB     *sql.DB
+	DBPath string // Store dbPath for reinitialization
+}
+
+// Scheme returns the URI scheme for this reader.
+func (r *PklResourceReader) Scheme() string {
+	return "tool"
+}
+
+// IsGlobbable indicates whether the reader supports globbing (not needed here).
+func (r *PklResourceReader) IsGlobbable() bool {
+	return false
+}
+
+// HasHierarchicalUris indicates whether URIs are hierarchical (not needed here).
+func (r *PklResourceReader) HasHierarchicalUris() bool {
+	return false
+}
+
+// ListElements is not used in this implementation.
+func (r *PklResourceReader) ListElements(_ url.URL) ([]pkl.PathElement, error) {
+	return nil, nil
+}
+
+// Read retrieves, runs, or retrieves history of script outputs in the SQLite database based on the URI.
+func (r *PklResourceReader) Read(uri url.URL) ([]byte, error) {
+	// Check if receiver is nil and initialize with fixed DBPath
+	if r == nil {
+		log.Printf("Warning: PklResourceReader is nil for URI: %s, initializing with DBPath", uri.String())
+		newReader, err := InitializeTool(r.DBPath)
+		if err != nil {
+			log.Printf("Failed to initialize PklResourceReader in Read: %v", err)
+			return nil, fmt.Errorf("failed to initialize PklResourceReader: %w", err)
+		}
+		r = newReader
+		log.Printf("Initialized PklResourceReader with DBPath")
+	}
+
+	// Check if db is nil and initialize with retries
+	if r.DB == nil {
+		log.Printf("Database connection is nil, attempting to initialize with path: %s", r.DBPath)
+		maxAttempts := 5
+		for attempt := 1; attempt <= maxAttempts; attempt++ {
+			db, err := InitializeDatabase(r.DBPath)
+			if err == nil {
+				r.DB = db
+				log.Printf("Database initialized successfully in Read on attempt %d", attempt)
+				break
+			}
+			log.Printf("Attempt %d: Failed to initialize database in Read: %v", attempt, err)
+			if attempt == maxAttempts {
+				return nil, fmt.Errorf("failed to initialize database after %d attempts: %w", maxAttempts, err)
+			}
+			time.Sleep(1 * time.Second)
+		}
+	}
+
+	id := strings.TrimPrefix(uri.Path, "/")
+	query := uri.Query()
+	operation := query.Get("op")
+
+	log.Printf("Read called with URI: %s, operation: %s", uri.String(), operation)
+
+	switch operation {
+	case "run":
+		if id == "" {
+			log.Printf("runScript failed: no item ID provided")
+			return nil, errors.New("invalid URI: no item ID provided for run operation")
+		}
+		script := query.Get("script")
+		if script == "" {
+			log.Printf("runScript failed: no script provided")
+			return nil, errors.New("run operation requires a script parameter")
+		}
+		params := query.Get("params")
+
+		log.Printf("runScript processing id: %s, script: %s, params: %s", id, script, params)
+
+		// Parse parameters
+		var paramList []string
+		if params != "" {
+			// Split params by comma and trim whitespace
+			for _, p := range strings.Split(params, ",") {
+				trimmed := strings.TrimSpace(p)
+				if trimmed != "" {
+					paramList = append(paramList, trimmed)
+				}
+			}
+		}
+
+		// Determine if script is a file path or inline script
+		var output []byte
+		var err error
+		if _, statErr := os.Stat(script); statErr == nil {
+			// Script is a file path; pass params as arguments
+			cmd := exec.Command(script, paramList...)
+			output, err = cmd.CombinedOutput()
+		} else {
+			// Script is inline; pass script as $1 and params as $2, $3, etc.
+			args := append([]string{"-c", script, "_"}, paramList...)
+			cmd := exec.Command("sh", args...)
+			output, err = cmd.CombinedOutput()
+		}
+
+		outputStr := string(output)
+		if err != nil {
+			log.Printf("runScript execution failed: %v, output: %s", err, outputStr)
+			// Still store the output (which includes stderr) even if execution failed
+		}
+
+		// Store the output in the database, overwriting any existing record
+		result, dbErr := r.DB.Exec(
+			"INSERT OR REPLACE INTO items (id, value) VALUES (?, ?)",
+			id, outputStr,
+		)
+		if dbErr != nil {
+			log.Printf("runScript failed to execute SQL: %v", dbErr)
+			return nil, fmt.Errorf("failed to store script output: %w", dbErr)
+		}
+
+		rowsAffected, dbErr := result.RowsAffected()
+		if dbErr != nil {
+			log.Printf("runScript failed to check result: %v", dbErr)
+			return nil, fmt.Errorf("failed to check run result: %w", dbErr)
+		}
+		if rowsAffected == 0 {
+			log.Printf("runScript: no item set for ID %s", id)
+			return nil, fmt.Errorf("no item set for ID %s", id)
+		}
+
+		// Append to history table
+		_, dbErr = r.DB.Exec(
+			"INSERT INTO history (id, value, timestamp) VALUES (?, ?, ?)",
+			id, outputStr, time.Now().Unix(),
+		)
+		if dbErr != nil {
+			log.Printf("runScript failed to append to history: %v", dbErr)
+			// Note: Not failing the operation if history append fails
+		}
+
+		log.Printf("runScript succeeded for id: %s, output: %s", id, outputStr)
+		return []byte(outputStr), nil
+
+	case "history":
+		if id == "" {
+			log.Printf("history failed: no item ID provided")
+			return nil, errors.New("invalid URI: no item ID provided for history operation")
+		}
+
+		log.Printf("history processing id: %s", id)
+
+		rows, err := r.DB.Query("SELECT value, timestamp FROM history WHERE id = ? ORDER BY timestamp ASC", id)
+		if err != nil {
+			log.Printf("history failed to query: %v", err)
+			return nil, fmt.Errorf("failed to retrieve history: %w", err)
+		}
+		defer rows.Close()
+
+		var historyEntries []string
+		for rows.Next() {
+			var value string
+			var timestamp int64
+			if err := rows.Scan(&value, timestamp); err != nil {
+				log.Printf("history failed to scan row: %v", err)
+				return nil, fmt.Errorf("failed to scan history row: %w", err)
+			}
+			formattedTime := time.Unix(timestamp, 0).Format(time.RFC3339)
+			historyEntries = append(historyEntries, fmt.Sprintf("[%s] %s", formattedTime, value))
+		}
+		if err := rows.Err(); err != nil {
+			log.Printf("history failed during row iteration: %v", err)
+			return nil, fmt.Errorf("failed during history iteration: %w", err)
+		}
+
+		if len(historyEntries) == 0 {
+			log.Printf("history: no entries found for id: %s", id)
+			return []byte(""), nil
+		}
+
+		historyOutput := strings.Join(historyEntries, "\n")
+		log.Printf("history succeeded for id: %s, entries: %d", id, len(historyEntries))
+		return []byte(historyOutput), nil
+
+	default: // getItem (no operation specified)
+		if id == "" {
+			log.Printf("getItem failed: no item ID provided")
+			return nil, errors.New("invalid URI: no item ID provided")
+		}
+
+		log.Printf("getItem processing id: %s", id)
+
+		var value string
+		err := r.DB.QueryRow("SELECT value FROM items WHERE id = ?", id).Scan(&value)
+		if err == sql.ErrNoRows {
+			log.Printf("getItem: no item found for id: %s", id)
+			return []byte(""), nil // Return empty string for not found
+		}
+		if err != nil {
+			log.Printf("getItem failed to read item for id: %s, error: %v", id, err)
+			return nil, fmt.Errorf("failed to read item: %w", err)
+		}
+
+		log.Printf("getItem succeeded for id: %s, value: %s", id, value)
+		return []byte(value), nil
+	}
+}
+
+// InitializeDatabase sets up the SQLite database and creates the items and history tables with retries.
+func InitializeDatabase(dbPath string) (*sql.DB, error) {
+	const maxAttempts = 5
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		log.Printf("Attempt %d: Initializing SQLite database at %s", attempt, dbPath)
+		db, err := sql.Open("sqlite3", dbPath)
+		if err != nil {
+			log.Printf("Attempt %d: Failed to open database: %v", attempt, err)
+			if attempt == maxAttempts {
+				return nil, fmt.Errorf("failed to open database after %d attempts: %w", maxAttempts, err)
+			}
+			time.Sleep(1 * time.Second)
+			continue
+		}
+
+		// Verify connection
+		if err := db.Ping(); err != nil {
+			log.Printf("Attempt %d: Failed to ping database: %v", attempt, err)
+			db.Close()
+			if attempt == maxAttempts {
+				return nil, fmt.Errorf("failed to ping database after %d attempts: %w", maxAttempts, err)
+			}
+			time.Sleep(1 * time.Second)
+			continue
+		}
+
+		// Create items table
+		_, err = db.Exec(`
+			CREATE TABLE IF NOT EXISTS items (
+				id TEXT PRIMARY KEY,
+				value TEXT NOT NULL
+			)
+		`)
+		if err != nil {
+			log.Printf("Attempt %d: Failed to create items table: %v", attempt, err)
+			db.Close()
+			if attempt == maxAttempts {
+				return nil, fmt.Errorf("failed to create items table after %d attempts: %w", maxAttempts, err)
+			}
+			time.Sleep(1 * time.Second)
+			continue
+		}
+
+		// Create history table
+		_, err = db.Exec(`
+			CREATE TABLE IF NOT EXISTS history (
+				id TEXT NOT NULL,
+				value TEXT NOT NULL,
+				timestamp INTEGER NOT NULL
+			)
+		`)
+		if err != nil {
+			log.Printf("Attempt %d: Failed to create history table: %v", attempt, err)
+			db.Close()
+			if attempt == maxAttempts {
+				return nil, fmt.Errorf("failed to create history table after %d attempts: %w", maxAttempts, err)
+			}
+			time.Sleep(1 * time.Second)
+			continue
+		}
+
+		log.Printf("SQLite database initialized successfully at %s on attempt %d", dbPath, attempt)
+		return db, nil
+	}
+	return nil, fmt.Errorf("failed to initialize database after %d attempts", maxAttempts)
+}
+
+// InitializeTool creates a new PklResourceReader with an initialized SQLite database.
+func InitializeTool(dbPath string) (*PklResourceReader, error) {
+	db, err := InitializeDatabase(dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("error initializing database: %w", err)
+	}
+	// Do NOT close db here; caller will manage closing
+	return &PklResourceReader{DB: db, DBPath: dbPath}, nil
+}

--- a/pkg/tool/tool.go
+++ b/pkg/tool/tool.go
@@ -140,7 +140,8 @@ func (r *PklResourceReader) Read(uri url.URL) ([]byte, error) {
 			cmd := exec.Command(interpreter, args...)
 			output, err = cmd.CombinedOutput()
 			if err != nil {
-				if _, ok := err.(*exec.Error); ok {
+				var execErr *exec.Error
+				if errors.As(err, &execErr) {
 					log.Printf("Interpreter %s not found or inaccessible: %v", interpreter, err)
 					return nil, fmt.Errorf("interpreter %s not found or inaccessible: %w", interpreter, err)
 				}

--- a/pkg/utils/string.go
+++ b/pkg/utils/string.go
@@ -2,8 +2,14 @@ package utils
 
 import "strings"
 
+// StringPtr returns a pointer to the provided string.
 func StringPtr(s string) *string {
 	return &s
+}
+
+// BoolPtr returns a pointer to the provided bool.
+func BoolPtr(b bool) *bool {
+	return &b
 }
 
 // ContainsString checks if a string exists in a slice (case-sensitive).
@@ -32,4 +38,28 @@ func SafeDerefString(s *string) string {
 		return ""
 	}
 	return *s
+}
+
+// SafeDerefBool safely dereferences a bool pointer, returning false if nil.
+func SafeDerefBool(b *bool) bool {
+	if b == nil {
+		return false
+	}
+	return *b
+}
+
+// SafeDerefSlice safely dereferences a slice pointer, returning an empty slice if nil.
+func SafeDerefSlice[T any](s *[]T) []T {
+	if s == nil {
+		return []T{}
+	}
+	return *s
+}
+
+// SafeDerefMap safely dereferences a map pointer, returning an empty map if nil.
+func SafeDerefMap[K comparable, V any](m *map[K]V) map[K]V {
+	if m == nil {
+		return make(map[K]V)
+	}
+	return *m
 }

--- a/pkg/utils/string.go
+++ b/pkg/utils/string.go
@@ -26,7 +26,8 @@ func ContainsStringInsensitive(slice []string, item string) bool {
 	return false
 }
 
-func DerefString(s *string) string {
+// SafeDerefString safely dereferences a string pointer, returning an empty string if nil.
+func SafeDerefString(s *string) string {
 	if s == nil {
 		return ""
 	}

--- a/pkg/utils/string.go
+++ b/pkg/utils/string.go
@@ -63,3 +63,14 @@ func SafeDerefMap[K comparable, V any](m *map[K]V) map[K]V {
 	}
 	return *m
 }
+
+// TruncateString truncates a string to a maximum length, adding "..." if truncated.
+func TruncateString(s string, maxLength int) string {
+	if len(s) <= maxLength {
+		return s
+	}
+	if maxLength < 3 {
+		return "..."
+	}
+	return s[:maxLength-3] + "..."
+}


### PR DESCRIPTION
This PR introduces a feature that allows open-source LLMs to autonomously run scripts, akin to MCP or A2A.
LLM can choose multiple tools, and each tool output can influence the input of the next tool chain execution.

Tools can be defined in the LLM resource in the `tools {}` block, and can be triggered by the prompt, i.e. "perform: @(request.params("q"))"

For example:
```
tools {
        new {
                name = "add_two_numbers"
                script = "@(data.filepath("tools/1.0.0", "add_two_numbers.py"))"
                description = "add two integers and return the new number"
                parameters {
                        ["a"] { required = true; type = "integer"; description = "The first number" }
                        ["b"] { required = true; type = "integer"; description = "The second number" }
                }
        }
        new {
                name = "count_file_lines"
                script = "@(data.filepath("tools/1.0.0", "count_file_lines.py"))"
                description = "Count the number of lines in a file"
                parameters {
                        ["file_path"] { required = true; type = "string"; description = "Path to the file" }
                }
        }
}
```
