### PR TITLE
Potential fix for code scanning alert no. 18: Reflected cross-site scripting

### DIFF
--- a/pkg/infra/http/server.go
+++ b/pkg/infra/http/server.go
@@ -413,10 +413,10 @@ func (s *Server) HandleRequest(w stdhttp.ResponseWriter, r *stdhttp.Request) {
 					w.Header().Set("Content-Type", respContentType)
 				}
 
-				// For non-JSON content types (e.g. text/html), write the data field
-				// directly as raw bytes so the response is not wrapped in a JSON envelope.
-				// The ResponseWriterWrapper middleware handles HTML escaping for browser-rendered
-				// content types, so we pass raw bytes through and avoid double-encoding.
+				// For non-JSON content types (e.g. text/html), only pass through explicit
+				// string/[]byte payloads. For other payload types, force JSON serialization
+				// and JSON content type to avoid reflecting arbitrary structured data into
+				// browser-rendered responses.
 				if !strings.HasPrefix(respContentType, "application/json") {
 					var rawBytes []byte
 					switch v := data.(type) {
@@ -429,7 +429,7 @@ func (s *Server) HandleRequest(w stdhttp.ResponseWriter, r *stdhttp.Request) {
 						rawBytes, marshalErr = json.Marshal(data)
 						if marshalErr != nil {
 							s.logger.Error(
-								"failed to marshal raw API response",
+								"failed to marshal API response",
 								"error",
 								marshalErr,
 								"path",
@@ -442,6 +442,8 @@ func (s *Server) HandleRequest(w stdhttp.ResponseWriter, r *stdhttp.Request) {
 							), debugMode)
 							return
 						}
+						respContentType = "application/json; charset=utf-8"
+						w.Header().Set("Content-Type", respContentType)
 					}
 
 					w.WriteHeader(stdhttp.StatusOK)


### PR DESCRIPTION
Potential fix for [https://github.com/kdeps/kdeps/security/code-scanning/18](https://github.com/kdeps/kdeps/security/code-scanning/18)

Best fix: enforce safe response handling at the response-construction point in `pkg/infra/http/server.go`, not only in middleware. Keep JSON as JSON, and for non-JSON responses avoid reflecting arbitrary user-controlled structured data as executable markup. The least disruptive approach is:

1. For non-JSON responses, only allow raw passthrough for `[]byte` and `string`.
2. For all other data types, serialize to JSON and force `Content-Type: application/json; charset=utf-8` before writing.
3. Continue relying on `ResponseWriterWrapper` for HTML escaping when explicit text/html is intentionally returned as string/bytes.

This preserves existing functionality (string/byte raw responses still work), but removes risky implicit marshaling of arbitrary objects into markup-ish responses.

Change region: `pkg/infra/http/server.go`, block around current non-JSON write logic (lines ~416–457 in provided snippet). No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
