### PR TITLE
Fix for Writable file handle closed without error handling

### DIFF
--- a/pkg/executor/component_dotenv.go
+++ b/pkg/executor/component_dotenv.go
@@ -375,7 +375,7 @@ func UpdateComponentFiles(comp *domain.Component, compDir string) (map[string]st
 
 // mergeDotEnv appends env var entries that are present in the component's
 // resources but absent from the existing .env file. Returns the number of vars appended.
-func mergeDotEnv(comp *domain.Component, dotEnvPath string) (int, error) {
+func mergeDotEnv(comp *domain.Component, dotEnvPath string) (added int, err error) {
 	kdeps_debug.Log("enter: mergeDotEnv")
 
 	// Load existing keys.
@@ -404,7 +404,11 @@ func mergeDotEnv(comp *domain.Component, dotEnvPath string) (int, error) {
 	if openErr != nil {
 		return 0, fmt.Errorf("open .env for append: %w", openErr)
 	}
-	defer f.Close()
+	defer func() {
+		if closeErr := f.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("close .env after append: %w", closeErr)
+		}
+	}()
 
 	var sb strings.Builder
 	sb.WriteString("\n# Added by kdeps component update\n")


### PR DESCRIPTION
General fix: replace bare `defer f.Close()` with a deferred closure that checks `Close()` and propagates it if no prior error has occurred (or combines/logs as needed).

Best fix here (without changing functionality): in `mergeDotEnv` (`pkg/executor/component_dotenv.go`, around line 407), switch to a named return `(...)(added int, err error)`, then defer a closure that calls `f.Close()` and assigns `err` when close fails and no earlier error is present. Keep existing error wrapping for open/write failures, and return `len(missing), nil` on success. This preserves current return values while ensuring close/flush failures are not silently ignored.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._