### PR TITLE
fix(agent): a failed judge revision no longer replaces the answer with noise

### DIFF
--- a/docs/v2/modes/agent-loop-judges.md
+++ b/docs/v2/modes/agent-loop-judges.md
@@ -25,7 +25,10 @@ output, concurrently. If any judge rejects it, the rejecting judges' feedback
 is combined into a revision directive, the loop produces a new answer, and the
 whole panel reviews it again - up to `JudgeMaxIterations` times (default 2).
 Once the budget is spent the last attempted answer is returned regardless - a
-judge panel that never approves must not be able to block the turn forever.
+judge panel that never approves must not be able to block the turn forever. A
+revision that comes back empty (or with the "model produced nothing" notice) is
+discarded and the previous answer is kept, so a failed revision never replaces a
+real answer with a blank or a canned message.
 
 **You can see it happening.** Because a judge is a full tool-calling loop, a
 review can take as long as a real turn - the REPL prints `[judge]` status

--- a/pkg/agent/judge.go
+++ b/pkg/agent/judge.go
@@ -254,8 +254,17 @@ func (l *Loop) iterateWithJudges(
 		if err != nil {
 			return response, finalContent
 		}
-		finalContent = content
-		response = stripContentToolCalls(finalContent)
+		// Only accept a revision that actually produced a better answer. A round
+		// that ends with empty content, or with runToolRounds' canned
+		// "model produced nothing" notice, must not replace the last good
+		// response: blanking it makes the caller fall back to the raw round
+		// buffer (every prior iteration's text stacked up -> stray paragraphs
+		// before the prompt), and the notice itself is just as much an artifact.
+		revisedText := stripContentToolCalls(content)
+		if strings.TrimSpace(revisedText) != "" && !isTurnFailureNotice(revisedText) {
+			finalContent = content
+			response = revisedText
+		}
 	}
 	return response, finalContent
 }

--- a/pkg/agent/judge_test.go
+++ b/pkg/agent/judge_test.go
@@ -293,6 +293,47 @@ func TestIterateWithJudges_StopsAtBudgetWithoutBlocking(t *testing.T) {
 	}
 }
 
+// emptyRevisionJudgeStreamer always rejects the answer, and its revision rounds
+// produce no text at all (a bare no-op tool call) -- the degenerate case where a
+// reasoning model "revises" by only thinking.
+type emptyRevisionJudgeStreamer struct{ judgeCalls int }
+
+func (s *emptyRevisionJudgeStreamer) StreamChat(
+	_ context.Context, cfg *domain.ChatConfig, _ io.Writer,
+) (string, []domain.StreamedToolCall, error) {
+	for _, t := range cfg.Tools {
+		if t.Name == "judge_verdict" {
+			s.judgeCalls++
+			args, _ := json.Marshal(map[string]any{"approved": false, "feedback": "still wrong"})
+			return "", []domain.StreamedToolCall{
+				{ID: strconv.Itoa(s.judgeCalls), Name: "judge_verdict", Arguments: string(args)},
+			}, nil
+		}
+	}
+	return "", nil, nil // revision round: no text, no tool call
+}
+
+func TestIterateWithJudges_EmptyRevisionKeepsLastGoodResponse(t *testing.T) {
+	l := newJudgeTestLoop(&emptyRevisionJudgeStreamer{})
+	l.config.JudgeMaxIterations = 2
+	roster := []JudgeSpec{{Name: "a", Criteria: "check a"}}
+	response, final := l.iterateWithJudges(
+		context.Background(),
+		&domain.ChatConfig{Model: "test"},
+		roster,
+		"in",
+		"the original good answer",
+		"the original good answer",
+		io.Discard,
+	)
+	if strings.TrimSpace(response) == "" {
+		t.Fatal("an empty revision must not blank out the last good response")
+	}
+	if response != "the original good answer" || final != "the original good answer" {
+		t.Fatalf("expected the original answer to survive, got response=%q final=%q", response, final)
+	}
+}
+
 func TestReportJudgeEvent_PrefersConfigProgressWriter(t *testing.T) {
 	l := newJudgeTestLoop(nil)
 	var progress, passed bytes.Buffer

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -1243,6 +1243,16 @@ func (l *Loop) silentTurnNotice(w io.Writer) string {
 	return notice
 }
 
+// isTurnFailureNotice reports whether s is one of the canned strings
+// silentTurnNotice / stuckLoopNotice return when a turn produced nothing usable.
+// A judge revision that yields one of these has failed and must not replace the
+// prior answer with the notice.
+func isTurnFailureNotice(s string) bool {
+	t := strings.TrimSpace(s)
+	return strings.HasPrefix(t, "The model ended the turn without answering") ||
+		strings.HasPrefix(t, "The model repeated the same")
+}
+
 // stuckLoopNotice writes and returns the message shown when the model is broken
 // out of a repeat-block loop: it issued the same tool call too many times in a
 // row (usually because the tool was blocked by convergence or kept failing) and


### PR DESCRIPTION
## Symptom

Another source of the stray-lines-before-the-prompt artifact (after #729's
`[MEMORY:]` / goal-directive fixes): the **judge panel**.

With `AutoJudges` on (the REPL default), every non-trivial turn generates a
roster and runs `iterateWithJudges`. If a judge rejects the answer and the
revision round then produces nothing usable, `iterateWithJudges` overwrote the
last good `response` / `finalContent` with:

- empty content (a revision round that ends on a bare tool call, or a
  reasoning-only model), or
- `runToolRounds`' canned notice, e.g. *"The model ended the turn without
  answering or calling a tool..."*

An **empty** `response` makes `RunStreaming` return `""`, and the REPL then
falls back to the raw round buffer -- which by that point holds the original
answer **plus every revision iteration's text stacked together**, rendering as
several stray paragraphs. The **notice** case swaps a real answer for a canned
failure message.

## Fix

`iterateWithJudges` now accepts a revision only when its text is non-empty
**and** not a turn-failure notice (new `isTurnFailureNotice` helper alongside
the notice strings in `loop.go`). A failed revision keeps the prior answer --
which is exactly what the "budget spent, return the last attempt" path already
intends.

## Tests

- `TestIterateWithJudges_EmptyRevisionKeepsLastGoodResponse` -- panel always
  rejects, revision rounds produce nothing; asserts the original answer
  survives as both `response` and `finalContent`.
- Existing `TestIterateWithJudges_*` (revise-then-approve, budget-without-block)
  still green; full `pkg/agent` suite green, `make lint` clean, `docs/v2` build
  clean.

## Docs

`docs/v2/modes/agent-loop-judges.md` -- one sentence on discarding an empty /
failed revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)