### PR TITLE
fix: honor webServer port and keep merged web routes public

### DIFF
--- a/cmd/run_dispatch_notjs_test.go
+++ b/cmd/run_dispatch_notjs_test.go
@@ -359,6 +359,155 @@ func TestStartWebServer_SignalShutdown(t *testing.T) {
 	}
 }
 
+func TestStartBothServersWithEngine_MergedSignalShutdown(t *testing.T) {
+	origStart := httpServerStartFunc
+	t.Cleanup(func() { httpServerStartFunc = origStart })
+	block := make(chan struct{})
+	httpServerStartFunc = func(_ *kdepshttp.Server, _ string, _ bool) error {
+		<-block
+		return http.ErrServerClosed
+	}
+	eng := executor.NewEngine(nil)
+	samePort := mustFreePort(t)
+	wf := &domain.Workflow{
+		Metadata: domain.WorkflowMetadata{Name: "both", Version: "1.0", TargetActionID: "act"},
+		Settings: domain.WorkflowSettings{
+			APIServer: &domain.APIServerConfig{PortNum: samePort},
+			WebServer: &domain.WebServerConfig{PortNum: samePort, Routes: []domain.WebRoute{}},
+		},
+		Resources: []*domain.Resource{{ActionID: "act", APIResponse: &domain.APIResponseConfig{Success: true}}},
+	}
+	done := make(chan error, 1)
+	go func() { done <- startBothServersWithEngine(eng, wf, t.TempDir(), false, false) }()
+	time.Sleep(100 * time.Millisecond)
+	sendSIGINTToSelf(t)
+	close(block)
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestStartBothServersWithEngine_MergedStartsClean(t *testing.T) {
+	orig := httpServerStartFunc
+	t.Cleanup(func() { httpServerStartFunc = orig })
+	httpServerStartFunc = func(_ *kdepshttp.Server, _ string, _ bool) error {
+		return nil
+	}
+	eng := executor.NewEngine(nil)
+	samePort := mustFreePort(t)
+	wf := &domain.Workflow{
+		Metadata: domain.WorkflowMetadata{Name: "both", Version: "1.0", TargetActionID: "act"},
+		Settings: domain.WorkflowSettings{
+			APIServer: &domain.APIServerConfig{PortNum: samePort},
+			WebServer: &domain.WebServerConfig{PortNum: samePort, Routes: []domain.WebRoute{}},
+		},
+		Resources: []*domain.Resource{{ActionID: "act", APIResponse: &domain.APIResponseConfig{Success: true}}},
+	}
+	require.NoError(t, startBothServersWithEngine(eng, wf, t.TempDir(), false, false))
+}
+
+func TestStartBothServersWithEngine_MergedStartError(t *testing.T) {
+	orig := httpServerStartFunc
+	t.Cleanup(func() { httpServerStartFunc = orig })
+	httpServerStartFunc = func(_ *kdepshttp.Server, _ string, _ bool) error {
+		return errors.New("merged start failed")
+	}
+	eng := executor.NewEngine(nil)
+	samePort := mustFreePort(t)
+	wf := &domain.Workflow{
+		Metadata: domain.WorkflowMetadata{Name: "both", Version: "1.0", TargetActionID: "act"},
+		Settings: domain.WorkflowSettings{
+			APIServer: &domain.APIServerConfig{PortNum: samePort},
+			WebServer: &domain.WebServerConfig{PortNum: samePort, Routes: []domain.WebRoute{}},
+		},
+		Resources: []*domain.Resource{{ActionID: "act", APIResponse: &domain.APIResponseConfig{Success: true}}},
+	}
+	err := startBothServersWithEngine(eng, wf, t.TempDir(), false, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "merged start failed")
+}
+
+func TestStartBothServersWithEngine_SplitWebStartError(t *testing.T) {
+	origHTTPStart := httpServerStartFunc
+	origWebStart := webServerStartFunc
+	origWebShutdown := webServerShutdownFunc
+	t.Cleanup(func() {
+		httpServerStartFunc = origHTTPStart
+		webServerStartFunc = origWebStart
+		webServerShutdownFunc = origWebShutdown
+	})
+	block := make(chan struct{})
+	t.Cleanup(func() { close(block) })
+	httpServerStartFunc = func(_ *kdepshttp.Server, _ string, _ bool) error {
+		<-block
+		return http.ErrServerClosed
+	}
+	webServerStartFunc = func(_ *kdepshttp.WebServer, _ context.Context) error {
+		return errors.New("web bind failed")
+	}
+	webServerShutdownFunc = func(_ *kdepshttp.WebServer, _ context.Context) error {
+		return errors.New("web shutdown failed")
+	}
+	eng := executor.NewEngine(nil)
+	wf := &domain.Workflow{
+		Metadata: domain.WorkflowMetadata{Name: "both", Version: "1.0", TargetActionID: "act"},
+		Settings: domain.WorkflowSettings{
+			APIServer: &domain.APIServerConfig{PortNum: mustFreePort(t)},
+			WebServer: &domain.WebServerConfig{PortNum: mustFreePort(t), Routes: []domain.WebRoute{}},
+		},
+		Resources: []*domain.Resource{{ActionID: "act", APIResponse: &domain.APIResponseConfig{Success: true}}},
+	}
+	err := startBothServersWithEngine(eng, wf, t.TempDir(), false, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "web bind failed")
+}
+
+func TestStartBothServersWithEngine_SplitAPIStartsClean(t *testing.T) {
+	origHTTPStart := httpServerStartFunc
+	origWebStart := webServerStartFunc
+	t.Cleanup(func() {
+		httpServerStartFunc = origHTTPStart
+		webServerStartFunc = origWebStart
+	})
+	block := make(chan struct{})
+	t.Cleanup(func() { close(block) })
+	httpServerStartFunc = func(_ *kdepshttp.Server, _ string, _ bool) error {
+		return nil
+	}
+	webServerStartFunc = func(_ *kdepshttp.WebServer, _ context.Context) error {
+		<-block
+		return http.ErrServerClosed
+	}
+	eng := executor.NewEngine(nil)
+	wf := &domain.Workflow{
+		Metadata: domain.WorkflowMetadata{Name: "both", Version: "1.0", TargetActionID: "act"},
+		Settings: domain.WorkflowSettings{
+			APIServer: &domain.APIServerConfig{PortNum: mustFreePort(t)},
+			WebServer: &domain.WebServerConfig{PortNum: mustFreePort(t), Routes: []domain.WebRoute{}},
+		},
+		Resources: []*domain.Resource{{ActionID: "act", APIResponse: &domain.APIResponseConfig{Success: true}}},
+	}
+	require.NoError(t, startBothServersWithEngine(eng, wf, t.TempDir(), false, false))
+}
+
+func TestStartBothServersWithEngine_SplitBindAddressError(t *testing.T) {
+	orig := findAvailablePortFunc
+	t.Cleanup(func() { findAvailablePortFunc = orig })
+	findAvailablePortFunc = func(_ string, _ int) (int, error) { return 0, errors.New("no port") }
+	eng := executor.NewEngine(nil)
+	wf := &domain.Workflow{
+		Settings: domain.WorkflowSettings{
+			APIServer: &domain.APIServerConfig{PortNum: 8080},
+			WebServer: &domain.WebServerConfig{PortNum: 9090, Routes: []domain.WebRoute{}},
+		},
+	}
+	err := startBothServersWithEngine(eng, wf, t.TempDir(), false, false)
+	require.Error(t, err)
+}
+
 func TestStartOllamaServer_StartError(t *testing.T) {
 	origLook := execLookPathFunc
 	t.Cleanup(func() { execLookPathFunc = origLook })

--- a/cmd/run_servers_http.go
+++ b/cmd/run_servers_http.go
@@ -28,6 +28,7 @@ import (
 	kdeps_debug "github.com/kdeps/kdeps/v2/pkg/debug"
 	"github.com/kdeps/kdeps/v2/pkg/domain"
 	"github.com/kdeps/kdeps/v2/pkg/executor"
+	"github.com/kdeps/kdeps/v2/pkg/infra/http"
 	"github.com/kdeps/kdeps/v2/pkg/infra/logging"
 )
 
@@ -98,6 +99,11 @@ func startBothServersWithEngine(
 		return fmt.Errorf("failed to create web server: %w", err)
 	}
 	webServer.SetWorkflowDir(workflowPath)
+
+	if workflow.Settings.HasDistinctWebPort() {
+		return startSplitServers(httpServer, webServer, workflow, devMode)
+	}
+
 	webServer.RegisterRoutesOn(context.Background(), httpServer.Router)
 
 	addr, err := resolveServerBindAddress(workflow)
@@ -121,5 +127,49 @@ func startBothServersWithEngine(
 		webServer.Stop,
 	))
 }
