### PR TITLE
Potential fix for code scanning alert no. 9: Reflected cross-site scripting

### DIFF
--- a/pkg/infra/http/middleware.go
+++ b/pkg/infra/http/middleware.go
@@ -92,6 +92,13 @@ func (w *ResponseWriterWrapper) WriteHeader(code int) {
 // browsers render as markup or text, and therefore requires HTML escaping
 // to prevent reflected XSS.
 func browserRenderedContentType(ct string) bool {
+	// Empty content type is treated as browser-rendered text to be safe:
+	// net/http may sniff and default to text/plain when headers are not set yet.
+	ct = strings.TrimSpace(ct)
+	if ct == "" {
+		return true
+	}
+
 	// Strip parameters (e.g. "; charset=utf-8") before matching.
 	if i := strings.IndexByte(ct, ';'); i >= 0 {
 		ct = strings.TrimSpace(ct[:i])


### PR DESCRIPTION
Potential fix for [https://github.com/kdeps/kdeps/security/code-scanning/9](https://github.com/kdeps/kdeps/security/code-scanning/9)

The best fix is to ensure browser-rendered responses are always escaped at the final write sink, including when `Content-Type` is not explicitly set yet (net/http may sniff and default to text/plain).  
In this code, the sink is `ResponseWriterWrapper.Write` in `pkg/infra/http/middleware.go`.

Single best change (minimal and safe):  
- In `Write`, treat empty `Content-Type` as browser-rendered text (escape by default), while keeping existing explicit allowlist behavior.
- This closes gaps where handlers write tainted content before setting headers, and addresses all alert variants flowing into this sink.
- No behavior change for explicitly non-browser types like `application/json` or binary types.

Edits needed:
- File: `pkg/infra/http/middleware.go`
- Region: `browserRenderedContentType` function.
- No new imports/dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
