### PR TITLE
Potential fix for code scanning alert no. 8: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/pkg/infra/http/management.go
+++ b/pkg/infra/http/management.go
@@ -353,6 +353,11 @@ func extractKdepsPackage(data []byte, destDir string) error {
 	}
 	defer gzr.Close()
 
+	absDestDir, err := filepath.Abs(destDir)
+	if err != nil {
+		return fmt.Errorf("failed to resolve destination directory: %w", err)
+	}
+
 	tr := tar.NewReader(gzr)
 
 	for {
@@ -365,13 +370,21 @@ func extractKdepsPackage(data []byte, destDir string) error {
 			return fmt.Errorf("failed to read archive entry: %w", nextErr)
 		}
 
-		// Security: reject absolute paths and traversal sequences.
+		// Security: canonicalize and ensure extraction stays within destination.
 		relPath := filepath.Clean(hdr.Name)
-		if filepath.IsAbs(relPath) || strings.HasPrefix(relPath, "..") {
+		if relPath == "." || relPath == "" || filepath.IsAbs(relPath) {
 			return fmt.Errorf("invalid path in package: %s", hdr.Name)
 		}
 
-		targetPath := filepath.Join(destDir, relPath)
+		targetPath, absErr := filepath.Abs(filepath.Join(absDestDir, relPath))
+		if absErr != nil {
+			return fmt.Errorf("failed to resolve target path for %s: %w", relPath, absErr)
+		}
+
+		relToDest, relErr := filepath.Rel(absDestDir, targetPath)
+		if relErr != nil || relToDest == ".." || strings.HasPrefix(relToDest, ".."+string(filepath.Separator)) {
+			return fmt.Errorf("invalid path in package: %s", hdr.Name)
+		}
 
 		if hdr.FileInfo().IsDir() {
 			if mkdirErr := os.MkdirAll(targetPath, 0750); mkdirErr != nil {


### PR DESCRIPTION
Potential fix for [https://github.com/kdeps/kdeps/security/code-scanning/8](https://github.com/kdeps/kdeps/security/code-scanning/8)

Use a canonical destination-containment validation before any filesystem operation:

1. Keep cleaning the archive path (`relPath := filepath.Clean(hdr.Name)`), and reject empty/current-dir-like entries.
2. Build absolute canonical paths for both destination root and candidate target:
   - `absDest := filepath.Abs(destDir)`
   - `absTarget := filepath.Abs(filepath.Join(destDir, relPath))`
3. Enforce containment with `filepath.Rel(absDest, absTarget)` and reject if result is `..` or starts with `..` segment.
4. Use the validated `absTarget` for all subsequent operations (`MkdirAll`, parent dir creation, file write).

This is the best single fix because it directly guarantees no extracted path escapes `destDir`, covering all three CodeQL variants at lines 377, 385, and 402.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