+
+// startSplitServers runs the API and web servers on separate listeners when
+// webServer declares its own port. Web routes stay off the API router, so
+// static assets are served without API auth, matching webServer-only mode.
+func startSplitServers(
+	httpServer *http.Server,
+	webServer *http.WebServer,
+	workflow *domain.Workflow,
+	devMode bool,
+) error {
+	kdeps_debug.Log("enter: startSplitServers")
+	apiAddr, err := resolveServerBindAddress(workflow)
+	if err != nil {
+		return fmt.Errorf("server cannot start: %w", err)
+	}
+
+	fmt.Fprintf(os.Stdout, "  ✓ Starting API server on %s and web server on port %d\n",
+		apiAddr, workflow.Settings.GetWebPortNum())
+	fmt.Fprintln(os.Stdout, "\n✓ Server ready!")
+
+	ctx := context.Background()
+	return runUntilSignalOrError(httpServerSignalServeConfig(
+		func() error {
+			serveErr := make(chan error, splitServerCount)
+			go func() { serveErr <- webServerStartFunc(webServer, ctx) }()
+			go func() { serveErr <- httpServerStartFunc(httpServer, apiAddr, devMode) }()
+			if startErr := <-serveErr; startErr != nil {
+				return fmt.Errorf("server error: %w", startErr)
+			}
+			return nil
+		},
+		func(stopCtx context.Context) error {
+			webErr := webServerShutdownFunc(webServer, stopCtx)
+			if shutdownErr := httpServerShutdownFunc(httpServer, stopCtx); shutdownErr != nil {
+				return shutdownErr
+			}
+			return webErr
+		},
+		"Server",
+		webServer.Stop,
+	))
+}
+
+const splitServerCount = 2
 
 // botPlatformsFromInput returns the configured bot platform names for status output.

