### PR TITLE
Potential fix for code scanning alert no. 18: Reflected cross-site scripting

### DIFF
--- a/pkg/infra/http/middleware.go
+++ b/pkg/infra/http/middleware.go
@@ -92,7 +92,7 @@ func (w *ResponseWriterWrapper) WriteHeader(code int) {
 // browsers render as markup and therefore requires HTML escaping
 // to prevent reflected XSS.
 func browserRenderedContentType(ct string) bool {
-	ct = strings.TrimSpace(ct)
+	ct = strings.TrimSpace(strings.ToLower(ct))
 	if ct == "" {
 		return true
 	}
@@ -130,6 +130,9 @@ func (w *ResponseWriterWrapper) Write(b []byte) (int, error) {
 	out := b
 	if browserRenderedContentType(ct) {
 		out = []byte(html.EscapeString(string(b)))
+		if strings.TrimSpace(w.ResponseWriter.Header().Get("Content-Type")) == "" {
+			w.ResponseWriter.Header().Set("Content-Type", "text/html; charset=utf-8")
+		}
 	}
 	return w.ResponseWriter.Write(out)
 }


### PR DESCRIPTION
Potential fix for [https://github.com/kdeps/kdeps/security/code-scanning/18](https://github.com/kdeps/kdeps/security/code-scanning/18)

General fix: apply **consistent contextual output encoding at the final HTTP write point** and avoid bypass paths. In this codebase, the best single fix is to harden `ResponseWriterWrapper.Write` so browser-rendered content is always escaped reliably, including when `Content-Type` has not yet been set or differs by case/parameters, while keeping JSON/binary behavior unchanged.

Best concrete change (single-file, minimal functional impact):
- File: `pkg/infra/http/middleware.go`
- Region: `browserRenderedContentType` and `Write` methods.
- Changes:
  1. Normalize content type to lowercase before matching.
  2. Keep parameter stripping.
  3. In `Write`, if escaping occurs, ensure `Content-Type` is explicitly set to a safe browser-rendered type (`text/html; charset=utf-8`) when absent, so client interpretation is deterministic.
  4. Keep existing behavior for non-browser-rendered types unchanged.

This preserves existing functionality while making the sink-side defense explicit and strong for all tainted variants reported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
