### PR TITLE
docs: label all models as probabilistic on the provider/backend pages

### DIFF
--- a/docs/v2/reference/glossary.md
+++ b/docs/v2/reference/glossary.md
@@ -17,6 +17,7 @@ mode and agent mode.
 | `codeIntelligence` | A resource action type for code navigation: symbol search, definition lookup, reference finding, hover info, and diagnostics. | [Code intelligence](/resources/code-intelligence/navigation) |
 | <a id="component"></a>component | A reusable, packaged resource bundle. Installed from the registry or built in a `components/` directory. Declared as `kind: Component`. | [Components](/concepts/components) |
 | `componentTools` | Tools provided by a component that are exposed to the calling agent or workflow for the LLM to invoke. | [Components](/concepts/components) |
+| <a id="deterministic"></a>deterministic | Same input, same output, every time. In kdeps this describes the workflow-mode pipeline - route matching, `requires:` ordering, `validations`, and response shaping all resolve the same way for a given request. It does not describe the LLM's text output. Contrast [probabilistic](#probabilistic). | [Deterministic by design](/concepts/why-kdeps#deterministic-by-design) |
 | `embedding` | A resource action type that generates vector embeddings from text, for semantic search and RAG. | [Embedding](/resources/rag/embedding) |
 | `exec` | A resource action type that runs shell commands and captures stdout, stderr, and exit code. | [Exec](/resources/scripting/exec) |
 | expr | Short for expression: a statement evaluated by the expr-lang engine. Used in `before:` / `after:` blocks, `validations`, and `{{ }}` string interpolation. | [Expressions](/concepts/expressions) |
@@ -33,6 +34,7 @@ mode and agent mode.
 | memory (persistent) | Project-scoped storage for the agent loop in a bbolt database that survives across sessions. Built-in tools: `memory_save`, `memory_search`, `memory_delete`, `memory_list`, `memory_query`. | [Persistent memory](/concepts/memory) |
 | memory graph | A directed graph of memory entries linked by their `References` fields and auto-linked by type. Inlined into the `<memory>` block in causal order. | [Memory internals](/concepts/memory-internals#memory-graph) |
 | `output()` | An expression function that reads the output of a completed resource by its `actionId`. | [Unified API](/concepts/unified-api) |
+| <a id="probabilistic"></a>probabilistic | The same prompt can produce different output on each call. Every language model - Claude, GPT, Gemini, Groq, Ollama, local llamafile / GGUF - is probabilistic. A kdeps `chat:` resource inherits this; the pipeline around it stays [deterministic](#deterministic). | [LLM provider reference](/reference/llm-providers) |
 | `python` | A resource action type that runs Python scripts. Supports inline scripts, file paths, packages, and virtual environments. | [Python](/resources/scripting/python) |
 | <a id="requires"></a>`requires` | A list of `actionId`s that must complete before this resource runs. Defines the DAG edges. Transitive dependencies resolve automatically. | [Execution flow](/guides/execution-flow) |
 | resource | The fundamental building block of a workflow: an `actionId`, a primary action type, optional `requires`, and optional validations, loop, and error handling. | [Resources overview](/resources/overview) |

--- a/docs/v2/reference/llm-providers.md
+++ b/docs/v2/reference/llm-providers.md
@@ -4,6 +4,8 @@ Per-provider configuration for all backends supported by kdeps. Backend and API 
 
 *Applies to both workflow mode and agent mode.*
 
+Every model listed here - OpenAI, Anthropic (Claude), Google (Gemini), Groq, Ollama, local llamafile / GGUF, and the rest - is **probabilistic**: the same prompt can return different text on each call. Determinism in kdeps comes from [workflow mode](/modes/workflow-mode) wrapping the model, not from the model itself. See [Deterministic by design](/concepts/why-kdeps#deterministic-by-design).
+
 ## Local backends
 
 ### Llamafile (default)

--- a/docs/v2/resources/llm/backends.md
+++ b/docs/v2/resources/llm/backends.md
@@ -2,6 +2,8 @@
 
 kdeps separates two concerns: which model to call (set in the resource file) and where to call it (set in `~/.kdeps/config.yaml`). This lets you switch backends without touching your workflow.
 
+Whichever backend you pick - cloud (OpenAI, Anthropic, Groq, ...) or local (llamafile, Ollama, GGUF) - the model is probabilistic. The [workflow pipeline](/modes/workflow-mode) around it is what makes a kdeps agent deterministic, not the model.
+
 ## The default: llamafile (file backend)
 
 With no configuration at all, chat resources run on the `file` backend: the


### PR DESCRIPTION
Follow-up to #716. The two pages that list the models/providers - `reference/llm-providers.md` and `resources/llm/backends.md` - now state up front that every model (OpenAI, Anthropic/Claude, Google/Gemini, Groq, Ollama, local llamafile/GGUF, ...) is probabilistic, and that determinism in kdeps comes from workflow mode wrapping the model, not from the model. Both link to [Deterministic by design](/concepts/why-kdeps#deterministic-by-design).

`npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)