--- a/pkg/domain/workflow_settings.go
+++ b/pkg/domain/workflow_settings.go
@@ -58,6 +58,24 @@ func (w *WorkflowSettings) GetPortNum() int {
 	return DefaultPort
 }
 
+// GetWebPortNum returns the webServer port, falling back to the shared port
+// resolution when the web server does not declare its own.
+func (w *WorkflowSettings) GetWebPortNum() int {
+	kdeps_debug.Log("enter: GetWebPortNum")
+	if w.WebServer != nil && w.WebServer.PortNum > 0 {
+		return w.WebServer.PortNum
+	}
+	return w.GetPortNum()
+}
+
+// HasDistinctWebPort reports whether the web server declares its own port and
+// must run on a separate listener instead of being merged onto the API port.
+func (w *WorkflowSettings) HasDistinctWebPort() bool {
+	kdeps_debug.Log("enter: HasDistinctWebPort")
+	return w.APIServer != nil && w.WebServer != nil &&
+		w.WebServer.PortNum > 0 && w.WebServer.PortNum != w.GetPortNum()
+}
+
 // GetCORSConfig returns the CORS configuration, providing defaults if not set.
 // Presence of a cors: block always enables CORS. To disable, omit the block.
 func (w *WorkflowSettings) GetCORSConfig() *CORS {

--- a/pkg/domain/workflow_test.go
+++ b/pkg/domain/workflow_test.go
@@ -498,6 +498,107 @@ func TestWorkflowSettings_GetPortNum(t *testing.T) {
 	}
 }
 
