### PR TITLE
docs: apply ghost-review fixes (hero, single mental model, landing parity)

### DIFF
--- a/docs/v2/agencies/index.md
+++ b/docs/v2/agencies/index.md
@@ -1,6 +1,23 @@
-# AI agencies
+# kdeps agencies
 
-An AI agency is a collection of kdeps agents that cooperate on a task. Each agent is a `kind: Workflow` with its own resources, bundled under one `agency.yaml`. Agencies work in both modes: `kdeps run my-agency/` runs the entry-point pipeline; `kdeps ./my-agency/` registers the agency as one LLM tool and runs that pipeline only when the model calls it.
+**Several agents composed into one system.** Each agent is its own `kind: Workflow`
+with its own model and resources, bundled under one `agency.yaml`. One agent
+delegates to another with the `agent:` resource - like a function call where the
+function is an entire pipeline.
+
+```bash
+kdeps run ./my-agency/     # run the entry-point agent's pipeline
+kdeps ./my-agency/         # register the agency as one LLM tool in the REPL
+```
+
+**Not this?** For a single deterministic pipeline, use [kdeps workflow](/workflow/).
+For an autonomous agent that decides what to do next, [kdeps agent](/agent/). To
+reuse one bundle of resources across projects, that's a
+[component](/agencies/components), not an agency.
+
+---
+
+An AI agency is a collection of kdeps agents that cooperate on a task. Agencies work in both modes: `kdeps run my-agency/` runs the entry-point pipeline; `kdeps ./my-agency/` registers the agency as one LLM tool and runs that pipeline only when the model calls it.
 
 ## Use cases
 
