### PR TITLE
docs: add Innovation technology section (kartographer, turo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Docs: [Deployment guide](https://kdeps.com/deploy/) · [TLS and HTTPS](https://k
 - **Global config** - machine-local settings (LLM backend, API keys, SQL/SMTP/IMAP connections) live in `~/.kdeps/config.yaml`, never in `workflow.yaml`. `kdeps edit` to open it, `kdeps doctor` to check it. [Docs](https://kdeps.com/reference/advanced-config)
 - **Security** - when `apiServer` is set, requests require a bearer token (`KDEPS_API_AUTH_TOKEN`) and pass through rate-limit, body-size, and concurrency caps before reaching the DAG. [Docs](https://kdeps.com/reference/security)
 - **Logging** - structured JSON via `log/slog`. `KDEPS_LOG_FORMAT=json` for production; default level WARN; `--verbose` (INFO), `--debug` (DEBUG).
+- **Innovation technology** - two standalone Go tools built alongside kdeps: [kdeps/kartographer](https://github.com/kdeps/kartographer) (graph library for resolving dependent nodes - powers the `requires:` DAG and folder/skill graphs) and [kdeps/turo](https://github.com/kdeps/turo) (reduces prose to content words to cut LLM input tokens - the optional agent-mode [prompt reducer](https://kdeps.com/agent/turo)).
 - **Book** - [*AI Appliances - Build & Deploy Autonomous AI Agents and Agencies in YAML*](https://leanpub.com/kdeps). Free (PDF, EPUB, web).
 
 ---

--- a/docs/v2/start/why-kdeps.md
+++ b/docs/v2/start/why-kdeps.md
@@ -97,6 +97,14 @@ Concretely: log-file analysis, automated code reviews, JIRA ticket creation from
 
 kdeps is short for **knowledge dependencies**. It grew out of earlier work on [Kartographer](https://github.com/kdeps/kartographer), a graph library for resolving dependent nodes: knowledge - from a model, a machine, or a person - can be represented and orchestrated as a graph. A kdeps workflow is exactly that, a dependency graph of resources, run in order.
 
+## Innovation technology
+
+kdeps is built on two small open-source projects developed alongside it. Both are standalone Go tools you can use on their own.
+
+| Project | What it does | Where kdeps uses it |
+|---|---|---|
+| [kdeps/kartographer](https://github.com/kdeps/kartographer) | A graph library for resolving dependent nodes. | The `requires:` DAG that orders every workflow; the reference/topic graph behind `codeIntelligence` folder indexing, `searchLocal` `graphBoost`, and skill-library linking. |
+| [kdeps/turo](https://github.com/kdeps/turo) | Reduces prose to its content words to cut LLM input tokens - "point more, token less." | The optional [prompt reducer](/agent/turo) for agent mode: when the `turo` binary is on `PATH`, kdeps pipes system preamble, input, tool results, and history through it before every model call. |
 
 ## See also
 


### PR DESCRIPTION
New "## Innovation technology" section in start/why-kdeps.md (plus a README Reference bullet) collecting the two standalone Go projects kdeps is built on:

- [kdeps/kartographer](https://github.com/kdeps/kartographer) - graph library for resolving dependent nodes
- [kdeps/turo](https://github.com/kdeps/turo) - prose -> content words to cut LLM input tokens

Both were already referenced scattershot across the docs; this gives them one home. Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)