+func TestWorkflowSettings_GetWebPortNum(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings *domain.WorkflowSettings
+		want     int
+	}{
+		{
+			name: "returns WebServer PortNum when set",
+			settings: &domain.WorkflowSettings{
+				APIServer: &domain.APIServerConfig{PortNum: 8080},
+				WebServer: &domain.WebServerConfig{PortNum: 9090},
+			},
+			want: 9090,
+		},
+		{
+			name: "falls back to shared port when WebServer PortNum unset",
+			settings: &domain.WorkflowSettings{
+				APIServer: &domain.APIServerConfig{PortNum: 8080},
+				WebServer: &domain.WebServerConfig{},
+			},
+			want: 8080,
+		},
+		{
+			name:     "falls back to default without server config",
+			settings: &domain.WorkflowSettings{},
+			want:     domain.DefaultPort,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.settings.GetWebPortNum()
+			if got != tt.want {
+				t.Errorf("GetWebPortNum() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWorkflowSettings_HasDistinctWebPort(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings *domain.WorkflowSettings
+		want     bool
+	}{
+		{
+			name: "true when both servers declare different ports",
+			settings: &domain.WorkflowSettings{
+				APIServer: &domain.APIServerConfig{PortNum: 8080},
+				WebServer: &domain.WebServerConfig{PortNum: 9090},
+			},
+			want: true,
+		},
+		{
+			name: "false when ports match",
+			settings: &domain.WorkflowSettings{
+				APIServer: &domain.APIServerConfig{PortNum: 8080},
+				WebServer: &domain.WebServerConfig{PortNum: 8080},
+			},
+			want: false,
+		},
+		{
+			name: "false when WebServer PortNum unset",
+			settings: &domain.WorkflowSettings{
+				APIServer: &domain.APIServerConfig{PortNum: 8080},
+				WebServer: &domain.WebServerConfig{},
+			},
+			want: false,
+		},
+		{
+			name: "false when only API port unset (web port becomes shared port)",
+			settings: &domain.WorkflowSettings{
+				APIServer: &domain.APIServerConfig{},
+				WebServer: &domain.WebServerConfig{PortNum: 9090},
+			},
+			want: false,
+		},
+		{
+			name: "false without APIServer",
+			settings: &domain.WorkflowSettings{
+				WebServer: &domain.WebServerConfig{PortNum: 9090},
+			},
+			want: false,
+		},
+		{
+			name:     "false without WebServer",
+			settings: &domain.WorkflowSettings{APIServer: &domain.APIServerConfig{PortNum: 8080}},
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.settings.HasDistinctWebPort()
+			if got != tt.want {
+				t.Errorf("HasDistinctWebPort() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // TestInputConfig_UnmarshalYAML covers all input source branches.
 //
 //nolint:gocognit // table-driven test covers all input source branches

--- a/pkg/infra/http/http_middleware_auth.go
+++ b/pkg/infra/http/http_middleware_auth.go
@@ -32,9 +32,22 @@ func isPublicAPIPath(path string) bool {
 // Clients supply the API token via "Authorization: Bearer <token>" or "X-API-Key: <token>".
 func AuthMiddleware(token string) func(stdhttp.HandlerFunc) stdhttp.HandlerFunc {
 	debugEnter("AuthMiddleware")
+	return AuthMiddlewareExempting(token, nil)
+}
+
+// AuthMiddlewareExempting behaves like AuthMiddleware but additionally bypasses
+// authentication for paths where isPublicPath returns true. Used to keep
+// webServer routes public when they are merged onto the API router, matching
+// webServer-only mode semantics.
+func AuthMiddlewareExempting(
+	token string,
+	isPublicPath func(string) bool,
+) func(stdhttp.HandlerFunc) stdhttp.HandlerFunc {
+	debugEnter("AuthMiddlewareExempting")
 	return func(next stdhttp.HandlerFunc) stdhttp.HandlerFunc {
 		return func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
-			if shouldBypassAuth(token, requestPath(r)) {
+			path := requestPath(r)
+			if shouldBypassAuth(token, path) || pathIsPublic(isPublicPath, path) {
 				next(w, r)
 				return
 			}
@@ -45,4 +58,8 @@ func AuthMiddleware(token string) func(stdhttp.HandlerFunc) stdhttp.HandlerFunc 
 			next(w, r)
 		}
 	}
+}
+
+func pathIsPublic(isPublicPath func(string) bool, path string) bool {
+	return isPublicPath != nil && isPublicPath(path)
 }

--- a/pkg/infra/http/http_webserver_routes.go
+++ b/pkg/infra/http/http_webserver_routes.go
@@ -66,7 +66,7 @@ func (s *WebServer) logWebRouteConfigured(route domain.WebRoute) {
 func webServerListenAddr(settings domain.WorkflowSettings) string {
 	return listenAddrFromHostPort(
 		effectiveBindHostFromEnv(settings.GetHostIP()),
-		settings.GetPortNum(),
+		settings.GetWebPortNum(),
 	)
 }
 

--- a/pkg/infra/http/server_security.go
+++ b/pkg/infra/http/server_security.go
@@ -18,6 +18,8 @@
 
 package http
 
+import "github.com/kdeps/kdeps/v2/pkg/domain"
+
 // applySecurityMiddleware wires auth, rate-limit, and body-limit middleware
 // from the workflow's APIServer config.
 func (s *Server) applySecurityMiddleware() error {
@@ -30,9 +32,54 @@ func (s *Server) applySecurityMiddleware() error {
 	if err != nil {
 		return err
 	}
-	s.Router.Use(AuthMiddleware(token))
+	s.Router.Use(AuthMiddlewareExempting(token, mergedWebRouteMatcher(s.Workflow)))
 	configureTrustedProxyLimits(s.Router, s.Workflow.Settings, apiServerLimitConfig(api), s.logger)
 	return nil
+}
+
+// mergedWebRouteMatcher returns a predicate marking webServer routes as public
+// when they are merged onto the API router. Web assets are unauthenticated in
+// webServer-only mode; merging them onto the API port must not change that —
+// a browser navigation cannot send an Authorization header. Paths claimed by
+// an API route always stay authenticated, even when a wildcard web route
+// (e.g. "/") would also match them. Returns nil (no exemption) when the web
+// server runs on its own listener or is absent.
+func mergedWebRouteMatcher(workflow *domain.Workflow) func(string) bool {
+	if workflow == nil || workflow.Settings.WebServer == nil ||
+		workflow.Settings.HasDistinctWebPort() {
+		return nil
+	}
+	apiRoutes := apiRoutePatterns(workflow.Settings.APIServer)
+	webPatterns := make([]string, 0, len(workflow.Settings.WebServer.Routes))
+	for _, route := range workflow.Settings.WebServer.Routes {
+		webPatterns = append(webPatterns, wildcardRoutePath(route.Path))
+	}
+	return func(path string) bool {
+		if anyPatternMatches(apiRoutes, path) {
+			return false
+		}
+		return anyPatternMatches(webPatterns, path)
+	}
+}
+
+func apiRoutePatterns(api *domain.APIServerConfig) []string {
+	if api == nil {
+		return nil
+	}
+	patterns := make([]string, 0, len(api.Routes))
+	for _, route := range api.Routes {
+		patterns = append(patterns, route.Path)
+	}
+	return patterns
+}
+
+func anyPatternMatches(patterns []string, path string) bool {
+	for _, pattern := range patterns {
+		if matchRouterPattern(pattern, path) {
+			return true
+		}
+	}
+	return false
 }
 
 // applyWebSecurityMiddleware wires rate-limit and body-limit middleware for webServer-only mode.

--- a/pkg/infra/http/server_security_test.go
+++ b/pkg/infra/http/server_security_test.go
@@ -155,6 +155,90 @@ func TestServer_configureRouter_corsPreflightBypassesAuth(t *testing.T) {
 	assert.NotEmpty(t, rec.Header().Get("Access-Control-Allow-Methods"))
 }
 
+func TestServer_configureRouter_mergedWebRoutesArePublic(t *testing.T) {
+	t.Setenv("KDEPS_API_AUTH_TOKEN", "secret")
+
+	workflow := &domain.Workflow{
+		Metadata: domain.WorkflowMetadata{Name: "test"},
+		Settings: domain.WorkflowSettings{
+			APIServer: &domain.APIServerConfig{
+				Routes: []domain.Route{{Path: "/api/v1/chat", Methods: []string{"POST"}}},
+			},
+			WebServer: &domain.WebServerConfig{
+				Routes: []domain.WebRoute{{Path: "/", ServerType: "static", PublicPath: t.TempDir()}},
+			},
+		},
+	}
+	server, err := NewServer(workflow, nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, server.configureRouter(false))
+
+	webServer, err := NewWebServer(workflow, slog.Default())
+	require.NoError(t, err)
+	webServer.RegisterRoutesOn(t.Context(), server.Router)
+
+	// Browser navigations cannot send Authorization headers; merged web
+	// routes must load without a token, like webServer-only mode.
+	rec := httptest.NewRecorder()
+	server.Router.ServeHTTP(rec, httptest.NewRequest(stdhttp.MethodGet, "/", nil))
+	assert.NotEqual(t, stdhttp.StatusUnauthorized, rec.Code)
+
+	// API routes stay authenticated even though the "/" web route's
+	// wildcard pattern also matches them.
+	rec = httptest.NewRecorder()
+	server.Router.ServeHTTP(rec, httptest.NewRequest(stdhttp.MethodPost, "/api/v1/chat", bytes.NewBufferString("{}")))
+	assert.Equal(t, stdhttp.StatusUnauthorized, rec.Code)
+}
+
+func TestMergedWebRouteMatcher(t *testing.T) {
+	workflow := &domain.Workflow{
+		Settings: domain.WorkflowSettings{
+			APIServer: &domain.APIServerConfig{
+				Routes: []domain.Route{{Path: "/api/v1/chat", Methods: []string{"POST"}}},
+			},
+			WebServer: &domain.WebServerConfig{
+				Routes: []domain.WebRoute{{Path: "/", ServerType: "static"}},
+			},
+		},
+	}
+
+	matcher := mergedWebRouteMatcher(workflow)
+	require.NotNil(t, matcher)
+	assert.True(t, matcher("/"))
+	assert.True(t, matcher("/index.html"))
+	assert.False(t, matcher("/api/v1/chat"))
+
+	assert.Nil(t, mergedWebRouteMatcher(nil))
+	assert.Nil(t, mergedWebRouteMatcher(&domain.Workflow{
+		Settings: domain.WorkflowSettings{APIServer: &domain.APIServerConfig{}},
+	}))
+
+	// Without an API server every web path is public.
+	webOnly := mergedWebRouteMatcher(&domain.Workflow{
+		Settings: domain.WorkflowSettings{
+			WebServer: &domain.WebServerConfig{
+				Routes: []domain.WebRoute{{Path: "/", ServerType: "static"}},
+			},
+		},
+	})
+	require.NotNil(t, webOnly)
+	assert.True(t, webOnly("/anything"))
+
+	// Distinct web port means web routes are not merged: no exemption.
+	workflow.Settings.APIServer.PortNum = 8080
+	workflow.Settings.WebServer.PortNum = 9090
+	assert.Nil(t, mergedWebRouteMatcher(workflow))
+}
+
+func TestAuthMiddlewareExempting_nilPredicate(t *testing.T) {
+	handler := AuthMiddlewareExempting("token", nil)(func(w stdhttp.ResponseWriter, _ *stdhttp.Request) {
+		w.WriteHeader(stdhttp.StatusOK)
+	})
+	rec := httptest.NewRecorder()
+	handler(rec, httptest.NewRequest(stdhttp.MethodGet, "/private", nil))
+	assert.Equal(t, stdhttp.StatusUnauthorized, rec.Code)
+}
+
 func TestWebServer_applyWebSecurityMiddleware_appliesRateLimit(t *testing.T) {
 	webServer, err := NewWebServer(&domain.Workflow{
 		Metadata: domain.WorkflowMetadata{Name: "web"},


### PR DESCRIPTION
## Problem

With both `apiServer` and `webServer` configured, web routes were merged onto the API port:

- `webServer.portNum` was **silently ignored** (#470)
- the API bearer-token middleware applied to static assets, so `GET /` returned 401 — a browser can never load a kdeps-served UI because navigations cannot send `Authorization` headers (#469)

Fixes #469
Fixes #470

## Change

**Split mode (new):** when `webServer` declares its own port, `startSplitServers` runs it on a separate listener with webServer-only semantics — no API auth on web routes, API auth unchanged on the API port. `webServerListenAddr` now resolves via the new `GetWebPortNum()` so the web listener binds the configured port instead of the shared one.

**Merged mode (same/unset port):** unchanged single listener, but `AuthMiddlewareExempting` now bypasses auth for paths matching a webServer route — matching webServer-only mode, where static assets are already public. Paths claimed by an API route **always stay authenticated**, even when a wildcard web route such as `/` also matches them (`mergedWebRouteMatcher` checks API patterns first). `AuthMiddleware(token)` keeps its signature and behavior.

## Testing

- `go test ./cmd/ ./pkg/infra/http/ ./pkg/domain/` — 2349 passed
- 100% coverage on every new/changed function (`startBothServersWithEngine`, `startSplitServers`, `mergedWebRouteMatcher`, `AuthMiddlewareExempting`, `GetWebPortNum`, `HasDistinctWebPort`, ...)
- `golangci-lint` — 0 issues
- Live verification with a real chat workflow on the patched binary:
  - split (API 16402 / web 8091): `GET :8091/` → 200 no token; API POST → 401 without token, 200 with
  - merged (both 16403): `GET /` → 200 no token (index.html, correct Content-Length); API POST → 401 without token, 200 with

## Notes

- Existing dual-server tests used two distinct free ports and now exercise the split path; merged-path tests with matching ports were added so both modes stay covered.
- Combined with #474 (CORS preflights before auth), a browser chat UI on a kdeps API now works with zero external proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
