### PR TITLE
feat: header injection on webServer app proxy routes

### DIFF
--- a/pkg/domain/workflow_settings.go
+++ b/pkg/domain/workflow_settings.go
@@ -227,6 +227,10 @@ type WebRoute struct {
 	PublicPath string `yaml:"publicPath,omitempty"`
 	AppPort    int    `yaml:"appPort,omitempty"`
 	Command    string `yaml:"command,omitempty"`
+	// Headers are set on proxied requests for app routes. Values support
+	// {{ env('VAR') }} interpolation so secrets stay out of the YAML, e.g.
+	// Authorization: "Bearer {{ env('UPSTREAM_TOKEN') }}".
+	Headers map[string]string `yaml:"headers,omitempty"`
 }
 
 // Resources contains resource limits and requests.

--- a/pkg/infra/http/http_webserver_proxy.go
+++ b/pkg/infra/http/http_webserver_proxy.go
@@ -22,6 +22,8 @@ import (
 	stdhttp "net/http"
 	"net/http/httputil"
 	"net/url"
+	"os"
+	"regexp"
 
 	"github.com/kdeps/kdeps/v2/pkg/domain"
 )
@@ -39,6 +41,7 @@ func newAppReverseProxy(
 			copyQueryString(pr.Out.URL, r.URL)
 			setProxyHost(pr.Out.URL, targetURL)
 			forwardProxyRequestHeaders(pr.Out.Header, r.Header)
+			applyRouteHeaders(pr.Out.Header, route.Headers)
 			logProxyRequest(s.logger, pr.Out.URL.String())
 		},
 		Transport: &stdhttp.Transport{
@@ -52,4 +55,26 @@ func newAppReverseProxy(
 
 func localAppProxyTarget(port int) (*url.URL, error) {
 	return httpURLFromHostPort(localAppProxyHost, port)
+}
+
+// routeHeaderEnvPattern matches {{ env('VAR') }} (single or double quotes)
+// inside webServer route header values.
+var routeHeaderEnvPattern = regexp.MustCompile(
+	`\{\{\s*env\(\s*['"]([A-Za-z_][A-Za-z0-9_]*)['"]\s*\)\s*\}\}`,
+)
+
+// applyRouteHeaders sets configured route headers on the proxied request,
+// overriding any forwarded header of the same name. Values support
+// {{ env('VAR') }} interpolation so secrets stay out of the workflow YAML.
+func applyRouteHeaders(header stdhttp.Header, routeHeaders map[string]string) {
+	for name, value := range routeHeaders {
+		header.Set(name, resolveRouteHeaderValue(value))
+	}
+}
+
+func resolveRouteHeaderValue(value string) string {
+	return routeHeaderEnvPattern.ReplaceAllStringFunc(value, func(match string) string {
+		name := routeHeaderEnvPattern.FindStringSubmatch(match)[1]
+		return os.Getenv(name)
+	})
 }

--- a/pkg/infra/http/webserver_internal_test.go
+++ b/pkg/infra/http/webserver_internal_test.go
@@ -103,3 +103,21 @@ func TestWebServer_HandleWebSocketProxy_HandshakeFailure(t *testing.T) {
 	webServer.HandleWebSocketProxy(rec, req, targetURL, &domain.WebRoute{Path: "/"})
 	assert.Equal(t, stdhttp.StatusBadGateway, rec.Code)
 }
+
+func TestResolveRouteHeaderValue(t *testing.T) {
+	t.Setenv("ROUTE_HDR_TOKEN", "tok-123")
+
+	assert.Equal(t, "plain", resolveRouteHeaderValue("plain"))
+	assert.Equal(t, "Bearer tok-123", resolveRouteHeaderValue("Bearer {{ env('ROUTE_HDR_TOKEN') }}"))
+	assert.Equal(t, "Bearer tok-123", resolveRouteHeaderValue(`Bearer {{env("ROUTE_HDR_TOKEN")}}`))
+	// Unset variables resolve to an empty string, like env() in workflows.
+	assert.Equal(t, "Bearer ", resolveRouteHeaderValue("Bearer {{ env('ROUTE_HDR_UNSET_VAR') }}"))
+	// Other expression forms are left untouched: header values only support env().
+	assert.Equal(t, "{{ get('q') }}", resolveRouteHeaderValue("{{ get('q') }}"))
+}
+
+func TestApplyRouteHeaders_Empty(t *testing.T) {
+	header := stdhttp.Header{}
+	applyRouteHeaders(header, nil)
+	assert.Empty(t, header)
+}

--- a/pkg/infra/http/webserver_test.go
+++ b/pkg/infra/http/webserver_test.go
@@ -1351,6 +1351,57 @@ func TestWebServer_HandleAppRequest_WithBackend(t *testing.T) {
 	})
 }
 
