### PR TITLE
docs: README review — lead with agent mode, fix commands, split dense sentences

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ kdeps works at three levels:
 - **Workflow** - define what the agent does in one `workflow.yaml` and run it as an HTTP API, a bot, or a file processor. Same file, laptop or server.
 - **Appliance** - ship that file unchanged as a Docker image, Kubernetes manifests, a bootable ISO, or a single binary.
 
-One YAML file replaces a Python script wiring together an LLM SDK, a web server, retry logic, and a Dockerfile - and it is code you version and commit like any other.
+One YAML file replaces a Python script wiring together an LLM SDK, a web server, retry logic, and a Dockerfile.
 
 ## Quickstart
 
@@ -66,6 +66,7 @@ resources:
 ```
 
 ```bash
+# KDEPS_API_AUTH_TOKEN is the HTTP endpoint's bearer token - not an LLM key
 export KDEPS_API_AUTH_TOKEN=dev-token
 kdeps run workflow.yaml
 
@@ -97,6 +98,8 @@ brew install kdeps/tap/kdeps
 ```
 
 ## How it works
+
+Whichever level you use, a workflow runs in one of two execution modes - and an agency bundles several workflows into one system.
 
 **Workflow mode** - DAG-deterministic request/response pipelines. Each resource declares its dependencies via `requires:` and runs in order, ending in an `apiResponse`.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,15 @@
 
 > Before moving on, please consider giving us a GitHub star ⭐️. Thank you!
 
-**AI Appliance Builder** - YAML-defined AI agents and workflow pipelines. Ship as Docker, K8s, ISO, or a single binary. You write one `workflow.yaml` instead of a Python script wiring together an LLM SDK, a web server, retry logic, and a Dockerfile; everything lives in versionable YAML you commit to your repo like any other code.
+**AI Appliance Builder** - YAML-defined AI agents, workflows, and agencies.
+
+kdeps works at three levels:
+
+- **Local agent** - run `kdeps` and you are in an autonomous AI REPL: tool use, memory, fully offline against a local model. No config, no API key.
+- **Workflow** - define what the agent does in one `workflow.yaml` and run it as an HTTP API, a bot, or a file processor. Same file, laptop or server.
+- **Appliance** - ship that file unchanged as a Docker image, Kubernetes manifests, a bootable ISO, or a single binary.
+
+One YAML file replaces a Python script wiring together an LLM SDK, a web server, retry logic, and a Dockerfile - and it is code you version and commit like any other.
 
 ## Quickstart
 
@@ -90,7 +98,11 @@ brew install kdeps/tap/kdeps
 
 ## How it works
 
-**Workflow mode** - DAG-deterministic request/response pipelines. Each resource declares its dependencies via `requires:` and runs in order, ending in an `apiResponse`. The LLM call inside a `chat:` resource is still probabilistic, but the pipeline around it is not: the same request takes the same path, validation runs before any model call, and the response is shaped to a fixed schema. Resource types cover `chat`, `httpClient`, `python`, `exec`, `sql`, `email`, `scraper`, `browser`, `embedding`, `searchLocal`, `searchWeb`, `agent`, and `component`; expressions (`get()`, `output()`, `set()`, plus Jinja2 control flow) wire steps together.
+**Workflow mode** - DAG-deterministic request/response pipelines. Each resource declares its dependencies via `requires:` and runs in order, ending in an `apiResponse`.
+
+The LLM call inside a `chat:` resource is still probabilistic, but the pipeline around it is not: the same request takes the same path, validation runs before any model call, and the response is shaped to a fixed schema.
+
+Resources cover LLM chat, HTTP, Python, shell, SQL, email, web scraping, browser automation, embeddings, local and web search, and calls to other agents or components. Expressions (`get()`, `output()`, `set()`, plus Jinja2 control flow) wire the steps together.
 
 ```bash
 kdeps run workflow.yaml          # local, instant startup
