### PR TITLE
docs: add "What is kdeps?" intro, gloss terms, concept before command

### DIFF
--- a/docs/v2/.vitepress/config.ts
+++ b/docs/v2/.vitepress/config.ts
@@ -50,7 +50,7 @@ export default defineConfig({
     siteTitle: false,
 
     nav: [
-      { text: 'Guide', link: '/getting-started/local-agent' },
+      { text: 'Guide', link: '/getting-started/introduction' },
       {
         text: 'Deploy',
         items: [
@@ -84,12 +84,14 @@ export default defineConfig({
         {
           text: 'Getting started',
           items: [
+            { text: 'What is kdeps?', link: '/getting-started/introduction' },
             { text: 'Why kdeps?', link: '/concepts/why-kdeps' },
             { text: 'Run locally', link: '/getting-started/local-agent' },
             { text: 'Quickstart', link: '/getting-started/quickstart' },
             { text: 'Workflow as a tool', link: '/getting-started/workflow-as-tool' },
             { text: 'Local models', link: '/getting-started/local-models' },
             { text: 'Installation', link: '/getting-started/installation' },
+            { text: 'Glossary', link: '/reference/glossary' },
           ]
         },
         {

--- a/docs/v2/concepts/overview.md
+++ b/docs/v2/concepts/overview.md
@@ -1,6 +1,18 @@
 # Concepts overview
 
-The mental model behind kdeps: how a workflow is shaped, how data moves between steps, and which pieces apply to each mode. Start with the two modes, then reach for the rest as you need them.
+The mental model behind kdeps: how a workflow is shaped, how data moves between steps, and which pieces apply to each mode. If you have not run kdeps yet, read [What is kdeps?](/getting-started/introduction) first.
+
+## How a workflow is shaped
+
+A kdeps project is a folder. `workflow.yaml` is the manifest - name, version,
+and `targetActionId` (the resource that produces the final result). Every other
+`.yaml` file under `resources/` is a single **resource**: one LLM call, one SQL
+query, one shell command, one HTTP request. A resource lists what it `requires:`,
+and kdeps runs the resources in that dependency order, passing each one's output
+forward. That ordered graph is the workflow.
+
+The tables below group every concept by what it does. Start with the two modes,
+then reach for the rest as you need them.
 
 ## The two modes
 

--- a/docs/v2/concepts/why-kdeps.md
+++ b/docs/v2/concepts/why-kdeps.md
@@ -1,6 +1,12 @@
 # Why kdeps?
 
-kdeps exists because most AI tooling is built for prototyping, not for running unattended in production. This page applies to both workflow mode and agent mode - it explains why the two exist and when to reach for each.
+kdeps exists because most AI tooling is built for prototyping, not for running unattended in production. This page applies to both workflow mode and agent mode - it explains why the two exist and when to reach for each. New to kdeps? Read [What is kdeps?](/getting-started/introduction) first.
+
+## The problem
+
+Shipping AI into production means more than calling an API. You need deterministic pipelines, typed inputs and outputs, dependency ordering, retries, validation, and the ability to deploy anywhere - not a chat session that ends when the browser tab closes.
+
+kdeps is an **AI Appliance Builder**. You define what the agent does in YAML, and it runs as a self-contained unit - an HTTP API, a bot, a file processor - without a human in the loop.
 
 ## Three levels of investment
 
@@ -35,12 +41,6 @@ docker run -p 16395:16395 ...     # serve as an HTTP API
 The workflow you ran locally becomes a self-contained deployable unit. See [Deployment guide](/guides/deployment-guide).
 
 ---
-
-## The problem
-
-Shipping AI into production means more than calling an API. You need deterministic pipelines, typed inputs and outputs, dependency ordering, retries, validation, and the ability to deploy anywhere - not a chat session that ends when the browser tab closes.
-
-kdeps is an **AI Appliance Builder**. You define what the agent does in YAML, and it runs as a self-contained unit - an HTTP API, a bot, a file processor - without a human in the loop.
 
 ## Deterministic by design
 

--- a/docs/v2/getting-started/introduction.md
+++ b/docs/v2/getting-started/introduction.md
@@ -1,0 +1,89 @@
+---
+title: What is kdeps?
+description: kdeps in plain English - what it is, the problem it solves, and the smallest mental model before you run anything.
+---
+
+# What is kdeps?
+
+kdeps is a single binary that turns a folder of YAML files into an AI agent you
+can run two ways: as an interactive chat in your terminal, or as an HTTP API you
+deploy to a server. The same files work both ways with no rewrite.
+
+You describe *what the agent does* - which model to call, what to validate, what
+shape the answer takes - in YAML. kdeps runs it. There is no application code to
+write and no framework to import.
+
+## The problem it solves
+
+Calling an LLM API is easy. Shipping that call into production is not. You end up
+hand-writing the same glue every time: input validation, retries, ordering
+between steps, a fixed response schema, a way to deploy it, a way to run it
+offline for testing. kdeps is that glue, defined declaratively and reused across
+every agent you build.
+
+## The smallest mental model
+
+```text
+a folder with workflow.yaml
+        |
+        +--  kdeps run ./my-agent/     ->  one-shot pipeline / HTTP API
+        |
+        +--  kdeps ./my-agent/         ->  interactive REPL, agent calls the workflow as a tool
+```
+
+- A **resource** is one step - an LLM call, a shell command, a SQL query, an HTTP
+  request. It lives in its own YAML file.
+- A **workflow** is a folder of resources plus a `workflow.yaml` manifest. Each
+  resource declares what it `requires:`, and kdeps runs them in that order.
+- A **mode** is how you run the workflow. [Workflow mode](/modes/workflow-mode)
+  (`kdeps run`) executes the steps in a fixed order and returns a structured
+  response - this is what you deploy. [Agent mode](/modes/agent-loop-mode)
+  (`kdeps [path]`) starts a chat REPL where an LLM decides when to call the
+  workflow.
+
+Every term kdeps uses is defined in the [Glossary](/reference/glossary).
+
+## The smallest working example
+
+No YAML at all - just run the binary:
+
+```bash
+kdeps            # opens an AI chat REPL against a local model, no API key
+```
+
+A minimal one-step workflow is a folder with two files:
+
+```yaml
+# my-agent/workflow.yaml - the manifest
+apiVersion: kdeps.io/v1
+kind: Workflow
+metadata:
+  name: my-agent
+  targetActionId: answer   # which resource produces the final result
+```
+
+<div v-pre>
+
+```yaml
+# my-agent/resources/answer.yaml - the one step
+actionId: answer           # this resource's id, referenced by targetActionId
+chat:
+  model: llama3.2:1b       # a local model, downloaded on first run
+  prompt: "{{ get('q') }}"   # 'q' comes from the HTTP request body or REPL input
+```
+
+</div>
+
+```bash
+kdeps run ./my-agent/     # run it once / serve it
+kdeps ./my-agent/         # or load it as a tool in the chat REPL
+```
+
+## Where to go next
+
+| You want to... | Start here |
+|---|---|
+| Run an AI agent locally right now | [Run locally in 30 seconds](/getting-started/local-agent) |
+| Understand why kdeps works this way | [Why kdeps?](/concepts/why-kdeps) |
+| Build a real HTTP API from YAML | [Quickstart](/getting-started/quickstart) |
+| See the full picture of every concept | [Concepts overview](/concepts/overview) |

--- a/docs/v2/getting-started/local-agent.md
+++ b/docs/v2/getting-started/local-agent.md
@@ -7,7 +7,7 @@ description: Install kdeps and start an AI agent REPL on your machine. No Docker
 
 kdeps ships as a standalone binary. Install it, run it, and you have an interactive AI agent running on your machine. No Docker. No config file. No API key required if you use a local model.
 
-*Applies to agent mode.*
+*Applies to [agent mode](/modes/agent-loop-mode) - the interactive LLM chat REPL. New to kdeps? Start with [What is kdeps?](/getting-started/introduction).*
 
 ## Install
 

--- a/docs/v2/getting-started/quickstart.md
+++ b/docs/v2/getting-started/quickstart.md
@@ -1,8 +1,17 @@
 # Quickstart
 
-Build a two-resource LLM API in workflow mode, then load the same file as a tool in agent mode.
+Build a two-resource LLM API in [workflow mode](/modes/workflow-mode), then load the same file as a tool in [agent mode](/modes/agent-loop-mode).
 
-*Applies to both workflow mode and agent mode.*
+*Applies to both workflow mode and agent mode. New to kdeps? Read [What is kdeps?](/getting-started/introduction) first.*
+
+## The mental model
+
+A **resource** is one step in its own YAML file (here: an LLM call, then a
+response). A **workflow** is a folder of resources plus a `workflow.yaml`
+manifest. Each resource names what it `requires:`, and kdeps runs the steps in
+that dependency order - a DAG. One step's output is read by the next with
+`get('<actionId>')`. That fixed order is what "workflow mode" means, and it is
+what you deploy.
 
 ## Overview
 

--- a/docs/v2/getting-started/workflow-as-tool.md
+++ b/docs/v2/getting-started/workflow-as-tool.md
@@ -1,8 +1,8 @@
 # Load a workflow as a tool
 
-Turn a `kind: Workflow` file into an LLM-callable tool in agent mode. You type a prompt; the model decides when to call the workflow; kdeps runs the full DAG and returns the result.
+Turn a `kind: Workflow` file into an LLM-callable tool in [agent mode](/modes/agent-loop-mode). You type a prompt; the model decides when to call the workflow; kdeps runs the full DAG and returns the result.
 
-*Applies to agent mode.*
+*Applies to agent mode - the interactive LLM chat REPL.*
 
 ## Overview
 

--- a/docs/v2/index.md
+++ b/docs/v2/index.md
@@ -9,14 +9,14 @@ hero:
   announcementLink: /getting-started/agent-skills
   actions:
     - theme: brand
-      text: Get started
-      link: /getting-started/local-agent
+      text: What is kdeps?
+      link: /getting-started/introduction
     - theme: brand
+      text: Run locally
+      link: /getting-started/local-agent
+    - theme: alt
       text: Build a workflow
       link: /getting-started/quickstart
-    - theme: alt
-      text: Why kdeps?
-      link: /concepts/why-kdeps
 
 features:
   - title: Local AI agent


### PR DESCRIPTION
## Summary

Onboarding fixes for docs/v2. Review found the docs assumed the reader already knew kdeps: no plain-English intro, terms used before definition, "Why kdeps?" (a justification page) as sidebar #1, "Concepts overview" as a bare link directory.

## Changes

- **New `getting-started/introduction.md`** ("What is kdeps?") - what it is, the problem it solves, the smallest mental model (folder of YAML -> run as REPL or API), a minimal 2-file working example. Sidebar page #1; landing-page primary CTA.
- `.vitepress/config.ts` - "What is kdeps?" first in Getting started; Glossary added to that section; nav Guide -> introduction.
- `concepts/why-kdeps.md` - "The problem" moved above "Three levels of investment"; link to the new intro.
- `getting-started/quickstart.md` - new "The mental model" section (resource / `requires:` / DAG) before the YAML paste; glossed mode names.
- `concepts/overview.md` - new "How a workflow is shaped" prose before the concept tables.
- `getting-started/local-agent.md`, `getting-started/workflow-as-tool.md` - glossed "agent mode" on first use, linked to the intro.
- `index.md` - CTAs: What is kdeps? / Run locally / Build a workflow.

## Tests

`npm run build` in `docs/v2/` passes (dead-link checking on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)