### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,5 +1,8 @@
 name: Build and Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/kdeps/kdeps/security/code-scanning/1](https://github.com/kdeps/kdeps/security/code-scanning/1)

Add an explicit top-level `permissions` block to `.github/workflows/build-test.yml` so all jobs inherit least-privilege token access unless overridden.

Best fix without changing functionality:
- Insert at workflow root (after `name` and before `on`) a minimal permission set:
  - `contents: read`
- This is sufficient for `actions/checkout` and typical read-only CI tasks in this file.
- No imports, methods, or additional definitions are needed (YAML workflow only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
