### PR TITLE
docs: frame kdeps as a deterministic shell around a probabilistic model

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ brew install kdeps/tap/kdeps
 
 ## How it works
 
-**Workflow mode** - DAG-deterministic request/response pipelines. Each resource declares its dependencies via `requires:` and runs in order, ending in an `apiResponse`. Resource types cover `chat`, `httpClient`, `python`, `exec`, `sql`, `email`, `scraper`, `browser`, `embedding`, `searchLocal`, `searchWeb`, `agent`, and `component`; expressions (`get()`, `output()`, `set()`, plus Jinja2 control flow) wire steps together.
+**Workflow mode** - DAG-deterministic request/response pipelines. Each resource declares its dependencies via `requires:` and runs in order, ending in an `apiResponse`. The LLM call inside a `chat:` resource is still probabilistic, but the pipeline around it is not: the same request takes the same path, validation runs before any model call, and the response is shaped to a fixed schema. Resource types cover `chat`, `httpClient`, `python`, `exec`, `sql`, `email`, `scraper`, `browser`, `embedding`, `searchLocal`, `searchWeb`, `agent`, and `component`; expressions (`get()`, `output()`, `set()`, plus Jinja2 control flow) wire steps together.
 
 ```bash
 kdeps run workflow.yaml          # local, instant startup

--- a/docs/v2/.vitepress/theme/HomeCapabilities.vue
+++ b/docs/v2/.vitepress/theme/HomeCapabilities.vue
@@ -19,7 +19,7 @@ import agencySvg from './d2/cap-agency.svg?raw'
         <div class="col">
           <div class="col-badge workflow">workflow</div>
           <h3>Deterministic pipelines</h3>
-          <p>Resources run in DAG order defined by <code>requires:</code>. Every request takes the same path. Predictable, auditable, ships to production.</p>
+          <p>Resources run in DAG order defined by <code>requires:</code>. Every request takes the same path. The LLM's wording still varies - everything around it does not.</p>
           <div class="diagram" v-html="workflowSvg" />
           <div class="cmd"><span class="prompt">$</span> kdeps run workflow.yaml</div>
           <a href="/modes/workflow-mode" class="learn">Learn more -></a>

--- a/docs/v2/.vitepress/theme/HomeComparison.vue
+++ b/docs/v2/.vitepress/theme/HomeComparison.vue
@@ -9,6 +9,8 @@
       <h2 class="section-title">YAML replaces glue code</h2>
       <p class="section-sub">No Python scripts, no wiring, no boilerplate.</p>
 
+      <p class="callout">The model is probabilistic; the pipeline around it is not. In workflow mode the same request always takes the same path, validation runs before any LLM call, and the response is shaped to a fixed schema.</p>
+
       <div class="table-wrap">
         <table>
           <thead>
@@ -77,7 +79,16 @@
 .section-sub {
   font-size: 16px;
   color: var(--vp-c-text-2);
-  margin: 0 0 48px;
+  margin: 0 0 24px;
+}
+
+.callout {
+  font-size: 14px;
+  line-height: 1.65;
+  color: var(--vp-c-text-2);
+  border-left: 2px solid var(--vp-c-brand-1);
+  padding: 4px 0 4px 16px;
+  margin: 0 0 40px;
 }
 
 .table-wrap {

--- a/docs/v2/concepts/why-kdeps.md
+++ b/docs/v2/concepts/why-kdeps.md
@@ -44,9 +44,11 @@ kdeps is an **AI appliance builder**. You define what the agent does in YAML, an
 
 ## Deterministic by design
 
-Chat interfaces are deliberately open-ended. kdeps workflow mode is the opposite: inputs are declared, dependencies are explicit (`requires:`), and validations fire before any LLM is called. If the input is wrong, the workflow fails fast with a clear error instead of hallucinating a response.
+An LLM is probabilistic - ask Claude or GPT the same question twice and you can get two different answers. kdeps workflow mode wraps that in a deterministic shell: the same request always takes the same path through the same resources, `requires:` fixes the order, validations fire before any model is called, and the output is shaped to a fixed schema. The model's wording varies; the pipeline around it does not.
 
-Same input always produces the same execution path. Output is reproducible, auditable, and safe to run unattended. That is what makes kdeps suitable for production - not just demos.
+If the input is wrong, the workflow fails fast with a clear error instead of hallucinating a response. Output is reproducible in structure, auditable, and safe to run unattended - that is what makes kdeps suitable for production, not just demos.
+
+Agent loop mode is the opposite: there the model decides which resources run and in what order.
 
 ## Two modes, one workflow file
 


### PR DESCRIPTION
The point: an LLM is probabilistic (same prompt, different wording), but the kdeps workflow-mode pipeline around it is not - same request takes the same path, validation runs before any model call, output is shaped to a fixed schema.

## Changes
- **`concepts/why-kdeps.md`** "Deterministic by design" - leads with the probabilistic vs deterministic contrast; adds that agent loop mode is the opposite (the model decides what runs).
- **`HomeComparison.vue`** - a callout above the comparison table.
- **`HomeCapabilities.vue`** - sharper line in the "Deterministic pipelines" card ("The LLM's wording still varies - everything around it does not").
- **`README.md`** "How it works" - one sentence under Workflow mode.

Framing is deliberately "deterministic shell", not "kdeps is deterministic" - the `chat:` step itself is still probabilistic.

`npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)