### PR TITLE
docs: replace the landing-page code + "What you can build" examples

### DIFF
--- a/docs/v2/.vitepress/theme/HeroCode.vue
+++ b/docs/v2/.vitepress/theme/HeroCode.vue
@@ -19,24 +19,21 @@ const R = (v) => `<span class="re">${v}</span>`
 
 const files = [
   {
-    name: 'local agent',
+    name: 'agent REPL',
     html: [
       `${P('$')} kdeps`,
       ``,
-      `${D('kdeps v2.x.x  |  Local agent mode')}`,
-      `${D('Model: llama3.2 (Ollama)  |  Type /help for commands')}`,
+      `${D('kdeps v2.x  |  agent loop')}`,
+      `${D('Model: llama3.2 (llamafile, offline)  |  /help for commands')}`,
       ``,
-      `${T('>')} write a Go function that parses a CSV file`,
+      `${T('>')} find the failing tests in ./api and suggest a fix`,
       ``,
-      `${R('Sure. Here\'s an idiomatic Go CSV parser...')}`,
+      `${R('Ran go test ./api/... - 2 failures in handler_test.go.')}`,
+      `${R('Both assert 200, but the router now returns 204 for an')}`,
+      `${R('empty body. Update the expected status on lines 41 and 58.')}`,
       ``,
-      `${R('func ParseCSV(r io.Reader) ([][]string, error) {')}`,
-      `${R('    reader := csv.NewReader(r)')}`,
-      `${R('    return reader.ReadAll()')}`,
-      `${R('}')}`,
-      ``,
-      `${T('>')} /model claude-opus-4-8`,
-      `${D('Switched to claude-opus-4-8 (Anthropic)')}`,
+      `${T('>')} /model claude-sonnet`,
+      `${D('Switched to claude-sonnet (Anthropic)')}`,
       ``,
       `${T('>')}`,
     ].join('\n'),
@@ -48,39 +45,45 @@ const files = [
       `${K('kind')}${O(': ')}${S('Workflow')}`,
       ``,
       `${K('metadata')}${O(':')}`,
-      `  ${K('name')}${O(': ')}${S('summarizer')}`,
+      `  ${K('name')}${O(': ')}${S('chat-api')}`,
       `  ${K('version')}${O(': ')}${S('"1.0.0"')}`,
-      `  ${K('targetActionId')}${O(': ')}${S('summarize')}`,
+      `  ${K('targetActionId')}${O(': ')}${S('reply')}   ${D('# its output is the HTTP response')}`,
       ``,
       `${K('settings')}${O(':')}`,
       `  ${K('apiServer')}${O(':')}`,
       `    ${K('portNum')}${O(': ')}${N('16395')}`,
       `    ${K('routes')}${O(':')}`,
-      `      ${O('- ')}${K('path')}${O(': ')}${S('/summarize')}`,
+      `      ${O('- ')}${K('path')}${O(': ')}${S('/api/v1/chat')}`,
       `        ${K('methods')}${O(': ')}${S('[POST]')}`,
     ].join('\n'),
   },
   {
-    name: 'resources/fetch.yaml',
+    name: 'resources/chat.yaml',
     html: [
-      `${K('actionId')}${O(': ')}${S('fetch')}`,
-      `${K('httpClient')}${O(':')}`,
-      `  ${K('method')}${O(': ')}${S('GET')}`,
-      `  ${K('url')}${O(': ')}${S('"{{ get(\'url\') }}"')}`,
-      `  ${K('timeout')}${O(': ')}${S('10s')}`,
-      '', '', '', '', '', '', '', '',
+      `${K('actionId')}${O(': ')}${S('chat')}`,
+      `${K('name')}${O(': ')}${S('LLM Chat')}`,
+      `${K('validations')}${O(':')}`,
+      `  ${K('check')}${O(':')}`,
+      `    ${O('- ')}${S('get(\'q\') != \'\'')}       ${D('# 400 if the body has no "q"')}`,
+      `  ${K('error')}${O(':')}`,
+      `    ${K('code')}${O(': ')}${N('400')}`,
+      `    ${K('message')}${O(': ')}${S('"\'q\' is required"')}`,
+      `${K('chat')}${O(':')}`,
+      `  ${K('model')}${O(': ')}${S('llama3.2:1b')}     ${D('# local, no API key')}`,
+      `  ${K('prompt')}${O(': ')}${S('"{{ get(\'q\') }}"')}`,
+      `  ${K('timeout')}${O(': ')}${S('60s')}`,
     ].join('\n'),
   },
   {
-    name: 'resources/summarize.yaml',
+    name: 'resources/reply.yaml',
     html: [
-      `${K('actionId')}${O(': ')}${S('summarize')}`,
-      `${K('requires')}${O(': ')}${S('[fetch]')}`,
-      `${K('chat')}${O(':')}`,
-      `  ${K('model')}${O(': ')}${S('llama3.2:1b')}`,
-      `  ${K('prompt')}${O(': ')}${S('"Summarize: {{ output(\'fetch\').body }}"')}`,
+      `${K('actionId')}${O(': ')}${S('reply')}`,
+      `${K('name')}${O(': ')}${S('API Response')}`,
+      `${K('requires')}${O(': ')}${S('[chat]')}       ${D('# runs after chat')}`,
       `${K('apiResponse')}${O(':')}`,
-      `  ${K('response')}${O(': ')}${S('"{{ output(\'summarize\') }}"')}`,
+      `  ${K('success')}${O(': ')}${S('true')}`,
+      `  ${K('response')}${O(':')}`,
+      `    ${K('answer')}${O(': ')}${S('get(\'chat\').message.content')}`,
       '', '', '', '', '', '',
     ].join('\n'),
   },
@@ -109,15 +112,14 @@ const files = [
 
         <div class="terminal">
           <div class="tl"><span class="p">$</span><span class="c">export KDEPS_API_AUTH_TOKEN=dev-token</span></div>
-          <div class="tl"><span class="p">$</span><span class="c">kdeps run workflow.yaml</span></div>
+          <div class="tl"><span class="p">$</span><span class="c">kdeps run .</span></div>
           <div class="tl dim">Listening on :16395</div>
           <div class="tl">&nbsp;</div>
-          <div class="tl"><span class="p">$</span><span class="c">curl -s -X POST localhost:16395/summarize \</span></div>
+          <div class="tl"><span class="p">$</span><span class="c">curl -s -X POST localhost:16395/api/v1/chat \</span></div>
           <div class="tl"><span class="pad"></span><span class="c dim">-H "Authorization: Bearer $KDEPS_API_AUTH_TOKEN" \</span></div>
-          <div class="tl"><span class="pad"></span><span class="c dim">-H "Content-Type: application/json" \</span></div>
-          <div class="tl"><span class="pad"></span><span class="c dim">-d '{"url": "https://example.com"}'</span></div>
+          <div class="tl"><span class="pad"></span><span class="c dim">-d '{"q": "What is entropy, in one sentence?"}'</span></div>
           <div class="tl">&nbsp;</div>
-          <div class="tl resp">{"success": true, "data": {"response": "Example.com is used for illustrative examples in documentation."}}</div>
+          <div class="tl resp">{"success": true, "data": {"answer": "Entropy measures how many microscopic arrangements are consistent with a system's macroscopic state."}}</div>
         </div>
       </div>
     </div>

--- a/docs/v2/.vitepress/theme/HomeUseCases.vue
+++ b/docs/v2/.vitepress/theme/HomeUseCases.vue
@@ -7,36 +7,42 @@
     <div class="container">
       <p class="section-eyebrow">examples</p>
       <h2 class="section-title">What you can build</h2>
-      <p class="section-sub">Real patterns from the examples directory. Every one is a working workflow.</p>
+      <p class="section-sub">Every card links to a working project in the examples directory.</p>
 
       <div class="cards">
-        <a href="/examples/showcase" class="card">
-          <h3>REST API</h3>
-          <p>POST a JSON body, run a DAG pipeline, get structured JSON back. The default pattern for workflow mode.</p>
-          <span class="mode-tag">workflow mode</span>
-        </a>
-
-        <a href="/examples/telegram-bot/" class="card">
-          <h3>Telegram Bot</h3>
-          <p>Poll for messages, run a multi-step pipeline, reply with LLM responses. Two resources: llm and reply.</p>
-          <span class="mode-tag">workflow mode</span>
-        </a>
-
-        <a href="/examples/stateless-bot/" class="card">
-          <h3>Stateless Bot</h3>
-          <p>Read from stdin, call an LLM, write to stdout. One-shot. Perfect for cron jobs and CI pipelines.</p>
+        <a href="/examples/file-processor" class="card">
+          <h3>Document summarizer</h3>
+          <p>POST a file, get back a structured JSON summary - title, key points, entities. Runs on a local model.</p>
           <span class="mode-tag">workflow mode</span>
         </a>
 
         <a href="/examples/rag-search" class="card">
-          <h3>RAG Search</h3>
-          <p>Index documents locally, search with keywords, feed results into an LLM prompt. Fully on-prem.</p>
+          <h3>RAG over your own docs</h3>
+          <p>Index PDFs and text locally, retrieve the relevant chunks, and answer with an LLM. Nothing leaves the box.</p>
+          <span class="mode-tag">workflow mode</span>
+        </a>
+
+        <a href="/examples/web-scraper" class="card">
+          <h3>Web scraper API</h3>
+          <p>Fetch a page, extract the fields you name, return clean JSON. Swap in the browser resource for JS-heavy sites.</p>
+          <span class="mode-tag">workflow mode</span>
+        </a>
+
+        <a href="/examples/sql-api" class="card">
+          <h3>SQL-backed API</h3>
+          <p>Turn a plain-language question into a query against your database and answer it. Parameterized, not string-built.</p>
+          <span class="mode-tag">workflow mode</span>
+        </a>
+
+        <a href="/examples/telephony-bot" class="card">
+          <h3>Phone assistant (IVR)</h3>
+          <p>Answer a call, transcribe the caller, run a pipeline, speak the reply - say, ask, and menu steps in YAML.</p>
           <span class="mode-tag">workflow mode</span>
         </a>
 
         <a href="/examples/agency" class="card">
-          <h3>Agency Pipeline</h3>
-          <p>Orchestrate multiple agents. One summarises, another translates — each an independent workflow.</p>
+          <h3>Multi-agent agency</h3>
+          <p>One agent researches, another writes - each its own workflow.yaml, composed like function calls.</p>
           <span class="mode-tag agency-tag">multi-agent</span>
         </a>
       </div>


### PR DESCRIPTION
## Hero code window (`HeroCode.vue`)

Old example was a "fetch a URL and summarize it" pipeline with a circular demo response ("Example.com is used for illustrative examples in documentation") and schema slips (no `name:` on file resources, `output('fetch').body`, made-up model id `claude-opus-4-8`).

New: a validated two-resource chat API (same shape as the README quickstart, `kdeps validate`d) - `workflow.yaml` -> `resources/chat.yaml` (input check + 400) -> `resources/reply.yaml`. The agent REPL tab now shows tool use (running `go test`) and a real model switch.

## "What you can build" (`HomeUseCases.vue`)

Three of five cards (REST API, Telegram Bot, Stateless Bot) were the same shape - input, call an LLM, return the result. Replaced with six that span the range:

| Card | Tutorial |
|---|---|
| Document summarizer | `/examples/file-processor` |
| RAG over your own docs | `/examples/rag-search` |
| Web scraper API | `/examples/web-scraper` |
| SQL-backed API | `/examples/sql-api` |
| Phone assistant (IVR) | `/examples/telephony-bot` |
| Multi-agent agency | `/examples/agency` |

`npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)