+// TestWebServer_HandleAppRequest_RouteHeaders tests that configured route
+// headers are injected into proxied requests, with env() interpolation, and
+// override same-name headers forwarded from the client.
+func TestWebServer_HandleAppRequest_RouteHeaders(t *testing.T) {
+	t.Setenv("UPSTREAM_TOKEN", "secret-token")
+
+	var recordedHeaders http.Header
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		recordedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, "backend-ok")
+	}))
+	t.Cleanup(backend.Close)
+
+	addr := backend.Listener.Addr().String()
+	_, portStr, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portStr)
+	require.NoError(t, err)
+
+	workflow := &domain.Workflow{
+		Metadata: domain.WorkflowMetadata{Name: "test"},
+		Settings: domain.WorkflowSettings{
+			WebServer: &domain.WebServerConfig{},
+		},
+	}
+	webServer, err := httppkg.NewWebServer(workflow, slog.Default())
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/app/test", nil)
+	req.Header.Set("Authorization", "Bearer client-token")
+
+	route := &domain.WebRoute{
+		Path:       "/app",
+		ServerType: "app",
+		AppPort:    port,
+		Headers: map[string]string{
+			"Authorization": "Bearer {{ env('UPSTREAM_TOKEN') }}",
+			"X-Static":      "fixed-value",
+		},
+	}
+
+	webServer.HandleAppRequest(w, req, route)
+	require.Equal(t, http.StatusOK, w.Code)
+	// Configured headers reach the upstream, env-interpolated, and take
+	// precedence over the same header forwarded from the client.
+	assert.Equal(t, "Bearer secret-token", recordedHeaders.Get("Authorization"))
+	assert.Equal(t, "fixed-value", recordedHeaders.Get("X-Static"))
+}
+
 // TestWebServer_HandleAppRequest_RootPath tests HandleAppRequest with a root route path,
 // covering the route.Path == "/" branch of the Rewrite closure.
 func TestWebServer_HandleAppRequest_RootPathWithBackend(t *testing.T) {


### PR DESCRIPTION
## Problem

`WebRoute` (`serverType: app`) reverse-proxies to `appPort` but cannot set or override headers on proxied requests, so the web proxy can't front upstreams that require auth (API keys, bearer tokens).

Closes #473

## Change

New `headers:` map on web routes, applied in the proxy `Rewrite` after client headers are forwarded:

```yaml
webServer:
  routes:
    - path: /upstream
      serverType: app
      appPort: 9000
      headers:
        Authorization: "Bearer {{ env('UPSTREAM_TOKEN') }}"
        X-Injected: "from-kdeps"
```

- Values support `{{ env('VAR') }}` interpolation (single or double quotes) so secrets stay out of the YAML; unset variables resolve to empty, matching `env()` in workflows. Other expression forms are intentionally not evaluated here.
- Configured headers **override** same-name headers forwarded from the client (so a client can't smuggle its own `Authorization` past the route config).

## Testing

- 787 tests pass (`pkg/infra/http`, `pkg/domain`); `applyRouteHeaders`/`resolveRouteHeaderValue` at 100% coverage; `golangci-lint` 0 issues.
- New proxy integration test asserts the upstream receives the env-interpolated `Authorization` (overriding the client's) and the static header.
- Live verification: kdeps web server proxying to a local echo upstream — client sent `Bearer client-supplied`, upstream received `Bearer super-secret` + `X-Injected: from-kdeps`.

## Scope note

Headers apply to the HTTP reverse proxy path. The WebSocket proxy handshake path is unchanged — can follow up if there's a use case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
