### PR TITLE
ci: skip CodeQL on docs-only changes

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,13 +8,13 @@ on:
     branches: [ "main" ]
     paths-ignore:
       - 'docs/**'
-      - 'README.md'
+      - '*.md'
       - '.github/coverage-badge.json'
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - 'docs/**'
-      - 'README.md'
+      - '*.md'
       - '.github/coverage-badge.json'
 
 jobs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,8 +17,16 @@ name: "CodeQL"
 on:
   push:
     branches: ["main"]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - '.github/coverage-badge.json'
   pull_request:
     branches: ["main"]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - '.github/coverage-badge.json'
   schedule:
     - cron: "30 5 * * 1"
 


### PR DESCRIPTION
## Problem

`codeql.yml` has no `paths` filter, so every docs-only PR (e.g. #692, #693,
#695) triggers a full Go autobuild + CodeQL analysis - several minutes of
compute for a change that touches no code.

`build-test.yml` already skips docs changes via `paths-ignore`.

## Change

- Add the same `paths-ignore` to `codeql.yml` (`docs/**`, `*.md`,
  `.github/coverage-badge.json`).
- Broaden `build-test.yml`'s `README.md` entry to `*.md` so a `CONTRIBUTING.md`
  / `SECURITY.md` edit is skipped too.

## Note on required checks

The repo already relies on this pattern for `build-test.yml` and docs PRs merge
fine. If a future docs PR ever sits "waiting" on a skipped CodeQL run, the fix
is a branch-protection tweak (don't require the check for path-filtered runs),
not a workflow revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)