### PR TITLE
ci: fix stale coverage badge + orphaned docs from #757

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -440,8 +440,12 @@ jobs:
         run: bash tests/e2e/e2e.sh
 
   coverage-badge:
-    needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Gated on `changes`, not `test`: a squash-merge of an already-green PR
+    # skips `test` (already_tested), which used to skip the badge too - so the
+    # badge went stale after every fast-path merge. This computes coverage
+    # itself so it runs on every main push that touched code.
+    needs: changes
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -457,9 +461,15 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: go.mod
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: coverage-out
+      - name: Unit coverage
+        # Raw go test, not `make test-unit`: the badge must report the real
+        # number even when it dips below the 90% gate that `make test-unit`
+        # would fail on.
+        run: |
+          env -u KDEPS_SKIP_BOOTSTRAP -u KDEPS_COMPONENT_DIR KDEPS_MEMORY_DB_PATH=:memory: \
+            go test -short -parallel 1 -count=1 -timeout=30m \
+            -covermode=atomic -coverprofile=coverage.out ./pkg/... ./cmd/... ./ || true
+        timeout-minutes: 35
       - name: Update coverage badge
         run: |
           COV=$(go tool cover -func=coverage.out | tail -1 | awk '{print $NF}')

--- a/docs/v2/reference/cli/index.md
+++ b/docs/v2/reference/cli/index.md
@@ -50,6 +50,7 @@ kdeps run workflow.yaml
 | `kdeps export iso` | [Packaging commands](/reference/cli/packaging#kdeps-export-iso) | Export bootable image |
 | `kdeps export k8s` | [Packaging commands](/reference/cli/packaging#kdeps-export-k8s) | Generate Kubernetes manifests |
 | `kdeps llm` | [LLM commands](/reference/cli/llm) | LLM server appliances |
+| `kdeps m365 proxy` | [M365 Copilot](/reference/llm-providers-m365#standalone-proxy) | Serve M365 Copilot as a local OpenAI-compatible endpoint |
 
 ## Command workflow
 

--- a/docs/v2/resources/llm/index.md
+++ b/docs/v2/resources/llm/index.md
@@ -610,6 +610,12 @@ apiResponse:
     parsed: get('llmResource').answer            # if jsonResponse: true with key "answer"
 ```
 
+A failed call fails the resource. If the backend returns an HTTP error, times
+out, or is unreachable, the resource errors with `LLM call failed: <cause>` (the
+provider's own error text when it sends one) - it never yields an empty result,
+so `get('llmResource').message.content` never resolves to `<nil>`. Use `onError:`
+to retry or substitute a fallback.
+
 ## See also
 
 - [LLM backends](/resources/llm/backends) - Configure model, backend, API keys, and routing


### PR DESCRIPTION
## Coverage badge went stale
`coverage-badge` had `needs: test`. A squash-merge of an already-green PR skips the `test` job (the `already_tested` fast-path), so `coverage-badge` skipped with it — the badge JSON hasn't updated since before #752/#753/#757.

Fix: `coverage-badge` now `needs: changes` (not `test`), gated on `code == 'true'`, and runs its own raw `go test -coverprofile` pass so it reports the real number on every code-touching main push. Uses `|| true` so a dip below the 90% `make test-unit` gate still updates the badge.

## Orphaned docs
#757 fast-merged at its PR head before two follow-up doc commits synced; picking them up here:
- `reference/cli/index.md` — `kdeps m365 proxy` in the command table
- `resources/llm/index.md` — a failed chat call fails the resource with `LLM call failed: <cause>`, never `<nil>`

`book/` (gitignored) already synced locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)