### PR TITLE
Fix for Writable file handle closed without error handling

### DIFF
--- a/pkg/infra/http/management.go
+++ b/pkg/infra/http/management.go
@@ -406,10 +406,14 @@ func writeExtractedFile(targetPath string, r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
 
 	if _, copyErr := io.Copy(f, io.LimitReader(r, maxPackageFileSize)); copyErr != nil {
+		_ = f.Close()
 		return copyErr
+	}
+
+	if closeErr := f.Close(); closeErr != nil {
+		return closeErr
 	}
 
 	return nil


### PR DESCRIPTION
Handle `Close` errors explicitly in `writeExtractedFile` instead of deferring an unchecked close.

Best approach without changing behavior: keep the current open/copy flow, but:
1. Remove `defer f.Close()`.
2. After a copy error, explicitly call `f.Close()` (best-effort) and return the copy error.
3. On successful copy, call `f.Close()` and return its error if any.

This is localized to `pkg/infra/http/management.go` in `writeExtractedFile` (around lines 409–415). No new imports or helper methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._