### PR TITLE
fix(ci): venv for huggingface_hub in the nightly harvest

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -57,7 +57,12 @@ jobs:
           go-version-file: go.mod
 
       - name: Install huggingface_hub (for llamafile harvest)
-        run: pip3 install --break-system-packages -q huggingface_hub 2>/dev/null || pip3 install -q huggingface_hub
+        run: |
+          # macos-latest ships an externally-managed (PEP 668) Homebrew Python,
+          # so a plain `pip3 install` fails. Use an isolated venv.
+          python3 -m venv "$RUNNER_TEMP/hf-venv"
+          "$RUNNER_TEMP/hf-venv/bin/python" -m pip install -q --upgrade pip
+          "$RUNNER_TEMP/hf-venv/bin/python" -m pip install -q huggingface_hub
 
       - name: Cache HuggingFace Hub
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -70,7 +75,7 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
-          python3 tools/llamafile-harvester/harvest.py --write --gguf --chinese-labs || echo "harvest failed; keeping committed registry"
+          "$RUNNER_TEMP/hf-venv/bin/python" tools/llamafile-harvester/harvest.py --write --gguf --chinese-labs || echo "harvest failed; keeping committed registry"
           if git diff --quiet pkg/executor/llm/llamafile_versions_data.go tools/llamafile-harvester/llamafile_versions.yaml pkg/executor/llm/gguf_versions_data.go tools/llamafile-harvester/gguf_versions.yaml 2>/dev/null; then
             echo "has_registry_updates=false" >> $GITHUB_OUTPUT
           else

--- a/.gitignore
+++ b/.gitignore
@@ -198,6 +198,9 @@ zsdoc/data
 # (for Zsh plugins using Python)
 .venv
 
+# harvest-llamafiles Make target's isolated venv
+.venv-harvest/
+
 # Zunit tests' output
 /tests/_output/*
 !/tests/_output/.gitkeep

--- a/Makefile
+++ b/Makefile
@@ -349,8 +349,9 @@ deps:
 # Harvest llamafile registry from HuggingFace (requires huggingface_hub)
 harvest-llamafiles:
 	@echo "Harvesting llamafile registry from HuggingFace..."
-	@pip3 install --break-system-packages -q huggingface_hub 2>/dev/null || pip3 install -q huggingface_hub; \
-	PYTHONPATH="/tmp/hf-hub:$$PYTHONPATH" python3 tools/llamafile-harvester/harvest.py --write --gguf --chinese-labs && \
+	@test -x .venv-harvest/bin/python || python3 -m venv .venv-harvest
+	@.venv-harvest/bin/python -m pip install -q --upgrade pip huggingface_hub
+	@.venv-harvest/bin/python tools/llamafile-harvester/harvest.py --write --gguf --chinese-labs && \
 	echo "✓ llamafile + GGUF registries updated"
 help:
 	@echo "KDeps v2 - Makefile commands"


### PR DESCRIPTION
## Failure

Today's nightly release failed at the **Install huggingface_hub** step:

```
error: externally-managed-environment
```

`macos-latest` now ships a PEP 668 Homebrew Python. The step tried
`pip3 install --break-system-packages ... 2>/dev/null || pip3 install ...` -
the first attempt exits non-zero (its stderr is swallowed) and the fallback
hits the externally-managed error and fails the job.

## Fix

- **`.github/workflows/nightly-release.yml`**: create an isolated venv under
  `$RUNNER_TEMP/hf-venv` and run `harvest.py` with `$RUNNER_TEMP/hf-venv/bin/python`.
- **`Makefile`** `harvest-llamafiles`: same approach with a cached, gitignored
  `.venv-harvest/`, so `make harvest-llamafiles` works the same locally.
- `.gitignore`: ignore `.venv-harvest/`.

Verified locally: `make harvest-llamafiles` builds the venv, installs
`huggingface_hub`, and regenerates the registry data files successfully (those
regenerated files are intentionally **not** in this PR - the fixed nightly will
produce them).

`build-test.yml`'s `python3 -m pip install ...` steps run on Ubuntu runners and
are green, so they're left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)