### PR TITLE
docs: sharpen the motivation (self-hosted OSS, no subscription, RAG-first, the name)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 
 > Before moving on, please consider giving us a GitHub star ⭐️. Thank you!
 
-**AI Appliance Builder** - AI agents and workflows defined in YAML, shipped as appliances.
+**AI Appliance Builder** - AI agents and APIs (not chatbots) defined in YAML, shipped as appliances.
 
-One YAML file replaces a Python script wiring together an LLM SDK, a web server, retry logic, and a Dockerfile. kdeps is a small number of bounded pieces - pick the one you need:
+kdeps builds retrieval-augmented AI agents on open-source, self-hosted LLMs. One YAML file replaces a Python script wiring together an LLM SDK, a web server, retry logic, and a Dockerfile - and because it runs local models by default, the built image has no per-token cost and no AI subscription. kdeps is a small number of bounded pieces - pick the one you need:
 
 - **[kdeps agent](https://kdeps.com/agent/)** - run `kdeps` and you are in an autonomous AI REPL: tool use, memory, fully offline against a local model. No config, no API key.
 - **[kdeps workflow](https://kdeps.com/workflow/)** - define what the agent does in one `workflow.yaml` and run it as an HTTP API, a bot, or a file processor. Same file, laptop or server.

--- a/docs/v2/start/index.md
+++ b/docs/v2/start/index.md
@@ -15,11 +15,16 @@ write and no framework to import.
 
 ## The problem it solves
 
-Calling an LLM API is easy. Shipping that call into production is not. You end up
-hand-writing the same glue every time: input validation, retries, ordering
-between steps, a fixed response schema, a way to deploy it, a way to run it
-offline for testing. kdeps is that glue, defined declaratively and reused across
-every agent you build.
+There is no streamlined way to build **AI agents and APIs - not chatbots** - on
+open-source, self-hosted LLMs. You end up hand-writing the same glue every time:
+input validation, retries, ordering between steps, a fixed response schema, a way
+to deploy it, a way to run it offline. kdeps is that glue, defined declaratively.
+
+Everything a retrieval-augmented agent needs is in one Dockerized image you
+deploy on or off the cloud. Because it runs open-source models
+(llamafile, Ollama, or any HuggingFace GGUF), there is no per-token bill and no
+third-party AI subscription - the built appliance is free to run forever. Cloud
+providers (OpenAI, Anthropic, Groq) still work when you want them.
 
 ## The smallest mental model
 

--- a/docs/v2/start/why-kdeps.md
+++ b/docs/v2/start/why-kdeps.md
@@ -4,9 +4,11 @@ kdeps exists because most AI tooling is built for prototyping, not for running u
 
 ## The problem
 
-Shipping AI into production means more than calling an API. You need deterministic pipelines, typed inputs and outputs, dependency ordering, retries, validation, and the ability to deploy anywhere - not a chat session that ends when the browser tab closes.
+There is no streamlined way to build **AI agents and custom APIs - not chatbots** - on open-source, self-hosted LLMs. Every project re-implements the same glue: retrieval, deterministic pipelines, typed inputs and outputs, dependency ordering, retries, validation, and a way to deploy the result anywhere.
 
-kdeps is an **AI Appliance Builder**. You define what the agent does in YAML, and it runs as a self-contained unit - an HTTP API, a bot, a file processor - without a human in the loop.
+kdeps is an **AI Appliance Builder**. You define what the agent does in YAML, and it runs as a self-contained unit - an HTTP API, a bot, a file processor - without a human in the loop. Everything a retrieval-augmented agent needs ships in one Dockerized image.
+
+Because it runs open-source models by default (llamafile, Ollama, any HuggingFace GGUF), the built appliance has **no per-token cost and no AI subscription** - it is free to run forever, on or off the cloud. Cloud providers work too when you want them; the backend is one line of config, not baked into the workflow.
 
 ## Three levels of investment
 
@@ -98,9 +100,16 @@ The guarantee is not that your YAML runs forever on any future kdeps. It is that
 | Role | Use case |
 |------|----------|
 | Developers | Ship AI features into products (APIs, bots, internal tools) without glue code |
-| Operations teams | Automate repetitive work: reports, triage, data entry, document processing |
+| Operations teams | Automate repetitive work: log analysis, PR reviews, triage, ticket creation, incident messaging |
+| SMEs without an AI hire | Add AI to existing business processes and APIs with near-zero code and no recurring AI bill |
 | Marketing and growth | Content pipelines, SEO automation, campaign reporting |
 | Any team | Replace a human clicking through tabs and copy-pasting between tools |
+
+Concretely: log-file analysis, automated code reviews, JIRA ticket creation from an alert, an incident summary posted to MS Teams - each is a workflow that calls a model and one or two external APIs, deployed as one image.
+
+## The name
+
+kdeps is short for **knowledge dependencies**. It grew out of earlier work on Kartographer, a small graph library for organizing and interacting with information: knowledge - from a model, a machine, or a person - can be represented and orchestrated as a graph. A kdeps workflow is exactly that, a dependency graph of resources, run in order.
 
 
 ## See also


### PR DESCRIPTION
The production/determinism rewrite of why-kdeps replaced rather than augmented the original pitch. This restores three hooks it dropped:

1. self-hosted open-source LLMs, no per-token cost, no AI subscription
2. "agents and APIs, not chatbots" + RAG-first
3. the SME / no-AI-engineer audience, with concrete use cases

Also adds a short "The name" section (knowledge dependencies, from Kartographer). Determinism / built-to-last content kept as the second half.

Touches README intro, start/index.md, start/why-kdeps.md. Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)