### PR TITLE
Potential fix for code scanning alert no. 6: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/cmd/component.go
+++ b/cmd/component.go
@@ -284,30 +284,50 @@ func cmdExtractTarEntry(tr *tar.Reader, header *tar.Header, destDir string) erro
 	kdeps_debug.Log("enter: cmdExtractTarEntry")
 	// Sanitize path to prevent directory traversal.
 	cleanName := filepath.Clean(header.Name)
-	if strings.HasPrefix(cleanName, "..") {
+	if cleanName == "." || strings.HasPrefix(cleanName, "..") || filepath.IsAbs(cleanName) {
 		return nil
 	}
-	target := filepath.Join(destDir, cleanName)
+
+	baseDir, baseErr := filepath.Abs(destDir)
+	if baseErr != nil {
+		return fmt.Errorf("resolve dest dir: %w", baseErr)
+	}
+	baseDir = filepath.Clean(baseDir)
+
+	target := filepath.Join(baseDir, cleanName)
+	absTarget, targetErr := filepath.Abs(target)
+	if targetErr != nil {
+		return fmt.Errorf("resolve target path: %w", targetErr)
+	}
+	absTarget = filepath.Clean(absTarget)
+
+	rel, relErr := filepath.Rel(baseDir, absTarget)
+	if relErr != nil {
+		return fmt.Errorf("validate target path: %w", relErr)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return nil
+	}
 
 	switch header.Typeflag {
 	case tar.TypeDir:
-		if mkErr := os.MkdirAll(target, 0o750); mkErr != nil {
-			return fmt.Errorf("mkdir %s: %w", target, mkErr)
+		if mkErr := os.MkdirAll(absTarget, 0o750); mkErr != nil {
+			return fmt.Errorf("mkdir %s: %w", absTarget, mkErr)
 		}
 	case tar.TypeReg:
-		if mkErr := os.MkdirAll(filepath.Dir(target), 0o750); mkErr != nil {
+		if mkErr := os.MkdirAll(filepath.Dir(absTarget), 0o750); mkErr != nil {
 			return fmt.Errorf("mkdir parent: %w", mkErr)
 		}
-		f, createErr := os.Create(target)
+		f, createErr := os.Create(absTarget)
 		if createErr != nil {
-			return fmt.Errorf("create %s: %w", target, createErr)
+			return fmt.Errorf("create %s: %w", absTarget, createErr)
 		}
 		_, copyErr := io.Copy(f, tr)
 		if closeErr := f.Close(); closeErr != nil && copyErr == nil {
-			return fmt.Errorf("close %s: %w", target, closeErr)
+			return fmt.Errorf("close %s: %w", absTarget, closeErr)
 		}
 		if copyErr != nil {
-			return fmt.Errorf("copy %s: %w", target, copyErr)
+			return fmt.Errorf("copy %s: %w", absTarget, copyErr)
 		}
 	}
 	return nil


### PR DESCRIPTION
Potential fix for [https://github.com/kdeps/kdeps/security/code-scanning/6](https://github.com/kdeps/kdeps/security/code-scanning/6)

To fix Zip Slip/tar-slip safely, enforce a **path containment check** after joining and normalizing paths:

1. Resolve `destDir` to an absolute cleaned path.
2. Reject absolute entry names directly (`filepath.IsAbs(cleanName)`).
3. Compute `target := filepath.Join(absDestDir, cleanName)`, then resolve `absTarget`.
4. Ensure `absTarget` is inside `absDestDir` using `filepath.Rel(absDestDir, absTarget)` and reject if:
   - `rel == ".."` or starts with `"../"` (or platform separator equivalent), or
   - `filepath.Rel` fails.
5. Use the validated absolute `target` for mkdir/create operations.

This preserves current behavior (extract valid entries) while robustly blocking traversal and absolute-path escapes across platforms.  
Edits are only needed in `cmd/component.go`, within `cmdExtractTarEntry`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
