### PR TITLE
fix: surface validations.check error code and message in HTTP responses

### DIFF
--- a/pkg/domain/errors.go
+++ b/pkg/domain/errors.go
@@ -208,7 +208,7 @@ var appErrorHTTPStatus = map[AppErrorCode]int{ //nolint:gochecknoglobals // look
 	ErrCodeInternal:         http.StatusInternalServerError,
 	ErrCodeDependencyFailed: http.StatusInternalServerError,
 	ErrCodeResourceFailed:   http.StatusInternalServerError,
-	ErrCodePreflightFailed:  http.StatusInternalServerError,
+	ErrCodePreflightFailed:  http.StatusBadRequest,
 	ErrCodeExpressionErr:    http.StatusInternalServerError,
 }
 

--- a/pkg/domain/errors_test.go
+++ b/pkg/domain/errors_test.go
@@ -310,7 +310,7 @@ func TestGetHTTPStatus(t *testing.T) {
 		{domain.ErrCodeServiceUnavail, http.StatusServiceUnavailable},
 		{domain.ErrCodeInternal, http.StatusInternalServerError},
 		{domain.ErrCodeResourceFailed, http.StatusInternalServerError},
-		{domain.ErrCodePreflightFailed, http.StatusInternalServerError},
+		{domain.ErrCodePreflightFailed, http.StatusBadRequest},
 		{domain.ErrCodeExpressionErr, http.StatusInternalServerError},
 		{domain.AppErrorCode("UNKNOWN"), http.StatusInternalServerError},
 	}

--- a/pkg/executor/engine_preflight.go
+++ b/pkg/executor/engine_preflight.go
@@ -39,6 +39,15 @@ func (e *PreflightError) Error() string {
 	return fmt.Sprintf("preflight error (code %d): %s", e.Code, e.Message)
 }
 
