### PR TITLE
Fix for Writable file handle closed without error handling

### DIFF
--- a/cmd/registry_install.go
+++ b/cmd/registry_install.go
@@ -445,7 +445,7 @@ func extractArchive(archivePath, destDir string) error {
 	return nil
 }
 
-func extractFile(target string, r io.Reader) error {
+func extractFile(target string, r io.Reader) (retErr error) {
 	kdeps_debug.Log("enter: extractFile")
 	if mkdirErr := os.MkdirAll(filepath.Dir(target), registryInstallDirPerm); mkdirErr != nil {
 		return fmt.Errorf("mkdir parent %s: %w", filepath.Dir(target), mkdirErr)
@@ -454,7 +454,11 @@ func extractFile(target string, r io.Reader) error {
 	if err != nil {
 		return fmt.Errorf("create file %s: %w", target, err)
 	}
-	defer out.Close()
+	defer func() {
+		if closeErr := out.Close(); closeErr != nil && retErr == nil {
+			retErr = fmt.Errorf("close file %s: %w", target, closeErr)
+		}
+	}()
 	if _, copyErr := io.Copy(out, r); copyErr != nil {
 		return fmt.Errorf("write file %s: %w", target, copyErr)
 	}


### PR DESCRIPTION
General fix: for writable file descriptors, do not ignore `Close()` errors. Ensure `Close()` is called exactly once and its error is returned when no prior error exists, while preserving earlier write/copy errors if they happen.

Best fix here: in `cmd/registry_install.go`, update `extractFile` to use a named return error (`retErr`) and a deferred closure that checks `out.Close()`. If `io.Copy` fails, return that error; if `io.Copy` succeeds but `Close()` fails, return a wrapped close error. This preserves functionality and adds missing error handling without changing external behavior otherwise.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._