### PR TITLE
fix: repair chatgpt-clone example and stale telephony-bot E2E checks

### DIFF
--- a/examples/chatgpt-clone/resources/models.yaml
+++ b/examples/chatgpt-clone/resources/models.yaml
@@ -19,7 +19,3 @@ before:
       {"id": "gemma2:2b", "name": "Gemma 2 (2B)", "description": "Google's lightweight yet powerful model"},
       {"id": "qwen2.5:3b", "name": "Qwen 2.5 (3B)", "description": "Alibaba's model with strong multilingual support"}
     ])
-
-apiResponse:
-  success: true
-  response:

--- a/examples/chatgpt-clone/resources/response.yaml
+++ b/examples/chatgpt-clone/resources/response.yaml
@@ -5,19 +5,23 @@ requires:
     - llmResource
     - modelsResource
 
+# Guard every lookup: on each request one of the two endpoint resources is
+# route-skipped, so its keys do not exist. A bare get() on a missing key
+# aborts the before: chain; default() makes the lookups nil-safe.
 before:
   - "set('isModelsEndpoint', info('method') == 'GET' && info('path') == '/api/v1/models')"
   - "set('isChatEndpoint', info('method') == 'POST' && info('path') == '/api/v1/chat')"
-  - "set('llmResult', get('llmResource'))"
-  - "set('modelsResult', get('modelsResource'))"
+  - "set('llmResult', default(get('llmResource'), false))"
   - "set('hasLLMError', safe(get('llmResult'), 'error') == true)"
-  - "set('messageContent', safe(safe(get('llmResult'), 'message'), 'content'))"
+  - "set('messageContent', default(safe(safe(get('llmResult'), 'message'), 'content'), ''))"
 
 apiResponse:
   success: true
   response:
-    # Return models for models endpoint, chat for chat endpoint
-    message: "{{ get('isChatEndpoint') ? (get('hasLLMError') ? safe(get('llmResult'), 'error') : get('messageContent')) : '' }}"
-    query: "{{ get('isChatEndpoint') ? get('userMessage') : '' }}"
+    # Chat endpoint: the LLM reply (or the onError fallback message).
+    message: "{{ default(get('isChatEndpoint'), false) ? (default(get('hasLLMError'), false) ? safe(get('llmResult'), 'message') : default(get('messageContent'), '')) : '' }}"
+    query: "{{ default(get('isChatEndpoint'), false) ? default(get('userMessage'), '') : '' }}"
+    # Models endpoint: the list assembled by modelsResource.
+    models: "{{ default(get('isModelsEndpoint'), false) ? default(get('availableModels'), []) : [] }}"
   headers:
     Content-Type: application/json

--- a/tests/e2e/test_examples_components.sh
+++ b/tests/e2e/test_examples_components.sh
@@ -284,45 +284,47 @@ fi
 
 _TELE_DIR="$(find_example_dir telephony-bot)"
 TELE_WF="$_TELE_DIR/workflow.yaml"
-TELE_COMP="$_TELE_DIR/components/tts/component.yaml"
 
 if [ ! -f "$TELE_WF" ]; then
     test_skipped "telephony-bot component (workflow.yaml not found)"
 else
-    # Test 31: telephony-bot tts component exists
-    if [ -f "$TELE_COMP" ]; then
-        test_passed "telephony-bot - components/tts/component.yaml exists"
+    # Test 31: workflow validates
+    if "$KDEPS_BIN" validate "$TELE_WF" &> /dev/null; then
+        test_passed "telephony-bot - workflow validation"
     else
-        test_failed "telephony-bot - components/tts/component.yaml exists" "File not found: $TELE_COMP"
+        test_failed "telephony-bot - workflow validation" "kdeps validate failed for $TELE_WF"
     fi
 
-    # Test 32: telephony-bot tts component has kind: Component
-    if grep -q "kind: Component" "$TELE_COMP" 2>/dev/null; then
-        test_passed "telephony-bot - tts component has kind: Component"
+    # Test 32: native telephony IVR routes are declared
+    if grep -q "/twilio/voice" "$TELE_WF" 2>/dev/null && grep -q "/twilio/answer" "$TELE_WF" 2>/dev/null; then
+        test_passed "telephony-bot - declares /twilio IVR routes"
     else
-        test_failed "telephony-bot - tts component has kind: Component" "kind: Component not found in $TELE_COMP"
+        test_failed "telephony-bot - declares /twilio IVR routes" "/twilio routes not found in $TELE_WF"
     fi
 
