### PR TITLE
fix: answer CORS preflights before auth middleware

### DIFF
--- a/pkg/infra/http/server.go
+++ b/pkg/infra/http/server.go
@@ -150,7 +150,26 @@ func (s *Server) SetWatcher(watcher FileWatcher) {
 // Start starts the HTTP server.
 func (s *Server) Start(addr string, devMode bool) error {
 	debugEnter("Start")
+	if err := s.configureRouter(devMode); err != nil {
+		return err
+	}
+
+	certFile, keyFile := workflowTLSCertificates(s.Workflow)
+
+	s.httpServer = newDefaultHTTPServer(addr, s.Router)
+
+	return s.listenAndServe(addr, certFile, keyFile)
+}
+
+// configureRouter wires middleware and routes in execution order.
+func (s *Server) configureRouter(devMode bool) error {
 	s.setupCoreMiddleware()
+
+	// CORS must run before auth: browsers never attach credentials to
+	// preflight OPTIONS requests, so auth-first would reject every
+	// cross-origin request with 401. CORS-first also decorates auth
+	// error responses with CORS headers so browsers can surface them.
+	s.Router.Use(s.CorsMiddleware)
 
 	// Apply security middleware from apiServer config when present.
 	if err := s.applySecurityMiddleware(); err != nil {
@@ -163,16 +182,9 @@ func (s *Server) Start(addr string, devMode bool) error {
 	// Setup routes
 	s.SetupRoutes()
 
-	// Setup CORS (defaults to enabled)
-	s.Router.Use(s.CorsMiddleware)
-
 	s.enableHotReloadIfDev(devMode)
 
-	certFile, keyFile := workflowTLSCertificates(s.Workflow)
-
-	s.httpServer = newDefaultHTTPServer(addr, s.Router)
-
-	return s.listenAndServe(addr, certFile, keyFile)
+	return nil
 }
 
 // Shutdown gracefully shuts down the HTTP server.

--- a/pkg/infra/http/server_security_test.go
+++ b/pkg/infra/http/server_security_test.go
@@ -119,6 +119,42 @@ func TestServer_Start_rejectsMissingAuthToken(t *testing.T) {
 	assert.Contains(t, err.Error(), "KDEPS_API_AUTH_TOKEN")
 }
 
+func TestServer_configureRouter_corsPreflightBypassesAuth(t *testing.T) {
+	t.Setenv("KDEPS_API_AUTH_TOKEN", "secret")
+
+	server, err := NewServer(&domain.Workflow{
+		Metadata: domain.WorkflowMetadata{Name: "test"},
+		Settings: domain.WorkflowSettings{
+			APIServer: &domain.APIServerConfig{},
+		},
+	}, nil, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, server.configureRouter(false))
+
+	// Browsers never attach credentials to preflight OPTIONS requests, so
+	// the CORS middleware must answer them before auth can reject them.
+	preflight := httptest.NewRequest(stdhttp.MethodOptions, "/api/v1/test", nil)
+	preflight.Header.Set("Origin", "http://example.com")
+	preflight.Header.Set("Access-Control-Request-Method", stdhttp.MethodPost)
+	preflight.Header.Set("Access-Control-Request-Headers", "authorization,content-type")
+	rec := httptest.NewRecorder()
+	server.Router.ServeHTTP(rec, preflight)
+
+	assert.Equal(t, stdhttp.StatusOK, rec.Code)
+	assert.NotEmpty(t, rec.Header().Get("Access-Control-Allow-Methods"))
+
+	// Non-preflight requests still require the token.
+	post := httptest.NewRequest(stdhttp.MethodPost, "/api/v1/test", bytes.NewBufferString("{}"))
+	post.Header.Set("Origin", "http://example.com")
+	rec = httptest.NewRecorder()
+	server.Router.ServeHTTP(rec, post)
+
+	assert.Equal(t, stdhttp.StatusUnauthorized, rec.Code)
+	// Auth failures must carry CORS headers so browsers can surface them.
+	assert.NotEmpty(t, rec.Header().Get("Access-Control-Allow-Methods"))
+}
+
 func TestWebServer_applyWebSecurityMiddleware_appliesRateLimit(t *testing.T) {
 	webServer, err := NewWebServer(&domain.Workflow{
 		Metadata: domain.WorkflowMetadata{Name: "web"},


### PR DESCRIPTION
## Problem

When `apiServer` is configured (auth mandatory), CORS preflight `OPTIONS` requests are rejected with **401** before the CORS middleware runs. Browsers never attach credentials to preflights (Fetch spec), so every cross-origin browser request to a kdeps API fails regardless of `cors.allowedOrigins`.

Root cause: `applySecurityMiddleware()` (which registers `AuthMiddleware`) ran before `s.Router.Use(s.CorsMiddleware)` in `Server.Start`, and the router executes middleware in registration order.

Fixes #468

## Change

- Extract the middleware/route wiring from `Start` into `configureRouter` (also makes the chain testable without a listener).
- Register `CorsMiddleware` **before** the security middleware. Effects:
  - Preflights are answered by `writePreflightOK` instead of 401.
  - Auth failures now carry CORS headers, so browsers can read the 401 body instead of opaque network errors.
  - Non-preflight requests still require the token — auth semantics unchanged.

## Testing

- New regression test `TestServer_configureRouter_corsPreflightBypassesAuth`: unauthenticated preflight → 200 with `Access-Control-Allow-Methods`; unauthenticated POST → 401 with CORS headers.
- `go test ./pkg/infra/http/` — 517 passed.
- `go tool cover`: `Start` and `configureRouter` both at 100%.
- `golangci-lint run ./pkg/infra/http/...` — 0 issues.

Manually verified against the repro in #468: preflight now returns 200 with CORS headers; POST without token still 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
