### PR TITLE
docs: tighten hero tagline and feature cards

### DIFF
--- a/docs/v2/.vitepress/theme/FooterCTAs.vue
+++ b/docs/v2/.vitepress/theme/FooterCTAs.vue
@@ -8,8 +8,20 @@ const { frontmatter } = useData()
 </script>
 
 <template>
-  <div v-if="frontmatter.layout === 'home'" class="footer-ctas">
-    <a class="primary" href="/getting-started/installation">Get Started</a>
-    <a class="secondary" href="https://github.com/kdeps/kdeps" target="_blank">Star on GitHub</a>
+  <div v-if="frontmatter.layout === 'home'">
+    <div class="footer-ctas">
+      <a class="primary" href="/getting-started/installation">Get Started</a>
+      <a class="secondary" href="https://github.com/kdeps/kdeps" target="_blank">Star on GitHub</a>
+    </div>
+    <p class="footer-note">Proud member of the NVIDIA Inception program.</p>
   </div>
 </template>
+
+<style scoped>
+.footer-note {
+  text-align: center;
+  font-size: 12px;
+  color: var(--vp-c-text-3);
+  margin: 0 0 40px;
+}
+</style>

--- a/docs/v2/index.md
+++ b/docs/v2/index.md
@@ -20,15 +20,15 @@ hero:
 
 features:
   - title: Local AI agent
-    details: Run `kdeps` and you are in an AI REPL. Use Ollama or llamafile for a fully offline, private coding agent - no API key, no cloud dependency.
+    details: Run `kdeps` and you are in an AI REPL - an autonomous agent with tool use and memory that works fully offline against a local model.
   - title: Deterministic workflows
     details: Each resource declares its dependencies and runs in a fixed DAG order. Same input, same execution path - auditable, testable, safe to run unattended.
   - title: Multi-agent agencies
     details: One agent calls another declaratively via the agent resource type. Compose agents like functions - each runs independently, results flow back.
   - title: Any LLM backend
-    details: llamafile and Ollama work with no server install or API key. Or use OpenAI, Anthropic, Groq, and any OpenAI-compatible endpoint. Auto-router picks the best installed model with cloud fallback.
+    details: Switch backends with one line. llamafile and Ollama need no server install or API key; OpenAI, Anthropic, Groq, and any OpenAI-compatible endpoint work too. Auto-router picks the best installed model with cloud fallback.
   - title: Deploy anywhere
-    details: Export the workflow you tested locally as a Docker image, Kubernetes manifests, bootable ISO, or a single binary. Same file, no rewrites. Apache 2.0, standard YAML in a git repo.
+    details: Export the workflow you tested locally as a Docker image, Kubernetes manifests, a bootable ISO, or a single binary. Same file, no rewrites, no re-config.
   - title: Build with AI assistance
     details: Install the kdeps skill and ask Claude Code, Cursor, or any coding agent to scaffold workflows, components, and agencies. It knows the full schema.
 ---

--- a/docs/v2/index.md
+++ b/docs/v2/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: kdeps
   text: Run AI workflows locally. Or deploy them anywhere.
-  tagline: Install kdeps, run `kdeps`, get an AI agent - no API key needed with Ollama or llamafile. Build your workflow in YAML. Deploy as Docker, Kubernetes, or a single binary when you're ready. Proud member of the NVIDIA Inception program.
+  tagline: Describe your AI agent in YAML instead of wiring up an LLM SDK, a web server, retry logic, and a Dockerfile.
   announcement: Skills for AI agents are here
   announcementLink: /getting-started/agent-skills
   actions:


### PR DESCRIPTION
## Summary

Two `/ghost-rewrite` passes on `docs/v2/index.md`.

**hero.tagline** (55 -> 19 words): was a 4-sentence paragraph under the headline that restated `hero.text` and duplicated the feature cards ("no API key... Ollama or llamafile", "Deploy as Docker, Kubernetes, or a single binary") and ended on the NVIDIA Inception badge in the reader's last-read position.
- Tagline -> one line, the differentiator: *"Describe your AI agent in YAML instead of wiring up an LLM SDK, a web server, retry logic, and a Dockerfile."*
- NVIDIA Inception -> a small footer note on the home page (`FooterCTAs.vue`).

**feature cards**: "Local AI agent" and "Any LLM backend" both opened on "Ollama/llamafile, no API key".
- Card 1 leads on the REPL/agent experience; Card 4 owns provider choice ("Switch backends with one line").
- Card 5 ("Deploy anywhere") drops its unrelated tail (Apache 2.0 is already in the page footer).

## Tests

`npm run build` passes on both commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)