### PR TITLE
feat(agent): KDEPS.md instruction file, highest priority

### DIFF
--- a/docs/v2/modes/agent-loop-mode.md
+++ b/docs/v2/modes/agent-loop-mode.md
@@ -265,8 +265,14 @@ Place templates in `~/.kdeps/prompts/` or `./.kdeps/prompts/`. Templates use the
 
 The agent automatically discovers instruction files by walking up the directory tree from CWD:
 
-- `CLAUDE.md`, `CLAUDE.local.md` at any ancestor directory
-- `.kdeps/CLAUDE.md`, `.kdeps/instructions.md` at any ancestor directory
+- `KDEPS.md`, `KDEPS.local.md` at any ancestor directory
+- `CLAUDE.md`, `CLAUDE.local.md`, `AGENTS.md`, `GEMINI.md` at any ancestor directory
+- `.kdeps/KDEPS.md`, `.kdeps/CLAUDE.md`, `.kdeps/instructions.md` at any ancestor directory
+
+`KDEPS.md` is kdeps' own instruction file and takes the highest priority: it is
+discovered first, keeps its full character budget, and the agent is told that
+`KDEPS.md` wins any conflict with `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, or the
+rest.
 
 Duplicate content (by hash) is deduplicated. Total injected context is capped at ~12 KB. Instructions are injected into the system prompt at startup.
 

--- a/pkg/agent/instructions.go
+++ b/pkg/agent/instructions.go
@@ -42,9 +42,14 @@ type instructionFile struct {
 }
 
 // discoverInstructions walks up from startDir to the filesystem root,
-// collecting AI instruction files (CLAUDE.md, AGENTS.md, GEMINI.md,
-// COPILOT.md, CURSOR.md, CODEX.md, .cursorrules, .kdeps/CLAUDE.md,
-// .kdeps/instructions.md, .github/copilot-instructions.md).
+// collecting AI instruction files (KDEPS.md, CLAUDE.md, AGENTS.md, GEMINI.md,
+// COPILOT.md, CURSOR.md, CODEX.md, .cursorrules, .kdeps/KDEPS.md,
+// .kdeps/CLAUDE.md, .kdeps/instructions.md, .github/copilot-instructions.md).
+//
+// KDEPS.md is kdeps' own instruction file and comes first: it is discovered
+// before the others, keeps its full character budget, and formatInstructions
+// prepends a note telling the model KDEPS.md wins any conflict.
+//
 // Files are deduplicated by content hash and capped at maxTotalChars total.
 //
 //nolint:gocognit // complexity comes from walking ancestor chain with 4 file candidates
@@ -58,6 +63,8 @@ func discoverInstructions(startDir string) string {
 	}
 
 	candidates := []string{
+		"KDEPS.md",
+		"KDEPS.local.md",
 		"CLAUDE.md",
 		"CLAUDE.local.md",
 		"AGENTS.md",
@@ -67,6 +74,7 @@ func discoverInstructions(startDir string) string {
 		"CODEX.md",
 		".cursorrules",
 		filepath.Join(".github", "copilot-instructions.md"),
+		filepath.Join(".kdeps", "KDEPS.md"),
 		filepath.Join(".kdeps", "CLAUDE.md"),
 		filepath.Join(".kdeps", "instructions.md"),
 	}
@@ -131,8 +139,24 @@ func discoverInstructions(startDir string) string {
 	return formatInstructions(files)
 }
 
+// kdepsInstructionFile reports whether name is one of kdeps' own instruction
+// files (KDEPS.md, KDEPS.local.md, or .kdeps/KDEPS.md).
+func kdepsInstructionFile(name string) bool {
+	base := filepath.Base(name)
+	return base == "KDEPS.md" || base == "KDEPS.local.md"
+}
+
 func formatInstructions(files []instructionFile) string {
 	var sb strings.Builder
+	for _, f := range files {
+		if kdepsInstructionFile(f.Name) {
+			sb.WriteString(
+				"When these project instruction files conflict, KDEPS.md takes " +
+					"priority over CLAUDE.md, AGENTS.md, GEMINI.md, and the rest.\n\n",
+			)
+			break
+		}
+	}
 	for _, f := range files {
 		fmt.Fprintf(&sb, "## %s (scope: %s)\n\n%s\n\n", f.Name, f.Path, f.Content)
 	}

--- a/pkg/agent/instructions_test.go
+++ b/pkg/agent/instructions_test.go
@@ -155,3 +155,43 @@ func TestDiscoverInstructions_TruncatesAtMaxTotal(t *testing.T) {
 		t.Fatalf("expected result to reach max capacity, got len=%d", len(result))
 	}
 }
+
+func TestDiscoverInstructions_KDEPSmdWinsPriority(t *testing.T) {
+	dir := t.TempDir()
+	for name, body := range map[string]string{
+		"KDEPS.md":  "# kdeps rules\n\nAlways use kdeps tools.",
+		"CLAUDE.md": "# claude rules\n\nsomething else",
+		"AGENTS.md": "# agents rules\n\nyet another",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	out := discoverInstructions(dir)
+
+	// Precedence note is present.
+	if !strings.Contains(out, "KDEPS.md takes priority over CLAUDE.md") {
+		t.Fatalf("missing precedence note:\n%s", out)
+	}
+	// KDEPS.md section comes before CLAUDE.md and AGENTS.md.
+	kdepsIdx := strings.Index(out, "## KDEPS.md")
+	claudeIdx := strings.Index(out, "## CLAUDE.md")
+	agentsIdx := strings.Index(out, "## AGENTS.md")
+	if kdepsIdx < 0 || claudeIdx < 0 || agentsIdx < 0 {
+		t.Fatalf("all three sections should be present:\n%s", out)
+	}
+	if kdepsIdx > claudeIdx || kdepsIdx > agentsIdx {
+		t.Fatalf("KDEPS.md must come first: k=%d c=%d a=%d", kdepsIdx, claudeIdx, agentsIdx)
+	}
+}
+
+func TestDiscoverInstructions_NoKDEPSmdNoNote(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "CLAUDE.md"), []byte("# c"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(discoverInstructions(dir), "takes priority over") {
+		t.Fatal("no KDEPS.md present -> no precedence note")
+	}
+}


### PR DESCRIPTION
## What

`KDEPS.md` is now a recognized project instruction file for the agent loop, and
it outranks `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, and the rest.

On start the agent walks up from the working directory collecting instruction
files. This PR:

- adds `KDEPS.md`, `KDEPS.local.md`, and `.kdeps/KDEPS.md` to the candidate list,
  at the **front** - discovered first, so `KDEPS.md` gets its full character
  budget before the ~12 KB total cap;
- when any `KDEPS.md` is present, `formatInstructions` prepends:
  *"When these project instruction files conflict, KDEPS.md takes priority over
  CLAUDE.md, AGENTS.md, GEMINI.md, and the rest."* - so precedence is explicit,
  not dependent on the model's positional bias.

## Tests

`TestDiscoverInstructions_KDEPSmdWinsPriority` (note present, KDEPS.md section
first), `TestDiscoverInstructions_NoKDEPSmdNoNote`. 2206 `pkg/agent` tests pass;
`make lint` clean for the changed code.

## Docs

`docs/v2/modes/agent-loop-mode.md` instruction-discovery section updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)