@@ -188,5 +205,5 @@ curl "http://localhost:17100/api/v1/greet?name=Alice" \
 - [Agent resource](/agencies/agent-resource) - `agent:` resource reference
 - [`examples/agency/`](https://github.com/kdeps/kdeps/tree/main/examples/agency) - runnable example
 - [Packaging commands](/deploy/cli) - `.kdeps` and `.kagency` formats
-- [Docker deployment](../deploy/docker) - building Docker images
-- [Standalone executables](../deploy/binaries) - exporting self-contained binaries
+- [Docker deployment](/deploy/docker) - building Docker images
+- [Standalone executables](/deploy/binaries) - exporting self-contained binaries

--- a/docs/v2/deploy/index.md
+++ b/docs/v2/deploy/index.md
@@ -1,8 +1,23 @@
-# Deployment guide
+# kdeps deploy
 
-End-to-end CI/CD pipeline: package your workflow, build a Docker image, push to a registry, and deploy to Kubernetes.
+**Ship the workflow you tested locally, unchanged.** Package it, build an image
+with no Dockerfile, and run it as a Docker container, Kubernetes deployment,
+bootable ISO, or a single self-contained binary. Same `workflow.yaml`, no
+rewrites, no re-config.
+
+```bash
+kdeps bundle build .      # workflow + model -> Docker image
+```
+
+**Not this?** To deploy a shared model server instead of an agent, that's
+[kdeps LLM server](/llm-server/). To publish an agent for others to install
+rather than run it yourself, [kdeps registry](/registry/).
+
+---
 
 *Applies to workflow mode.*
+
+End-to-end CI/CD pipeline: package your workflow, build a Docker image, push to a registry, and deploy to Kubernetes.
 
 ## Overview
 

--- a/docs/v2/index.md
+++ b/docs/v2/index.md
@@ -3,8 +3,8 @@ layout: home
 
 hero:
   name: kdeps
-  text: AI Appliance Builder
-  tagline: YAML-defined AI agents and workflow pipelines. Ship as Docker, K8s, ISO, or a single binary.
+  text: AI agents and APIs, not chatbots
+  tagline: Build retrieval-augmented AI agents on open-source, self-hosted LLMs. One YAML file, shipped as Docker, K8s, ISO, or a single binary - no per-token cost, no AI subscription.
   announcement: Scaffold YAML from Claude Code, Cursor, or Grok
   announcementLink: /agent/ai-assisted-authoring
   actions:

--- a/docs/v2/llm-server/index.md
+++ b/docs/v2/llm-server/index.md
@@ -1,12 +1,21 @@
-# LLM server appliance
+# kdeps LLM server
 
-Provision a **standalone LLM inference appliance** (no kdeps agent, no workflow) to Docker, ISO, or Kubernetes. Any kdeps host uses it as a client over **OpenAI-compatible `/v1`**.
+**A standalone OpenAI-compatible inference appliance** - no kdeps agent, no
+workflow. Build it once (Docker, ISO, or Kubernetes); every kdeps host on your
+network points at it over `/v1`.
 
-*Applies to workflow mode.*
+```bash
+kdeps llm wizard          # pick engine + model, then build/run/export
+```
 
-Works for **both** workflow mode and agent mode clients - set `llm.backend: openai` and `llm.base_url` on the client machine.
+**Not this?** `kdeps llm` deploys *only* the model server. To package an agent
+(workflow + model) as an image, that's [kdeps deploy](/deploy/). To run a model
+locally with no server at all, the default llamafile backend already does that -
+see [Local models](/start/local-models).
 
-Agent packaging (`kdeps bundle build` / `export iso` / `export k8s`) still deploys **agents**. `kdeps llm` deploys **only the inference server**.
+---
+
+Serves **both** workflow mode and agent mode clients - set `llm.backend: openai` and `llm.base_url` on the client machine.
 
 ## How it fits
 

--- a/docs/v2/start/index.md
+++ b/docs/v2/start/index.md
@@ -94,8 +94,8 @@ kdeps is a small number of bounded things. Pick one.
 | A deterministic YAML pipeline - API, bot, or file processor | [kdeps workflow](/workflow/) |
 | To orchestrate several agents/workflows as one system | [kdeps agencies](/agencies/) |
 | Just a self-hosted OpenAI-compatible endpoint, no workflow | [kdeps LLM server](/llm-server/) |
-| To ship a tested workflow as Docker / K8s / ISO / a binary | [kdeps deploy](/deploy/docker) |
-| To find, install, or publish shared agents and components | [kdeps registry](/registry/cli) |
+| To ship a tested workflow as Docker / K8s / ISO / a binary | [kdeps deploy](/deploy/) |
+| To find, install, or publish shared agents and components | [kdeps registry](/registry/) |
 
 ## First steps
 

--- a/docs/v2/start/why-kdeps.md
+++ b/docs/v2/start/why-kdeps.md
@@ -10,37 +10,23 @@ kdeps is an **AI Appliance Builder**. You define what the agent does in YAML, an
 
 Because it runs open-source models by default (llamafile, Ollama, any HuggingFace GGUF), the built appliance has **no per-token cost and no AI subscription** - it is free to run forever, on or off the cloud. Cloud providers work too when you want them; the backend is one line of config, not baked into the workflow.
 
-## Three levels of investment
+## The six products
 
-You don't need Docker or a workflow file to start. kdeps works at three levels - a local REPL, a YAML workflow, a deployed appliance - and the [two modes](#two-modes-one-workflow-file) run at every level:
+kdeps is a small number of bounded pieces. Most people need one or two.
 
-**1. Local AI agent** - run `kdeps` in your terminal right now
+| Product | What it is | First command |
+|---|---|---|
+| [kdeps agent](/agent/) | Autonomous LLM REPL - tool use, memory, calls a workflow when it decides to | `kdeps` |
+| [kdeps workflow](/workflow/) | Deterministic YAML pipeline - HTTP API, bot, or file processor | `kdeps run ./my-agent/` |
+| [kdeps agencies](/agencies/) | Several agents composed into one system via the `agent:` resource | `kdeps run ./my-agency/` |
+| [kdeps LLM server](/llm-server/) | Standalone OpenAI-compatible inference appliance, no workflow | `kdeps llm wizard` |
+| [kdeps deploy](/deploy/) | Ship a tested workflow as Docker, K8s, ISO, or a binary | `kdeps bundle build .` |
+| [kdeps registry](/registry/) | Find, install, and publish shared agents and components | `kdeps registry search` |
 
-```bash
-kdeps                            # open-source AI agent REPL, zero config
-kdeps --model llama3.2           # swap to any local or cloud model
-kdeps ./my-workflow/             # load your workflows as tools
-```
-
-Works with any model: local llamafile (default, no API key), Ollama, or any cloud provider. See [Run locally in 30 seconds](/agent/quickstart).
-
-**2. Workflow runner** - define what the agent does in YAML, run it locally or share it
-
-```bash
-kdeps run workflow.yaml          # run a workflow as a one-shot pipeline
-kdeps ./my-agent/                # load it as tools in the agent REPL
-```
-
-One file describes inputs, resources, and outputs. Run it on your laptop or on a server - same file, same behavior. See [Quickstart](/workflow/quickstart).
-
-**3. Production API** - deploy to Docker, Kubernetes, or a standalone binary
-
-```bash
-kdeps bundle build .              # package workflow + model into a Docker image
-docker run -p 16395:16395 ...     # serve as an HTTP API
-```
-
-The workflow you ran locally becomes a self-contained deployable unit. See [Deployment guide](/deploy/).
+You don't need Docker or even a YAML file to start: run `kdeps` and you have an
+agent REPL against a local model. Add a `workflow.yaml` when you want a
+deterministic pipeline you can deploy; reach for the rest as the work grows. The
+[two modes](#two-modes-one-workflow-file) below apply to whichever you use.
 
 ---
 


### PR DESCRIPTION
From a /ghost-review pass over the core reader-path pages.

1. **Hero** now leads with the sharpened positioning (not-chatbots / self-hosted OSS / no subscription) instead of the generic "YAML AI agents" line - the pitch README and start/ make was one click deep.
2. **One mental model**: why-kdeps.md's leftover "three levels of investment" section becomes the 6-product table, matching start/ and README.
3. **Landing parity**: agencies/, llm-server/, deploy/ opened like old topic pages while agent/, workflow/, registry/ opened as product landings. All six now use the same bold-one-liner + first-command + "Not this?" pattern. "Deployment guide" retitled "kdeps deploy".
4. Minor: start/ product table -> landing URLs; agencies/ absolute links.

Build clean. Full review report saved locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)