### PR TITLE
Potential fix for code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/pkg/infra/http/management.go
+++ b/pkg/infra/http/management.go
@@ -370,8 +370,11 @@ func extractKdepsPackage(data []byte, destDir string) error {
 			return fmt.Errorf("failed to read archive entry: %w", nextErr)
 		}
 
-		relPath := filepath.Clean(hdr.Name)
+		relPath := filepath.Clean(filepath.FromSlash(hdr.Name))
 		if relPath == "." || relPath == "" || filepath.IsAbs(relPath) {
+			return fmt.Errorf("invalid path in package: %s", hdr.Name)
+		}
+		if relPath == ".." || strings.HasPrefix(relPath, ".."+string(os.PathSeparator)) {
 			return fmt.Errorf("invalid path in package: %s", hdr.Name)
 		}
 
@@ -381,8 +384,11 @@ func extractKdepsPackage(data []byte, destDir string) error {
 			return fmt.Errorf("failed to resolve package path %s: %w", relPath, absErr)
 		}
 
-		baseWithSep := baseDirAbs + string(os.PathSeparator)
-		if targetPathAbs != baseDirAbs && !strings.HasPrefix(targetPathAbs, baseWithSep) {
+		relToBase, relErr := filepath.Rel(baseDirAbs, targetPathAbs)
+		if relErr != nil {
+			return fmt.Errorf("failed to validate package path %s: %w", relPath, relErr)
+		}
+		if relToBase == ".." || strings.HasPrefix(relToBase, ".."+string(os.PathSeparator)) {
 			return fmt.Errorf("invalid path in package: %s", hdr.Name)
 		}
 

--- a/pkg/infra/http/management.go
+++ b/pkg/infra/http/management.go
@@ -347,6 +347,11 @@ func (s *Server) HandleManagementUpdatePackage(w stdhttp.ResponseWriter, r *stdh
 // may include workflow.yaml, resources/, data/, scripts/, etc.
 func extractKdepsPackage(data []byte, destDir string) error {
 	kdeps_debug.Log("enter: extractKdepsPackage")
+	baseDirAbs, baseErr := filepath.Abs(destDir)
+	if baseErr != nil {
+		return fmt.Errorf("failed to resolve destination directory: %w", baseErr)
+	}
+
 	gzr, err := gzip.NewReader(bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("invalid package: not a valid gzip archive: %w", err)
@@ -365,16 +370,24 @@ func extractKdepsPackage(data []byte, destDir string) error {
 			return fmt.Errorf("failed to read archive entry: %w", nextErr)
 		}
 
-		// Security: reject absolute paths and traversal sequences.
 		relPath := filepath.Clean(hdr.Name)
-		if filepath.IsAbs(relPath) || strings.HasPrefix(relPath, "..") {
+		if relPath == "." || relPath == "" || filepath.IsAbs(relPath) {
 			return fmt.Errorf("invalid path in package: %s", hdr.Name)
 		}
 
-		targetPath := filepath.Join(destDir, relPath)
+		targetPath := filepath.Join(baseDirAbs, relPath)
+		targetPathAbs, absErr := filepath.Abs(targetPath)
+		if absErr != nil {
+			return fmt.Errorf("failed to resolve package path %s: %w", relPath, absErr)
+		}
+
+		baseWithSep := baseDirAbs + string(os.PathSeparator)
+		if targetPathAbs != baseDirAbs && !strings.HasPrefix(targetPathAbs, baseWithSep) {
+			return fmt.Errorf("invalid path in package: %s", hdr.Name)
+		}
 
 		if hdr.FileInfo().IsDir() {
-			if mkdirErr := os.MkdirAll(targetPath, 0750); mkdirErr != nil {
+			if mkdirErr := os.MkdirAll(targetPathAbs, 0750); mkdirErr != nil {
 				return fmt.Errorf("failed to create directory %s: %w", relPath, mkdirErr)
 			}
 
@@ -382,11 +395,11 @@ func extractKdepsPackage(data []byte, destDir string) error {
 		}
 
 		// Create parent directories if needed.
-		if mkdirErr := os.MkdirAll(filepath.Dir(targetPath), 0750); mkdirErr != nil {
+		if mkdirErr := os.MkdirAll(filepath.Dir(targetPathAbs), 0750); mkdirErr != nil {
 			return fmt.Errorf("failed to create parent directory for %s: %w", relPath, mkdirErr)
 		}
 
-		if writeErr := writeExtractedFile(targetPath, tr); writeErr != nil {
+		if writeErr := writeExtractedFile(targetPathAbs, tr); writeErr != nil {
 			return fmt.Errorf("failed to extract %s: %w", relPath, writeErr)
 		}
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/kdeps/kdeps/security/code-scanning/4](https://github.com/kdeps/kdeps/security/code-scanning/4)

To fix this safely without changing intended functionality, keep allowing multi-component archive paths, but enforce that every extracted entry resolves **within** `destDir`.

Best fix in this file:
1. Resolve `destDir` to an absolute canonical base once in `extractKdepsPackage`.
2. For each header:
   - Clean entry path.
   - Reject empty or `"."`.
   - Reject absolute paths.
   - Join with base dir, resolve absolute path.
   - Verify the resolved target is inside base dir (prefix with path-separator boundary).
3. Use the resolved target path for `MkdirAll`, parent creation, and file writing.

This addresses CodeQL’s concern at line 385 and closes traversal gaps while preserving archive extraction behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
