### PR TITLE
Fix for Writable file handle closed without error handling

### DIFF
--- a/cmd/registry_install.go
+++ b/cmd/registry_install.go
@@ -374,7 +374,7 @@ func resolvePackageInfo(name, baseURL string) (*packageInfo, error) {
 	return &info, nil
 }
 
-func downloadArchive(rawURL, destPath string) error {
+func downloadArchive(rawURL, destPath string) (err error) {
 	kdeps_debug.Log("enter: downloadArchive")
 	client := &stdhttp.Client{Timeout: registryInstallTimeout}
 	req, err := stdhttp.NewRequestWithContext(context.Background(), stdhttp.MethodGet, rawURL, nil)
@@ -398,7 +398,11 @@ func downloadArchive(rawURL, destPath string) error {
 	if err != nil {
 		return fmt.Errorf("create archive file: %w", err)
 	}
-	defer out.Close()
+	defer func() {
+		if closeErr := out.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("close archive file: %w", closeErr)
+		}
+	}()
 	if _, copyErr := io.Copy(out, io.LimitReader(resp.Body, registryInstallMaxResponseSize)); copyErr != nil {
 		return fmt.Errorf("write archive: %w", copyErr)
 	}


### PR DESCRIPTION
To fix this safely without changing intended behavior, replace the bare `defer out.Close()` with a deferred closure that captures and propagates close errors when no earlier error has already occurred.

Best approach here:
- Change `downloadArchive` to use a **named return error** (`func ... (err error)`).
- Keep existing early-return behavior for request/open/copy failures.
- Add a deferred function after opening `out` that:
  - calls `out.Close()`
  - if `Close()` returns an error and `err` is still `nil`, set `err = fmt.Errorf("close archive file: %w", closeErr)`

This preserves current functionality and adds the missing error handling for close-time failures.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._