### PR TITLE
Potential fix for code scanning alert no. 9: Reflected cross-site scripting

### DIFF
--- a/pkg/infra/http/server.go
+++ b/pkg/infra/http/server.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html"
 	"log/slog"
 	stdhttp "net/http"
 	"os"
@@ -435,6 +436,12 @@ func (s *Server) HandleRequest(w stdhttp.ResponseWriter, r *stdhttp.Request) {
 							), debugMode)
 							return
 						}
+					}
+
+					// Prevent reflected XSS when writing browser-rendered content.
+					// Escape untrusted output for HTML responses before writing.
+					if strings.HasPrefix(respContentType, "text/html") {
+						rawBytes = []byte(html.EscapeString(string(rawBytes)))
 					}
 
 					w.WriteHeader(stdhttp.StatusOK)


### PR DESCRIPTION
Potential fix for [https://github.com/kdeps/kdeps/security/code-scanning/9](https://github.com/kdeps/kdeps/security/code-scanning/9)

To fix reflected XSS, sanitize/encode untrusted output **at the HTTP response boundary** before writing it for non-JSON content types. The best minimal-impact fix is in `pkg/infra/http/server.go` where raw API responses are currently written directly (`w.Write(rawBytes)`) for non-JSON types.

Implement this by:
- Adding standard library import `html`.
- In the non-JSON response branch (around lines 411–450), after `rawBytes` are prepared, conditionally HTML-escape when `Content-Type` is HTML/text-ish (at minimum `text/html`; optionally also `text/plain`) and then write escaped bytes.
- Keep JSON behavior unchanged.
- Do not alter executor/context parsing logic; preserve functionality while making browser-rendered output safe.

This addresses all variants because all tainted sources converge on this response emission path.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
