### PR TITLE
fix(m365): keep prose that quotes tool syntax as text, not a bogus call

### DIFF
--- a/docs/v2/reference/llm-providers-m365.md
+++ b/docs/v2/reference/llm-providers-m365.md
@@ -78,6 +78,14 @@ claims it cannot read files. The system preamble tells the model to use the
 kdeps tools only; if it still slips, reply `use the kdeps tools, not your own`
 and it recovers.
 
+Because tool calls are recovered from `<invoke>` blocks in free text, a written
+answer that *quotes* that syntax (or just names a tool, like "read the plan file,
+limit 100 lines") could be mis-read as an action. kdeps keeps such a reply as
+text when the recovered call is missing a required parameter, repeats a call
+already run this turn, or sits inside a long prose answer - so a final summary
+that mentions tool names renders in full instead of leaving a few dangling
+fragments before the prompt.
+
 Reasoning-tone models (`think-deeper`, `*-think-deeper`) stream their
 chain-of-thought summary as live reasoning feedback, same as native
 extended-thinking models - visible in the agent-loop REPL automatically

--- a/go.mod
+++ b/go.mod
@@ -208,7 +208,7 @@ require (
 	google.golang.org/genproto v0.0.0-20260618152121-87f3d3e198d3 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260618152121-87f3d3e198d3 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260618152121-87f3d3e198d3 // indirect
-	google.golang.org/grpc v1.82.1 // indirect
+	google.golang.org/grpc v1.83.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gotest.tools/v3 v3.5.2 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -660,8 +660,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260618152121-87f3d3e198d3 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260618152121-87f3d3e198d3/go.mod h1:Z4WJ5pJOYWFWcHEQUelD5QaZDknIQkpIL/+fyJOT9+A=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260618152121-87f3d3e198d3 h1:phvBWCAQMGN1945mp5fjCXP6jEF0+a0+4TjokS4sxNY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260618152121-87f3d3e198d3/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
-google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
+google.golang.org/grpc v1.83.1 h1:HIO0+BEtBP6soyqvqC8sNUjZ7bTs+0hFQuFF+RAy++Y=
+google.golang.org/grpc v1.83.1/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=

--- a/pkg/executor/llm/m365/m365_server_test.go
+++ b/pkg/executor/llm/m365/m365_server_test.go
@@ -425,6 +425,50 @@ func TestServerChatCompletionReplyToolBecomesText(t *testing.T) {
 	}
 }
 
+// TestServerChatCompletion_IllustrativeCallStaysText drives the issue #701 fix
+// through the real server pipeline: a long written answer that quotes
+// read_file-style syntax gets parsed into a bogus read_file call (missing the
+// required file_path) plus scrap leftover. The response must come back as the
+// full text, not a tool call.
+func TestServerChatCompletion_IllustrativeCallStaysText(t *testing.T) {
+	prose := "## Using design/ on the current plans\n\n" + strings.Repeat(
+		"Read the plan file (limit 100 lines) and cross-reference each UI Framework "+
+			"component against the 5 open items before editing. ", 6,
+	)
+	raw := prose + "\n\n<invoke name=\"read_file\"><parameter name=\"limit\">100</parameter></invoke>"
+	srv, _ := newTestServer(t, [][]string{successFrame(raw)})
+
+	_, body := postChat(t, srv.URL, map[string]any{
+		"model":    "m365-copilot",
+		"messages": []map[string]any{{"role": "user", "content": "how can design/ be used"}},
+		"tools": []map[string]any{{
+			"type": "function",
+			"function": map[string]any{
+				"name": "read_file",
+				"parameters": map[string]any{
+					"properties": map[string]any{
+						"file_path": map[string]any{"type": "string"},
+						"limit":     map[string]any{"type": "integer"},
+					},
+					"required": []any{"file_path"},
+				},
+			},
+		}},
+	})
+	choice := body["choices"].([]any)[0].(map[string]any)
+	if choice["finish_reason"] != "stop" {
+		t.Fatalf("finish_reason = %v, body=%+v", choice["finish_reason"], body)
+	}
+	msg := choice["message"].(map[string]any)
+	if calls, _ := msg["tool_calls"].([]any); len(calls) != 0 {
+		t.Fatalf("illustrative call should not execute: %+v", calls)
+	}
+	if got, _ := msg["content"].(string); !strings.Contains(got, "UI Framework") ||
+		!strings.Contains(got, "Using design/ on the current plans") {
+		t.Errorf("full prose answer not returned, got %q", got)
+	}
+}
+
 // --- confabulation / hallucination forced retry ---
 
 func TestServerChatCompletionConfabulationRetry(t *testing.T) {

--- a/pkg/executor/llm/m365/m365_test.go
+++ b/pkg/executor/llm/m365/m365_test.go
@@ -646,6 +646,65 @@ func TestIsProseDocument(t *testing.T) {
 	}
 }
 
+func TestDropIllustrativeCalls(t *testing.T) {
+	readFile := ToolDef{Function: ToolFunction{
+		Name:       "read_file",
+		Parameters: &ToolParameters{Required: []string{"file_path"}},
+	}}
+	longProse := "## Plan review\n\n" + strings.Repeat(
+		"Read the plan file (limit 100 lines) and cross-reference the components. ", 8,
+	)
+
+	// A call missing a required param inside a long written answer is prose the
+	// parser mis-read: drop the call, keep the whole reply as text (issue #701).
+	got := dropIllustrativeCalls(
+		ParseResult{
+			HasToolCalls: true,
+			ToolCalls:    []ParsedToolCall{{Name: "read_file", Arguments: `{"limit":100}`}},
+			TextContent:  "UI Framework\n5",
+		},
+		[]ToolDef{readFile}, nil, longProse,
+	)
+	if got.HasToolCalls || got.TextContent != longProse {
+		t.Fatalf("missing-required call in long prose should become text, got %+v", got)
+	}
+
+	// A call that repeats one already executed this turn is the model quoting
+	// its own history back inside the answer.
+	history := []Message{{Role: "assistant", ToolCalls: []ToolCall{
+		{Function: ToolCallFunction{Name: "read_file", Arguments: `{"file_path":"PLAN.md"}`}},
+	}}}
+	got = dropIllustrativeCalls(
+		ParseResult{
+			HasToolCalls: true,
+			ToolCalls:    []ParsedToolCall{{Name: "read_file", Arguments: `{"file_path":"PLAN.md"}`}},
+			TextContent:  "done",
+		},
+		[]ToolDef{readFile}, history, longProse,
+	)
+	if got.HasToolCalls {
+		t.Fatalf("duplicate of an executed call should be dropped, got %+v", got)
+	}
+
+	// A well-formed, novel call in a short reply is untouched.
+	action := ParseResult{
+		HasToolCalls: true,
+		ToolCalls:    []ParsedToolCall{{Name: "read_file", Arguments: `{"file_path":"NEW.md"}`}},
+	}
+	if got = dropIllustrativeCalls(action, []ToolDef{readFile}, nil, "short"); !got.HasToolCalls {
+		t.Fatalf("a real call must be kept, got %+v", got)
+	}
+
+	// A malformed call in a SHORT reply still reaches the model as an error.
+	broken := ParseResult{
+		HasToolCalls: true,
+		ToolCalls:    []ParsedToolCall{{Name: "read_file", Arguments: `{"limit":100}`}},
+	}
+	if got = dropIllustrativeCalls(broken, []ToolDef{readFile}, nil, "check the plan"); !got.HasToolCalls {
+		t.Fatalf("a short malformed call must pass through for model recovery, got %+v", got)
+	}
+}
+
 func TestFormatMessagesInjectsTools(t *testing.T) {
 	msgs := []Message{{Role: "user", Content: "do it"}}
 	out := FormatMessages(msgs, []ToolDef{shellToolDef()}, nil, "conv-1", "baseline")

--- a/pkg/executor/llm/m365/server.go
+++ b/pkg/executor/llm/m365/server.go
@@ -546,6 +546,7 @@ func (c *completion) produce(ctx context.Context, onDelta func(string)) *produce
 		parsed = ParseResult{HasToolCalls: false, TextContent: fullText}
 	}
 
+	parsed = dropIllustrativeCalls(parsed, c.body.Tools, c.body.Messages, fullText)
 	parsed = resolveProseAlongsideCalls(parsed, fullText)
 
 	if parsed.HasToolCalls {
@@ -628,6 +629,103 @@ func resolveProseAlongsideCalls(parsed ParseResult, fullText string) ParseResult
 	}
 	parsed.TextContent = ""
 	return parsed
+}
+
+// dropIllustrativeCalls removes recovered "tool calls" that the fenced parser
+// almost certainly mis-read out of a written answer rather than an action turn:
+//
+//   - a call missing a parameter the tool declares as required -- a real action
+//     call carries its required args; prose that merely names a tool ("read the
+//     plan file, limit 100 lines") does not.
+//   - a call that exactly repeats one already executed earlier this turn -- the
+//     model quoting its own history back inside the answer.
+//
+// It only fires when the full reply is substantial prose (>= proseDocMinChars),
+// so a genuinely malformed single call still reaches the model as an error it
+// can correct. When every recovered call is illustrative, the reply is text:
+// this is the case IsProseDocument misses once the parser has already gutted the
+// prose into one or two calls plus scraps (issue #701).
+func dropIllustrativeCalls(
+	parsed ParseResult,
+	tools []ToolDef,
+	history []Message,
+	fullText string,
+) ParseResult {
+	if !parsed.HasToolCalls || len(parsed.ToolCalls) == 0 {
+		return parsed
+	}
+	if len(strings.TrimSpace(fullText)) < proseDocMinChars {
+		return parsed
+	}
+
+	required := map[string][]string{}
+	for _, t := range tools {
+		if t.Function.Parameters != nil && len(t.Function.Parameters.Required) > 0 {
+			required[t.Function.Name] = t.Function.Parameters.Required
+		}
+	}
+	executed := map[string]bool{}
+	for _, m := range history {
+		if m.Role != "assistant" {
+			continue
+		}
+		for _, tc := range m.ToolCalls {
+			executed[toolCallSig(tc.Function.Name, tc.Function.Arguments)] = true
+		}
+	}
+
+	var kept []ParsedToolCall
+	for _, call := range parsed.ToolCalls {
+		if missingRequiredArg(call.Arguments, required[call.Name]) {
+			continue
+		}
+		if executed[toolCallSig(call.Name, call.Arguments)] {
+			continue
+		}
+		kept = append(kept, call)
+	}
+	if len(kept) == len(parsed.ToolCalls) {
+		return parsed
+	}
+	if len(kept) == 0 {
+		return ParseResult{HasToolCalls: false, TextContent: fullText}
+	}
+	parsed.ToolCalls = kept
+	return parsed
+}
+
+// missingRequiredArg reports whether the JSON arguments object omits (or leaves
+// empty) any of the named required parameters.
+func missingRequiredArg(arguments string, requiredKeys []string) bool {
+	if len(requiredKeys) == 0 {
+		return false
+	}
+	var args map[string]any
+	if json.Unmarshal([]byte(arguments), &args) != nil {
+		return true
+	}
+	for _, k := range requiredKeys {
+		v, ok := args[k]
+		if !ok {
+			return true
+		}
+		if s, isStr := v.(string); isStr && strings.TrimSpace(s) == "" {
+			return true
+		}
+	}
+	return false
+}
+
+// toolCallSig is a stable name+arguments signature for duplicate detection.
+// Arguments are normalised through a map so key order does not matter.
+func toolCallSig(name, arguments string) string {
+	var args map[string]any
+	if json.Unmarshal([]byte(arguments), &args) == nil {
+		if norm, err := json.Marshal(args); err == nil {
+			return name + "\x00" + string(norm)
+		}
+	}
+	return name + "\x00" + strings.TrimSpace(arguments)
 }
 
 // finalizeToolCalls converts a synthetic reply() call back to plain text and