-    # Test 33: telephony-bot tts component provides ttsResponse action
-    if grep -q "actionId: ttsResponse" "$TELE_COMP" 2>/dev/null; then
-        test_passed "telephony-bot - tts component exports ttsResponse action"
+    # Test 33: one resource per IVR action exists
+    if [ -f "$_TELE_DIR/resources/menu.yaml" ] && \
+       [ -f "$_TELE_DIR/resources/hours.yaml" ] && \
+       [ -f "$_TELE_DIR/resources/ask.yaml" ] && \
+       [ -f "$_TELE_DIR/resources/answer.yaml" ]; then
+        test_passed "telephony-bot - IVR resources exist (menu, hours, ask, answer)"
     else
-        test_failed "telephony-bot - tts component exports ttsResponse action" "actionId: ttsResponse not found in $TELE_COMP"
+        test_failed "telephony-bot - IVR resources exist" "missing resource files in $_TELE_DIR/resources"
     fi
 
-    # Test 34: tts-response.yaml removed (logic in component)
-    if [ ! -f "$_TELE_DIR/resources/tts-response.yaml" ]; then
-        test_passed "telephony-bot - tts-response.yaml removed (moved to component)"
+    # Test 34: answer resource feeds the LLM from the provider webhook
+    if grep -q "SpeechResult" "$_TELE_DIR/resources/answer.yaml" 2>/dev/null; then
+        test_passed "telephony-bot - answer.yaml reads SpeechResult"
     else
-        test_failed "telephony-bot - tts-response.yaml removed (moved to component)" "tts-response.yaml still exists as a resource"
+        test_failed "telephony-bot - answer.yaml reads SpeechResult" "SpeechResult not found in answer.yaml"
     fi
 
-    # Test 35: call-response.yaml still requires ttsResponse (component-provided)
-    CALL_RES="$_TELE_DIR/resources/call-response.yaml"
-    if grep -q "ttsResponse" "$CALL_RES" 2>/dev/null; then
-        test_passed "telephony-bot - call-response.yaml still requires ttsResponse"
+    # Test 35: respond.yaml aggregates the IVR actions
+    RESPOND_RES="$_TELE_DIR/resources/respond.yaml"
+    if grep -q "answerLLM" "$RESPOND_RES" 2>/dev/null; then
+        test_passed "telephony-bot - respond.yaml requires answerLLM"
     else
-        test_failed "telephony-bot - call-response.yaml requires ttsResponse" "ttsResponse not found in $CALL_RES"
+        test_failed "telephony-bot - respond.yaml requires answerLLM" "answerLLM not found in $RESPOND_RES"
     fi
 fi
 


### PR DESCRIPTION
## Problem

The `test` check has been permanently red — the same 6 E2E failures on every CI run:

- `ChatGPT Clone - GET /api/v1/models` / `POST /api/v1/chat` → 500
- 4 × `telephony-bot` structural checks

## Root causes and fixes

**chatgpt-clone — example bug.** `responseResource`'s `before:` chain did bare `get()` lookups of keys owned by whichever endpoint resource was route-skipped for the request. A missing key aborts the rest of the chain, leaving the `apiResponse` ternary conditions nil — interpolation fails (`interface {} is nil, not bool`) and **both** endpoints 500. It passed locally only because stale keys in the developer's persistent `~/.kdeps/memory.db` shadowed the missing values; CI's fresh HOME exposed it. Fixed with `default()`-guarded lookups and nil-safe ternaries. Also removed `models.yaml`'s vestigial truncated `apiResponse:` (its `response:` was empty) and moved the models list into the routed response, restoring `data.models`.

**telephony-bot — stale test.** Tests 31–35 expected a `components/tts` refactor (`ttsResponse` action, `call-response.yaml`) that **never existed in any commit**; the example intentionally uses the native telephony resource. The checks now verify the example's real structure: `kdeps validate`, `/twilio` IVR routes, per-action resources, `SpeechResult` wiring, and `respond.yaml`'s `answerLLM` aggregation.

## Verification (fresh HOME = CI-equivalent)

- `test_examples_chatgpt_clone.sh`: 10/10 pass — including with the chat model absent (`onError` fallback path, matching CI where only `tinydolphin` is pulled).
- `test_examples_components.sh`: all telephony-bot checks pass.
- Full `tests/e2e/e2e.sh`: 946 passed / 3 failed — the 3 are Scraper checks that pass in CI and fail only in my local sandbox (component Python deps); untouched by this diff.

This should turn the `test` job green for the first time in the visible run history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
