### PR TITLE
docs: adopt "AI Appliance Builder" as the headline

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Registry](https://img.shields.io/badge/registry-kdeps.io-00E5FF)](https://kdeps.io)
 [![GitHub stars](https://img.shields.io/github/stars/kdeps/kdeps)](https://github.com/kdeps/kdeps/stargazers)
 
-Build and deploy AI agents in YAML. Instead of a Python script wiring together an LLM SDK, a web framework, retry logic, and a Dockerfile, you write one `workflow.yaml` and `kdeps` runs it - locally, or as a Docker image, Kubernetes deployment, or single binary. Git-native: everything lives in versionable YAML you commit to your repo like any other code.
+**AI Appliance Builder** - YAML-defined AI agents and workflow pipelines. Ship as Docker, K8s, ISO, or a single binary. You write one `workflow.yaml` instead of a Python script wiring together an LLM SDK, a web server, retry logic, and a Dockerfile; everything lives in versionable YAML you commit to your repo like any other code.
 
 ## Quickstart
 

--- a/docs/v2/.vitepress/config.ts
+++ b/docs/v2/.vitepress/config.ts
@@ -26,7 +26,7 @@ import pkg from '../package.json' with { type: 'json' }
 
 export default defineConfig({
   title: 'KDeps',
-  description: 'AI agents in YAML. Orchestrate LLMs, databases, and APIs without glue code.',
+  description: 'AI Appliance Builder - YAML-defined AI agents and workflow pipelines. Ship as Docker, K8s, ISO, or a single binary.',
 
   appearance: 'force-dark',
 
@@ -38,8 +38,8 @@ export default defineConfig({
     ['meta', { name: 'theme-color', content: '#080808' }],
     ['meta', { name: 'og:type', content: 'website' }],
     ['meta', { name: 'og:site_name', content: 'KDeps Documentation' }],
-    ['meta', { name: 'og:title', content: 'KDeps - AI Agent Framework' }],
-    ['meta', { name: 'og:description', content: 'AI agents in YAML. Orchestrate LLMs, databases, and APIs without glue code.' }],
+    ['meta', { name: 'og:title', content: 'kdeps - AI Appliance Builder' }],
+    ['meta', { name: 'og:description', content: 'AI Appliance Builder - YAML-defined AI agents and workflow pipelines. Ship as Docker, K8s, ISO, or a single binary.' }],
   ],
 
   lastUpdated: true,

--- a/docs/v2/index.md
+++ b/docs/v2/index.md
@@ -3,8 +3,8 @@ layout: home
 
 hero:
   name: kdeps
-  text: Run AI workflows locally. Or deploy them anywhere.
-  tagline: Describe your AI agent in YAML instead of wiring up an LLM SDK, a web server, retry logic, and a Dockerfile.
+  text: AI Appliance Builder
+  tagline: YAML-defined AI agents and workflow pipelines. Ship as Docker, K8s, ISO, or a single binary.
   announcement: Skills for AI agents are here
   announcementLink: /getting-started/agent-skills
   actions:


### PR DESCRIPTION
Leads with the appliance identity, grounded immediately by the explainer:

> **AI Appliance Builder** - YAML-defined AI agents and workflow pipelines. Ship as Docker, K8s, ISO, or a single binary.

## Changed
- `README.md` - pitch line
- `docs/v2/index.md` - hero `text` + `tagline`
- `docs/v2/.vitepress/config.ts` - site `description`, `og:title` (`kdeps - AI Appliance Builder`), `og:description`
- GitHub repo description (set via `gh repo edit`)

Fixed the mixed dash / K8s inconsistency from the draft (ASCII hyphens throughout).

`npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)