### PR DESCRIPTION
## Problem

Issue #701: intermittently the agent-loop REPL prints ~3 stray fragments just
before the prompt on the m365 backend (`claude-sonnet`) - a working-directory
path, a partial phrase, and a bare number - instead of the model's full answer.

Refined diagnosis (from the issue thread): a written answer produced **after
tools have executed** names a tool or quotes `<invoke>` syntax
("read the plan file (limit 100 lines) and cross-reference the components").
`ParseFencedToolCalls` chops the prose into a bogus `read_file` call (missing
the required `file_path`) plus scrap leftover; `server.go` blanks `TextContent`
because `HasToolCalls` is true and executes the illustrative call. What the
REPL finally renders is `cleanLooseText(leftover)` = the scraps.

`IsProseDocument` misses it (needs >= 2 calls / a markdown header / >= 300
chars of *gutted* `TextContent`). PR #699's `resolveProseAlongsideCalls` misses
it too (the leftover is already short).

## Fix

`dropIllustrativeCalls` (m365 server pipeline, before `resolveProseAlongsideCalls`)
drops a recovered call when, and only when, the full reply is substantial prose
(>= `proseDocMinChars`) and the call is either:

- missing a parameter the tool declares **required** (a real action call carries
  its required args; prose that names a tool does not), or
- an exact duplicate (name + normalised args) of a call already executed this
  turn (the model quoting its own history back inside the answer).

When every recovered call is illustrative, the reply is returned as text. A
short malformed call still reaches the model as an error it can correct, so
genuine recovery is unaffected.

## Tests

- `TestDropIllustrativeCalls` - unit: missing-required in long prose -> text;
  duplicate-of-executed -> dropped; real novel call kept; short malformed call
  passes through.
- `TestServerChatCompletion_IllustrativeCallStaysText` - drives the fix through
  the real HTTP server pipeline with a mocked upstream frame; asserts the
  response comes back as full text with no `tool_calls`.
- m365 + `pkg/agent` + `pkg/executor` + `cmd` suites green, `make lint` clean,
  `docs/v2` build clean.

Docs: `docs/v2/reference/llm-providers-m365.md` gains a paragraph on prose that
quotes tool syntax being kept as text.

Also bumps `google.golang.org/grpc` 1.82.1 -> 1.83.1 to clear CVE-2026-84304
flagged by the security/docker scan jobs.

Closes #701. Same fenced-protocol fragility family as #699 / #700.

🤖 Generated with [Claude Code](https://claude.com/claude-code)