### PR TITLE
Potential fix for code scanning alert no. 10: Reflected cross-site scripting

### DIFF
--- a/pkg/input/bot/whatsapp.go
+++ b/pkg/input/bot/whatsapp.go
@@ -77,6 +77,11 @@ func (r *whatsAppRunner) Start(ctx context.Context, ch chan<- Message) error {
 			token := req.URL.Query().Get("hub.verify_token")
 			challenge := req.URL.Query().Get("hub.challenge")
 			if mode == "subscribe" && token == r.cfg.WebhookSecret {
+				if _, err := strconv.Atoi(challenge); err != nil {
+					http.Error(w, "bad request", http.StatusBadRequest)
+					return
+				}
+				w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte(challenge))
 				return


### PR DESCRIPTION
Potential fix for [https://github.com/kdeps/kdeps/security/code-scanning/10](https://github.com/kdeps/kdeps/security/code-scanning/10)

The safest minimal fix is to avoid reflecting the attacker-controlled `hub.challenge` value directly. For this specific handshake, preserve behavior by only returning a challenge that matches the expected token shape (digits), and reject invalid values.

Best single fix in `pkg/input/bot/whatsapp.go`:

- In the GET `/webhook` branch, after reading `challenge`, validate it with `strconv.Atoi(challenge)` (already imported).
- If invalid, return `http.StatusBadRequest`.
- If valid, set `Content-Type` to `text/plain; charset=utf-8` and write the validated challenge string.

This removes direct unsafe reflection of arbitrary input while keeping webhook verification functionality intact for valid Meta challenges.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
