### PR TITLE
fix: serve webServer route bodies verbatim in merged API+Web mode

### DIFF
--- a/pkg/infra/http/http_response_writer.go
+++ b/pkg/infra/http/http_response_writer.go
@@ -30,6 +30,16 @@ type ResponseWriterWrapper struct {
 	stdhttp.ResponseWriter
 	headersWritten bool
 	flusher        stdhttp.Flusher
+	escapeDisabled bool
+}
+
+// DisableHTMLEscape turns off the browser-rendered-content XSS escaping for
+// this response. Web server routes call it: they serve real HTML (static
+// files, proxied apps), where escaping corrupts the body and the length
+// mismatch with the already-written Content-Length truncates the response.
+func (w *ResponseWriterWrapper) DisableHTMLEscape() {
+	debugEnter("DisableHTMLEscape")
+	w.escapeDisabled = true
 }
 
 func (w *ResponseWriterWrapper) WriteHeader(code int) {
@@ -72,6 +82,10 @@ func (w *ResponseWriterWrapper) resolvedContentType(body []byte) string {
 func (w *ResponseWriterWrapper) Write(b []byte) (int, error) {
 	debugEnter("Write")
 	w.markHeadersWritten()
+
+	if w.escapeDisabled {
+		return w.ResponseWriter.Write(b)
+	}
 
 	ct := w.resolvedContentType(b)
 	if !browserRenderedContentType(ct) {

--- a/pkg/infra/http/http_response_writer_test.go
+++ b/pkg/infra/http/http_response_writer_test.go
@@ -183,6 +183,20 @@ func TestResponseWriterWrapper_Write_NonBrowserContent(t *testing.T) {
 	assert.Equal(t, string(data), recorder.Body.String())
 }
 
+func TestResponseWriterWrapper_DisableHTMLEscape(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	recorder.Header().Set("Content-Type", "text/html")
+	wrapper := &http.ResponseWriterWrapper{ResponseWriter: recorder}
+	wrapper.DisableHTMLEscape()
+	data := []byte("<html><body>raw</body></html>")
+	n, err := wrapper.Write(data)
+	assert.NoError(t, err)
+	assert.Equal(t, len(data), n)
+	// Web routes serve real HTML: with escaping disabled the body must pass
+	// through verbatim instead of being entity-encoded.
+	assert.Equal(t, string(data), recorder.Body.String())
+}
+
 func TestBrowserRenderedContentType_AllTypes(t *testing.T) {
 	middleware := http.BodyLimitMiddleware(1 << 20) // just to indirectly verify - we test Write directly
 	_ = middleware

--- a/pkg/infra/http/http_webserver_routes.go
+++ b/pkg/infra/http/http_webserver_routes.go
@@ -34,6 +34,12 @@ func (s *WebServer) dispatchWebRoute(
 	r *stdhttp.Request,
 	route *domain.WebRoute,
 ) {
+	// In merged API+Web mode the API router wraps responses in
+	// ResponseWriterWrapper, whose XSS guard HTML-escapes browser-rendered
+	// bodies. Web routes serve real HTML — disable escaping for them.
+	if wrapper, ok := w.(*ResponseWriterWrapper); ok {
+		wrapper.DisableHTMLEscape()
+	}
 	switch route.ServerType {
 	case serverTypeStatic:
 		s.HandleStaticRequest(w, r, route)

--- a/pkg/infra/http/server_security_test.go
+++ b/pkg/infra/http/server_security_test.go
@@ -23,6 +23,8 @@ import (
 	"log/slog"
 	stdhttp "net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -158,6 +160,10 @@ func TestServer_configureRouter_corsPreflightBypassesAuth(t *testing.T) {
 func TestServer_configureRouter_mergedWebRoutesArePublic(t *testing.T) {
 	t.Setenv("KDEPS_API_AUTH_TOKEN", "secret")
 
+	publicDir := t.TempDir()
+	indexHTML := "<html><body>merged fixture</body></html>"
+	require.NoError(t, os.WriteFile(filepath.Join(publicDir, "index.html"), []byte(indexHTML), 0o644))
+
 	workflow := &domain.Workflow{
 		Metadata: domain.WorkflowMetadata{Name: "test"},
 		Settings: domain.WorkflowSettings{
@@ -165,7 +171,7 @@ func TestServer_configureRouter_mergedWebRoutesArePublic(t *testing.T) {
 				Routes: []domain.Route{{Path: "/api/v1/chat", Methods: []string{"POST"}}},
 			},
 			WebServer: &domain.WebServerConfig{
-				Routes: []domain.WebRoute{{Path: "/", ServerType: "static", PublicPath: t.TempDir()}},
+				Routes: []domain.WebRoute{{Path: "/", ServerType: "static", PublicPath: publicDir}},
 			},
 		},
 	}
@@ -181,7 +187,10 @@ func TestServer_configureRouter_mergedWebRoutesArePublic(t *testing.T) {
 	// routes must load without a token, like webServer-only mode.
 	rec := httptest.NewRecorder()
 	server.Router.ServeHTTP(rec, httptest.NewRequest(stdhttp.MethodGet, "/", nil))
-	assert.NotEqual(t, stdhttp.StatusUnauthorized, rec.Code)
+	assert.Equal(t, stdhttp.StatusOK, rec.Code)
+	// Static HTML must arrive verbatim: the API router's XSS-escape wrapper
+	// must not mangle web-route bodies (escaping also breaks Content-Length).
+	assert.Equal(t, indexHTML, rec.Body.String())
 
 	// API routes stay authenticated even though the "/" web route's
 	// wildcard pattern also matches them.


### PR DESCRIPTION
## Problem

In merged API+Web mode, static HTML served by `webServer` routes reached clients as an **empty body** with correct headers (`200`, right `Content-Length`). In-process, the body was HTML-entity-escaped.

Root cause: the API router wraps responses in `ResponseWriterWrapper`, whose XSS guard escapes browser-rendered content types. Web routes merged onto the API router inherited it — the escaped body exceeds the `Content-Length` already written by `http.ServeContent`, so net/http aborts the write. This surfaced once #475 made merged web routes publicly reachable.

Fixes #479

## Change

- `ResponseWriterWrapper.DisableHTMLEscape()` — opt-out flag checked first in `Write`.
- `dispatchWebRoute` calls it before dispatching to static/app handlers (covers the reverse proxy too). API resource responses keep the existing escaping; webServer-only mode (never wrapped) is unchanged.
- The merged-mode regression test now asserts the **verbatim body**, not just the status — the gap that let this slip past #475.

## Testing

- `go test ./pkg/infra/http/` — 527 passed, package at 100% statement coverage; `golangci-lint` 0 issues.
- Live verification with the patched binary: merged-mode `GET /` returns the exact `index.html` bytes; API routes still 401 without token, 200 with, 400 on failed validation.
- The kdeps-skill fixture suite (94 checks incl. a new api-web smoke) passes against this build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