+// PreflightStatus returns the configured HTTP status code and client-facing
+// message. The HTTP layer probes for this method via a local interface so the
+// configured validations.error surfaces as the response instead of a generic
+// 500, without coupling infra to the executor package.
+func (e *PreflightError) PreflightStatus() (int, string) {
+	kdeps_debug.Log("enter: PreflightStatus")
+	return e.Code, e.Message
+}
+
 // RunPreflightCheck runs preflight validations.
 func (e *Engine) RunPreflightCheck(resource *domain.Resource, ctx *ExecutionContext) error {
 	kdeps_debug.Log("enter: RunPreflightCheck")

--- a/pkg/executor/engine_preflight_test.go
+++ b/pkg/executor/engine_preflight_test.go
@@ -21,6 +21,7 @@ package executor_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/kdeps/kdeps/v2/pkg/executor"
@@ -29,4 +30,11 @@ import (
 func TestParseAtTime_Invalid(t *testing.T) {
 	_, err := executor.ParseAtTimeForTesting("not-a-time")
 	require.Error(t, err)
+}
+
+func TestPreflightError_PreflightStatus(t *testing.T) {
+	preflight := &executor.PreflightError{Code: 400, Message: "'q' is required"}
+	code, message := preflight.PreflightStatus()
+	assert.Equal(t, 400, code)
+	assert.Equal(t, "'q' is required", message)
 }

--- a/pkg/infra/http/http_error_normalize.go
+++ b/pkg/infra/http/http_error_normalize.go
@@ -55,10 +55,39 @@ func appendDebugAppErrorDetails(
 	return appErr
 }
 
+// preflightStatusError is implemented by executor.PreflightError. Declared
+// locally so the infra layer stays decoupled from the executor package.
+type preflightStatusError interface {
+	error
+	PreflightStatus() (int, string)
+}
+
+const (
+	minHTTPStatus = 100
+	maxHTTPStatus = 599
+)
+
+// preflightAppError maps a failed validations.check to the user-configured
+// error code and message instead of a generic 500.
+func preflightAppError(preflight preflightStatusError) *domain.AppError {
+	status, message := preflight.PreflightStatus()
+	appErr := domain.NewAppError(domain.ErrCodePreflightFailed, message).
+		WithError(preflight)
+	if status >= minHTTPStatus && status <= maxHTTPStatus {
+		appErr.StatusCode = status
+	}
+	return appErr
+}
+
 func normalizeToAppError(err error, debugMode bool) *domain.AppError {
 	var appErr *domain.AppError
 	if errors.As(err, &appErr) {
 		return appErr
+	}
+
+	var preflight preflightStatusError
+	if errors.As(err, &preflight) {
+		return preflightAppError(preflight)
 	}
 
 	appErr = domain.NewAppError(

--- a/pkg/infra/http/http_error_normalize_test.go
+++ b/pkg/infra/http/http_error_normalize_test.go
@@ -9,11 +9,55 @@
 package http
 
 import (
+	"fmt"
+	stdhttp "net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/kdeps/kdeps/v2/pkg/domain"
 )
 
 func TestErrorDetailString_Nil(t *testing.T) {
 	assert.Empty(t, errorDetailString(nil))
+}
+
+// fakePreflightError mirrors executor.PreflightError without importing it.
+type fakePreflightError struct {
+	code    int
+	message string
+}
+
+func (e *fakePreflightError) Error() string {
+	return fmt.Sprintf("preflight error (code %d): %s", e.code, e.message)
+}
+
+func (e *fakePreflightError) PreflightStatus() (int, string) {
+	return e.code, e.message
+}
+
+func TestNormalizeToAppError_PreflightUsesConfiguredCode(t *testing.T) {
+	preflight := &fakePreflightError{code: 400, message: "'q' is required"}
+	wrapped := fmt.Errorf("preflight check failed for llm: %w", preflight)
+
+	appErr := normalizeToAppError(wrapped, false)
+
+	assert.Equal(t, domain.ErrCodePreflightFailed, appErr.Code)
+	assert.Equal(t, stdhttp.StatusBadRequest, appErr.StatusCode)
+	assert.Equal(t, "'q' is required", appErr.Message)
+}
+
+func TestNormalizeToAppError_PreflightInvalidCodeFallsBack(t *testing.T) {
+	for _, code := range []int{0, 99, 600, 9999} {
+		appErr := normalizeToAppError(&fakePreflightError{code: code, message: "bad input"}, false)
+
+		assert.Equal(t, domain.ErrCodePreflightFailed, appErr.Code)
+		assert.Equal(t, domain.GetHTTPStatus(domain.ErrCodePreflightFailed), appErr.StatusCode, "code %d", code)
+		assert.Equal(t, "bad input", appErr.Message)
+	}
+}
+
+func TestNormalizeToAppError_AppErrorTakesPrecedence(t *testing.T) {
+	appErr := normalizeToAppError(domain.NewAppError(domain.ErrCodeNotFound, "missing"), false)
+	assert.Equal(t, domain.ErrCodeNotFound, appErr.Code)
 }


### PR DESCRIPTION
## Problem

A failed `validations.check` with a configured `error: { code: 400, message: "'q' is required" }` was logged correctly but reached the client as:

```json
{"success":false,"error":{"code":"INTERNAL_ERROR","message":"Internal server error"}}   // HTTP 500
```

Clients couldn't distinguish bad input from a server failure, and the configured message never surfaced.

Fixes #471

## Change

- `executor.PreflightError` exposes `PreflightStatus() (int, string)`. The HTTP layer probes for it via a **local interface** in `normalizeToAppError`, so `pkg/infra/http` stays decoupled from `pkg/executor`.
- The configured code becomes the HTTP status (validated to 100–599; out-of-range falls back to the `PREFLIGHT_FAILED` default) and the configured message becomes the response body.
- `ErrCodePreflightFailed` default mapping changed **500 → 400**: a failed input check is a client error, including when no `error:` block is configured.

Response after the fix:

```json
{"success":false,"error":{"code":"PREFLIGHT_FAILED","message":"'q' is required"}}   // HTTP 400
```

## Testing

- `go test ./pkg/infra/http/ ./pkg/domain/ ./pkg/executor/` — 1811 passed
- 100% coverage on `PreflightStatus`, `preflightAppError`, `normalizeToAppError`
- `golangci-lint` — 0 issues
- Live verification with the patched binary against the #471 repro workflow: empty `q` → HTTP 400 with `PREFLIGHT_FAILED` and the configured message; valid request → 200 unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