@@ -120,8 +132,8 @@ Docs: [Workflow mode](https://kdeps.com/modes/workflow-mode) · [Agent loop mode
 The workflow you run locally exports unchanged to any target:
 
 ```bash
-kdeps bundle build          # Docker image
-kdeps bundle export iso     # bootable edge ISO
+kdeps bundle build .        # Docker image
+kdeps export iso            # bootable edge ISO
 kdeps bundle prepackage     # self-contained binary per arch
 kdeps export k8s            # Kubernetes manifests
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 > Before moving on, please consider giving us a GitHub star ⭐️. Thank you!
 
-**AI Appliance Builder** - YAML-defined AI agents, workflows, and agencies.
+**AI Appliance Builder** - AI agents and workflows defined in YAML, shipped as appliances.
 
 kdeps works at three levels:
 
@@ -101,7 +101,9 @@ brew install kdeps/tap/kdeps
 
 Whichever level you use, a workflow runs in one of two execution modes - and an agency bundles several workflows into one system.
 
-**Workflow mode** - DAG-deterministic request/response pipelines. Each resource declares its dependencies via `requires:` and runs in order, ending in an `apiResponse`.
+### Workflow mode
+
+DAG-deterministic request/response pipelines. Each resource declares its dependencies via `requires:` and runs in order, ending in an `apiResponse`.
 
 The LLM call inside a `chat:` resource is still probabilistic, but the pipeline around it is not: the same request takes the same path, validation runs before any model call, and the response is shaped to a fixed schema.
 
@@ -113,16 +115,19 @@ kdeps run ./my-agent/            # or point at a directory containing workflow.y
 kdeps run workflow.yaml --dev    # hot reload
 ```
 
-**Agent loop mode** - an autonomous LLM loop. Every workflow becomes a callable tool, and the LLM decides which to call, in what order, to complete the task. Runs as an interactive REPL until you exit (Ctrl+D).
+### Agent loop mode
+
+An autonomous LLM loop. Every workflow becomes a callable tool, and the LLM decides which to call, in what order, to complete the task. Runs as an interactive REPL until you exit (Ctrl+D).
 
 ```bash
 kdeps                            # bare agent loop REPL
-kdeps ./my-agent/                # register the workflow as an LLM-callable tool
 kdeps ./my-agent/ --model llama3.2 --system "You are a DevOps assistant."
 kdeps --stealth                  # "Muted" UI: dark gray, model name barely visible (for use in public)
 ```
 
-**Agencies** - a collection of agents that work together. Each agent is its own `workflow.yaml` with its own resources, model, and logic, wired together with the `agent:` resource type - like calling a function, but the function is an entire AI pipeline.
+### Agencies
+
+A collection of agents that work together. Each agent is its own `workflow.yaml` with its own resources, model, and logic, wired together with the `agent:` resource type - like calling a function, but the function is an entire AI pipeline.
 
 ```bash
 kdeps run agency.yaml

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -64,9 +64,9 @@ func newBuildCmd() *cobra.Command {
 	buildCmd := &cobra.Command{
 		Use:   "build [path]",
 		Short: "Build Docker image from workflow or agency",
-		Long: `Build Docker image from KDeps workflow or agency
+		Long: `Build Docker image from a kdeps workflow or agency
 
-This is optional - KDeps runs locally by default.
+This is optional - kdeps runs locally by default.
 Use this only for deployment/distribution.
 
 Accepts:

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -53,7 +53,7 @@ func newExportCmd() *cobra.Command {
 	exportCmd := &cobra.Command{
 		Use:   "export",
 		Short: "Export workflow to different formats",
-		Long:  `Export KDeps workflow to bootable ISO or other formats`,
+		Long:  `Export kdeps workflow to bootable ISO or other formats`,
 	}
 
 	exportCmd.AddCommand(newExportISOCmd())

--- a/cmd/export_iso.go
+++ b/cmd/export_iso.go
@@ -35,7 +35,7 @@ func newExportISOCmd() *cobra.Command {
 	isoCmd := &cobra.Command{
 		Use:   "iso [path]",
 		Short: "Export workflow or agency as bootable image",
-		Long: `Export KDeps workflow or agency as a bootable image using LinuxKit
+		Long: `Export kdeps workflow or agency as a bootable image using LinuxKit
 
 Creates a bootable image that runs the workflow on bare metal or VMs.
 The workflow Docker image runs as a container inside a minimal LinuxKit VM

--- a/cmd/export_k8s.go
+++ b/cmd/export_k8s.go
@@ -47,7 +47,7 @@ func newExportK8sCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "k8s [path]",
 		Short: "Export workflow as Kubernetes manifests",
-		Long: `Export KDeps workflow as Kubernetes manifests (Deployment and Service).
+		Long: `Export kdeps workflow as Kubernetes manifests (Deployment and Service).
 
 Generates YAML manifests that can be used to deploy the workflow to a Kubernetes cluster.
 The generated manifests include a Deployment with the specified image,

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -140,7 +140,7 @@ func resolveNewTemplate(template string) string {
 func buildNewTemplateData(agentName string) templates.TemplateData {
 	return templates.TemplateData{
 		Name:        agentName,
-		Description: "AI agent powered by KDeps",
+		Description: "AI agent powered by kdeps",
 		Version:     defaultVersion,
 		Port:        defaultPort,
 		Resources:   []string{"http-client", "llm", "response"},

--- a/cmd/package.go
+++ b/cmd/package.go
@@ -45,7 +45,7 @@ func newPackageCmd() *cobra.Command {
 	packageCmd := &cobra.Command{
 		Use:   "package [workflow-directory | agency-directory]",
 		Short: "Package workflow or agency for distribution",
-		Long: `Package KDeps workflow or agency into a portable archive file.
+		Long: `Package kdeps workflow or agency into a portable archive file.
 
 For a workflow directory (containing workflow.yaml):
   Creates a .kdeps archive (tar.gz) that can be used with:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,7 +87,7 @@ func createRootCommand() *cobra.Command {
 
 	rootCmd := &cobra.Command{
 		Use:           "kdeps [path]",
-		Short:         "KDeps - AI Agent Framework",
+		Short:         "kdeps - AI Appliance Builder",
 		Long:          `Build AI agents with YAML configuration. Run without arguments to start the interactive agent loop.`,
 		SilenceUsage:  true,
 		SilenceErrors: true,

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -60,7 +60,7 @@ func newRunCmd() *cobra.Command {
 	runCmd := &cobra.Command{
 		Use:   "run [workflow.yaml | package.kdeps]",
 		Short: "Run workflow locally",
-		Long: `Run KDeps workflow locally (default execution mode)
+		Long: `Run kdeps workflow locally (default execution mode)
 
 Local execution features:
   • Instant startup (< 1 second)
@@ -137,7 +137,7 @@ func RunWorkflowWithFlags(cmd *cobra.Command, args []string, flags *RunFlags) er
 		versionStr = "dev"
 	}
 
-	fmt.Fprintf(os.Stdout, "🚀 KDeps v%s - Local Execution\n\n", versionStr)
+	fmt.Fprintf(os.Stdout, "🚀 kdeps v%s - Local Execution\n\n", versionStr)
 	if debugMode {
 		fmt.Fprintln(os.Stdout, "🐛 Debug mode: Enabled")
 	}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -43,7 +43,7 @@ func newValidateCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "validate [path]",
 		Short: "Validate YAML configuration",
-		Long: `Validate KDeps workflow, component, or agency against JSON Schema and business rules
+		Long: `Validate kdeps workflow, component, or agency against JSON Schema and business rules
 
 Validation includes:
   - YAML syntax

--- a/docs/v2/concepts/agency.md
+++ b/docs/v2/concepts/agency.md
@@ -34,7 +34,7 @@ my-agency/
 ## Agency manifest (agency.yaml)
 
 ```yaml
-# workflow-agency.yaml
+# agency.yaml
 apiVersion: kdeps.io/v1
 kind: Agency
 

--- a/docs/v2/modes/workflow-mode.md
+++ b/docs/v2/modes/workflow-mode.md
@@ -98,7 +98,8 @@ requires: [llm]
 apiResponse:
   success: true
   response:
-    answer: get('llm')
+    # chat output is the raw response object; the reply text is at .message.content
+    answer: get('llm').message.content
 ```
 
 Run:
@@ -188,11 +189,11 @@ chat:
 actionId: response
 requires: [llm]
 before:
-  - memory_save('last_response', get('llm'))
+  - memory_save('last_response', get('llm').message.content)
 apiResponse:
   success: true
   response:
-    answer: get('llm')
+    answer: get('llm').message.content
 ```
 
 Memory entries are automatically linked into a relationship graph showing the chain from prompt to tool calls to results.


### PR DESCRIPTION
A three-pass `/ghost-review` of `README.md`, checked against the `./kdeps` binary and `docs/v2`.

## Pass 1
- **Lead with the agent-mode hook.** The pitch was one dense sentence about YAML + deployment; `kdeps` alone dropping you into an autonomous AI REPL was buried. Replaced with the three-levels framing (local agent / workflow / appliance), REPL first.
- **Fix inconsistent commands.** `kdeps bundle export iso` -> `kdeps export iso`; `kdeps bundle build .`.
- **Split the two densest sentences** (62-word pitch, ~100-word resource list -> prose).
- **Also:** `cmd/` help text and the `kdeps run` banner said "KDeps" -> lowercased across `run`, `package`, `build`, `export`, `validate`, `export_iso`, `export_k8s`, `new`. `root.go`'s `Short` -> `"kdeps - AI Appliance Builder"`. Scaffold description lowercased. `docs/v2/modes/workflow-mode.md` `get('llm')` -> `get('llm').message.content`.

## Pass 2
- **Bridge the taxonomies.** Pass 1 introduced "three levels"; "How it works" still said "two modes + agencies" with no link. Added a lead sentence tying them together.
- **Note the auth token.** Pitch says "no API key"; Quickstart opens with `export KDEPS_API_AUTH_TOKEN=dev-token`. Added a comment clarifying it guards the HTTP endpoint, not the model.
- Trimmed a soft trailing clause.

## Pass 3
- **Promote the three modes to `###` headings.** "Workflow mode" now spans a bridge sentence + 3 paragraphs + a code block; bold run-in text gave no outline, no anchor links, no scan boundary.
- **Tighten the pitch line** so it stops near-duplicating the three-levels list ("agents, workflows, and agencies" vs "Local agent / Workflow / Appliance").
- Dropped the redundant bare `kdeps ./my-agent/` line (the next line shows it with flags).
- `docs/v2/concepts/agency.md`: YAML block was commented `# workflow-agency.yaml` where the prose and file tree say `agency.yaml`.

## Verification
`go test ./cmd/` green, `make lint` clean, `docs/v2` build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)