### PR TITLE
fix(m365): Claude agent-loop tool-use fixes (internal tools + shredded answers)

### DIFF
--- a/docs/v2/reference/llm-providers-m365.md
+++ b/docs/v2/reference/llm-providers-m365.md
@@ -71,6 +71,13 @@ Override paths with `M365_CACHE_FILE`, `M365_SECRETS_FILE`, and
 Studio agent unless the resolved model tone is a `Claude_*` tone, in which case
 kdeps stays agent-less to preserve that tone (attaching an agent forces GPT-5).
 
+M365 models (Claude tones especially) have a built-in code interpreter and will
+sometimes use it instead of the fenced kdeps tools - its sandbox is empty, so
+every result comes back blank and the model reports "NO CONTENT AVAILABLE" or
+claims it cannot read files. The system preamble tells the model to use the
+kdeps tools only; if it still slips, reply `use the kdeps tools, not your own`
+and it recovers.
+
 Reasoning-tone models (`think-deeper`, `*-think-deeper`) stream their
 chain-of-thought summary as live reasoning feedback, same as native
 extended-thinking models - visible in the agent-loop REPL automatically

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -2308,19 +2308,25 @@ persistent memory. Check memory before every action; save after every
 turn. This is not optional — it is the core reliability mechanism.
 </internals>`
 
-// m365NoSandboxGuidance tells an M365 Copilot backend model explicitly that it
-// has no bash or code-interpreter tool here, countering the model's own
-// native "run code" habit that otherwise fires regardless of the fenced tool
-// list it was given.
-const m365NoSandboxGuidance = `<no-sandbox>
-This session has no bash, shell, or code-interpreter tool, and no /mnt/data
-or similar sandbox mount. Do not write a bash command, a heredoc, or any
-"Coding and executing" style action -- nothing runs it, and any files or
-paths it reports are not real. The ONLY way to act is a fenced call to one
-of the tools listed above, using the tool's exact name as the fence's
-info-string. If a task needs a capability none of those tools provide, say
-so instead of improvising a shell command.
-</no-sandbox>`
+// m365NoSandboxGuidance tells an M365 Copilot backend model to act through the
+// fenced kdeps tools above and never through its own built-in code interpreter.
+// The model has a native "run code" / "Coding and executing" habit baked in
+// from training that fires regardless of the fenced tool list -- confirmed
+// live: a model ran commands against M365's own empty sandbox at /mnt/data,
+// reported every result as "NO CONTENT AVAILABLE", and concluded it "could not
+// access the filesystem", never once emitting a real fenced tool call.
+const m365NoSandboxGuidance = `<use-kdeps-tools>
+Act ONLY through the fenced kdeps tools listed above -- including bash_exec for
+shell commands. Do NOT use your own built-in code interpreter, "Coding and
+executing" / "Analyzing" action, python tool, or any /mnt/data sandbox: that
+is a different, empty machine. Its output ("no content available", empty
+directory listings, "file not found") says nothing about the real working
+directory, which is a live filesystem with the files named in the task
+present right now. To run a shell command, emit a fenced bash_exec call and
+read the real result from its <tool_response>. If your last few tool results
+looked empty or you feel you "cannot access" anything, you are running your
+internal tools by mistake -- switch to a fenced kdeps tool call and try again.
+</use-kdeps-tools>`
 
 // InvalidateSystemPreamble forces the next turn to rebuild the system preamble.
 // Call after a runtime change that the preamble embeds (model switch, which

--- a/pkg/agent/system_preamble_test.go
+++ b/pkg/agent/system_preamble_test.go
@@ -136,13 +136,13 @@ func TestCachedSystemPreamble_NoSandboxGuidanceOnlyForM365(t *testing.T) {
 
 	m365Loop := &Loop{registry: reg, config: Config{Backend: backendM365}}
 	out := m365Loop.cachedSystemPreamble("focus")
-	if !strings.Contains(out, "no bash, shell, or code-interpreter tool") {
+	if !strings.Contains(out, "<use-kdeps-tools>") || !strings.Contains(out, "your own built-in code interpreter") {
 		t.Errorf("m365 backend should get the no-sandbox guidance:\n%s", out)
 	}
 
 	otherLoop := &Loop{registry: reg, config: Config{Backend: "openai"}}
 	out = otherLoop.cachedSystemPreamble("focus")
-	if strings.Contains(out, "no bash, shell, or code-interpreter tool") {
+	if strings.Contains(out, "<use-kdeps-tools>") {
 		t.Errorf("non-m365 backend must not get the m365-specific no-sandbox guidance:\n%s", out)
 	}
 }

--- a/pkg/executor/llm/m365/m365_test.go
+++ b/pkg/executor/llm/m365/m365_test.go
@@ -2125,3 +2125,40 @@ func TestGetEnvironmentURLHTTPError(t *testing.T) {
 		t.Error("want error on non-2xx BAP status")
 	}
 }
+
+func TestResolveProseAlongsideCalls(t *testing.T) {
+	longProse := "## Recommendation for New Dashboard\n\n" + strings.Repeat(
+		"These features should be core requirements in the new dashboard. ",
+		6,
+	)
+	oneCall := []ParsedToolCall{{Name: "read_file"}}
+
+	// Long leftover next to a call: the model wrote a document that quotes
+	// tool syntax, so keep the whole reply and drop the call.
+	got := resolveProseAlongsideCalls(
+		ParseResult{HasToolCalls: true, ToolCalls: oneCall, TextContent: longProse},
+		"FULL REPLY TEXT",
+	)
+	if got.HasToolCalls {
+		t.Fatal("long leftover should be treated as prose, not calls")
+	}
+	if got.TextContent != "FULL REPLY TEXT" {
+		t.Fatalf("should restore the full reply text, got %q", got.TextContent)
+	}
+
+	// Short stray leftover: drop it, keep the call (original fail-closed).
+	got = resolveProseAlongsideCalls(
+		ParseResult{HasToolCalls: true, ToolCalls: oneCall, TextContent: "ok let me check"},
+		"FULL",
+	)
+	if !got.HasToolCalls || got.TextContent != "" {
+		t.Fatalf("short leftover should be dropped and the call kept, got %+v", got)
+	}
+
+	// No calls: pass through unchanged.
+	in := ParseResult{HasToolCalls: false, TextContent: "just an answer"}
+	if out := resolveProseAlongsideCalls(in, "x"); out.HasToolCalls ||
+		out.TextContent != "just an answer" {
+		t.Fatalf("no-calls result must pass through unchanged, got %+v", out)
+	}
+}

--- a/pkg/executor/llm/m365/server.go
+++ b/pkg/executor/llm/m365/server.go
@@ -546,10 +546,7 @@ func (c *completion) produce(ctx context.Context, onDelta func(string)) *produce
 		parsed = ParseResult{HasToolCalls: false, TextContent: fullText}
 	}
 
-	// Fail-closed: strip stray prose emitted alongside tool calls.
-	if parsed.HasToolCalls && strings.TrimSpace(parsed.TextContent) != "" {
-		parsed.TextContent = ""
-	}
+	parsed = resolveProseAlongsideCalls(parsed, fullText)
 
 	if parsed.HasToolCalls {
 		if p := finalizeToolCalls(&parsed, fullText); p != nil {
@@ -607,6 +604,30 @@ func (c *completion) toneFallback(
 	c.conv.sentMessageCount = len(c.body.Messages)
 	fallbackParsed := ParseToolCalls(retryText, c.body.Tools)
 	return retryText, &fallbackParsed, nil
+}
+
+// resolveProseAlongsideCalls decides what a reply that carries BOTH tool calls
+// and leftover prose really is.
+//
+//   - short leftover  -> stray noise emitted next to a real call; drop the text
+//     (fail-closed, the original behaviour).
+//   - long leftover   -> a written answer that merely quotes <invoke> syntax as
+//     an example; the "calls" are illustrations, not an action turn. Keep the
+//     whole reply as text and drop the calls.
+//
+// IsProseDocument already covers the multi-invoke document case; this catches
+// the single-invoke one. Confirmed live on m365: a ~1.8k-token markdown
+// recommendation with one embedded invoke example was reduced to a bogus
+// read_file call plus three scrap lines of leftover.
+func resolveProseAlongsideCalls(parsed ParseResult, fullText string) ParseResult {
+	if !parsed.HasToolCalls || strings.TrimSpace(parsed.TextContent) == "" {
+		return parsed
+	}
+	if len(strings.TrimSpace(parsed.TextContent)) >= proseDocMinChars {
+		return ParseResult{HasToolCalls: false, TextContent: fullText}
+	}
+	parsed.TextContent = ""
+	return parsed
 }
 
 // finalizeToolCalls converts a synthetic reply() call back to plain text and

--- a/pkg/executor/llm/toolguard/guard.go
+++ b/pkg/executor/llm/toolguard/guard.go
@@ -28,6 +28,16 @@ var confabulationPatterns = compileAll([]string{
 	`(?i)(?:file|directory|folder|it)\s+(?:appears?|seems?|looks?)\s+(?:to\s+be\s+)?empty`,
 	`(?i)nothing\s+to\s+(?:simplify|fix|do|change|show|read)`,
 	`(?i)(?:tool|command|it)\s+returned\s+(?:no|empty|nothing)`,
+	// Relapse phrasings where the model blames the environment for empty tool
+	// results instead of retrying (confirmed live on the m365 backend with a
+	// Claude tone: every bash_exec reported as returning "NO CONTENT
+	// AVAILABLE"). None of the patterns above match these.
+	`(?i)no\s+content\s+available`,
+	`(?i)(?:prevent(?:s|ing|ed)?|blocking|blocked)\s+me\s+from\s+(?:accessing|reading|examining|running|executing)`,
+	`(?i)(?:infrastructure|execution\s+environment|environment)\s+(?:problem|issue|failure|is\s+not\s+functioning|not\s+working)`,
+	`(?i)\bsystem\s+(?:failure|is\s+(?:broken|down)|malfunction)`,
+	`(?i)requires?\s+(?:resolution|intervention|a\s+fix)\s+at\s+the\s+system\s+level`,
+	`(?i)cannot\s+complete\s+the\s+task\s+without\s+(?:working\s+)?(?:tool\s+access|the\s+ability)`,
 })
 
 //nolint:gochecknoglobals // compiled pattern set, read-only

--- a/pkg/executor/llm/toolguard/guard_test.go
+++ b/pkg/executor/llm/toolguard/guard_test.go
@@ -18,6 +18,29 @@ func TestLooksLikeConfabulation(t *testing.T) {
 	}
 }
 
+// Relapse phrasings from the m365 backend where the model blames the
+// environment for empty tool results instead of retrying with a real fenced
+// tool call. Each must be caught so the confab-retry loop forces another turn.
+func TestLooksLikeConfabulation_M365EnvironmentBlame(t *testing.T) {
+	cases := []string{
+		`All bash_exec calls are returning "NO CONTENT AVAILABLE" regardless of command.`,
+		"This appears to be an infrastructure problem preventing me from accessing the filesystem.",
+		"The issue requires resolution at the system level before I can proceed.",
+		"There is a critical system failure: all bash_exec calls return nothing.",
+		"The execution environment is not functioning properly.",
+		"I cannot complete the task without working tool access.",
+	}
+	for _, c := range cases {
+		if !LooksLikeConfabulation(c) {
+			t.Errorf("should detect m365 environment-blame confabulation: %q", c)
+		}
+	}
+	// A genuine final answer that merely mentions the word "system" must not trip.
+	if LooksLikeConfabulation("The system prompt controls the assistant's behavior on every turn.") {
+		t.Error("false positive on a normal sentence mentioning 'system'")
+	}
+}
+
 func TestLooksLikeHallucinatedCompletion(t *testing.T) {
 	if !LooksLikeHallucinatedCompletion("I've created the file and updated the README") {
 		t.Error("should detect hallucination")


### PR DESCRIPTION
Two related m365-fenced-protocol bugs in the agent loop, both reported live with
`claude-sonnet`.

## 1. Model uses its own tools instead of kdeps' (#700)

A Claude-tone model defaults to its built-in code interpreter (`/mnt/data`)
instead of the fenced kdeps tools. That sandbox is empty -> every call returns
nothing -> the model reports `NO CONTENT AVAILABLE`, says it "cannot access the
filesystem", and gives up. Prompting "use the kdeps tools, not your own" fixes
it instantly.

- `m365NoSandboxGuidance` (`pkg/agent/loop.go`) rewritten: it no longer falsely
  claims there is no shell tool (bash_exec IS registered); it tells the model
  to act only through fenced kdeps tools, never its internal interpreter, and
  that empty-looking results mean it is calling the wrong tools.
- `toolguard`: the give-up phrasings now match the confabulation patterns so
  the m365 confab-retry loop forces another turn.

## 2. Prose answers shredded into bogus tool calls (#701)

When a fenced reply carried both a tool call and leftover prose, the server
blanked the prose unconditionally. A 1.8k-token markdown recommendation that
merely *quoted* `<invoke>` syntax as an example was reduced to a bogus
`read_file` call ("file_path is required") plus three scrap lines - all the
user saw.

- `resolveProseAlongsideCalls` (`pkg/executor/llm/m365/server.go`): a
  substantial leftover means the "calls" are illustrations - keep the whole
  reply as text; only a short stray leftover is still dropped.

## Testing

`make lint` clean for the changed code. 2389 tests pass across `pkg/agent`,
`pkg/executor/llm/m365`, `pkg/executor/llm/toolguard`. New tests:
`TestResolveProseAlongsideCalls`, `TestLooksLikeConfabulation_M365EnvironmentBlame`.

Closes #700. Closes #701.

🤖 Generated with [Claude Code](https://claude.com/claude-code)