### PR TITLE
docs: reposition around AI appliance builder + who-it's-for section

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 
 > Before moving on, please consider giving us a GitHub star ⭐️. Thank you!
 
-**AI Appliance Builder** - AI agents and APIs (not chatbots) defined in YAML, shipped as appliances.
+**AI Appliance Builder** - define an agent once in YAML; ship the workflow, tools, and model as one self-contained deployment that runs anywhere.
 
-kdeps builds retrieval-augmented AI agents on open-source, self-hosted LLMs. One YAML file replaces a Python script wiring together an LLM SDK, a web server, retry logic, and a Dockerfile - and because it runs local models by default, the built image has no per-token cost and no AI subscription. kdeps is a small number of bounded pieces - pick the one you need:
+kdeps packages an AI workload - agent or deterministic API, not a chatbot - into a unit you can run as a terminal REPL, an HTTP API, a Docker image, Kubernetes manifests, a bootable ISO, or a single binary. One YAML file replaces a Python script wiring together an LLM SDK, a web server, retry logic, and a Dockerfile. It runs open-source, self-hosted models by default, so the built appliance has no per-token cost and no dependency on an external AI service - it works the same on a laptop and inside an air-gapped network. kdeps is a small number of bounded pieces - pick the one you need:
 
 - **[kdeps agent](https://kdeps.com/agent/)** - run `kdeps` and you are in an autonomous AI REPL: tool use, memory, fully offline against a local model. No config, no API key.
 - **[kdeps workflow](https://kdeps.com/workflow/)** - define what the agent does in one `workflow.yaml` and run it as an HTTP API, a bot, or a file processor. Same file, laptop or server.

--- a/docs/v2/.vitepress/theme/HomeWhoNeedsThis.vue
+++ b/docs/v2/.vitepress/theme/HomeWhoNeedsThis.vue
@@ -1,0 +1,125 @@
+<!--
+  Copyright 2026 Kdeps, KvK 94834768
+  Licensed under the Apache License, Version 2.0
+-->
+<template>
+  <section class="who-needs">
+    <div class="container">
+      <p class="section-eyebrow">who it's for</p>
+      <h2 class="section-title">When you can't send data to an external AI service</h2>
+      <p class="section-sub">kdeps packages the model with the workflow, so the whole thing runs inside your boundary.</p>
+
+      <div class="cards">
+        <a href="/deploy/kubernetes" class="card">
+          <h3>Private enterprise AI</h3>
+          <p>Deploy an internal RAG or document-processing agent entirely inside your customer's VPC. No prompts, no documents, no embeddings leave their infrastructure.</p>
+          <span class="tag">on-prem &middot; regulated</span>
+        </a>
+
+        <a href="/deploy/binaries" class="card">
+          <h3>Edge &amp; air-gapped AI</h3>
+          <p>Ship the model and workflow as a bootable ISO or a single binary. Runs on a disconnected edge box with no external AI dependency and no network at inference time.</p>
+          <span class="tag">edge &middot; offline</span>
+        </a>
+
+        <a href="/workflow/quickstart" class="card">
+          <h3>AI APIs without the glue</h3>
+          <p>Turn a YAML workflow into a production HTTP API and container. No FastAPI, no LangChain wiring, no hand-written Dockerfile - validation, ordering, and response shape are declared.</p>
+          <span class="tag">workflow mode</span>
+        </a>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.who-needs {
+  padding: 72px 24px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.section-eyebrow {
+  font-family: var(--vp-font-family-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vp-c-brand-1);
+  margin: 0 0 10px;
+}
+
+.section-title {
+  font-size: 36px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--vp-c-text-1);
+  margin: 0 0 8px;
+}
+
+.section-sub {
+  font-size: 16px;
+  color: var(--vp-c-text-2);
+  margin: 0 0 48px;
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 16px;
+}
+
+.card {
+  background: var(--vp-c-bg-soft);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 2px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  text-decoration: none;
+  transition: transform 0.15s ease, border-color 0.15s ease;
+}
+
+.card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(0, 229, 255, 0.25);
+}
+
+.card h3 {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--vp-c-text-1);
+  margin: 0;
+}
+
+.card p {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--vp-c-text-2);
+  margin: 0;
+  flex: 1;
+}
+
+.tag {
+  font-family: var(--vp-font-family-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vp-c-text-3);
+  align-self: flex-start;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 2px;
+  padding: 2px 8px;
+}
+
+@media (max-width: 768px) {
+  .who-needs { padding: 48px 16px; }
+  .cards { grid-template-columns: 1fr; }
+}
+</style>

--- a/docs/v2/.vitepress/theme/index.ts
+++ b/docs/v2/.vitepress/theme/index.ts
@@ -23,6 +23,7 @@ import { h } from 'vue'
 import type { Theme } from 'vitepress'
 import HeroInfo from './HeroInfo.vue'
 import HeroCode from './HeroCode.vue'
+import HomeWhoNeedsThis from './HomeWhoNeedsThis.vue'
 import HomeHowItWorks from './HomeHowItWorks.vue'
 import HomeCapabilities from './HomeCapabilities.vue'
 import HomeComparison from './HomeComparison.vue'
@@ -38,6 +39,7 @@ export default {
       'home-hero-info': () => h(HeroInfo),
       'home-hero-after': () => h(HeroCode),
       'home-features-after': () => [
+        h(HomeWhoNeedsThis),
         h(HomeHowItWorks),
         h(HomeCapabilities),
         h(HomeComparison),

--- a/docs/v2/index.md
+++ b/docs/v2/index.md
@@ -3,8 +3,8 @@ layout: home
 
 hero:
   name: kdeps
-  text: AI agents and APIs, not chatbots
-  tagline: Build retrieval-augmented AI agents on open-source, self-hosted LLMs. One YAML file, shipped as Docker, K8s, ISO, or a single binary - no per-token cost, no AI subscription.
+  text: Build AI appliances that run anywhere
+  tagline: "Define your agent once in YAML. kdeps packages the workflow, tools, and model into one self-contained deployment - cloud, on-prem, edge, or air-gapped. Open-source models by default: no per-token cost, no external AI dependency."
   announcement: Scaffold YAML from Claude Code, Cursor, or Grok
   announcementLink: /agent/ai-assisted-authoring
   actions:

--- a/docs/v2/start/index.md
+++ b/docs/v2/start/index.md
@@ -5,13 +5,15 @@ description: kdeps in plain English - what it is, the problem it solves, and the
 
 # What is kdeps?
 
-kdeps is a single binary that turns a folder of YAML files into an AI agent you
-can run two ways: as an interactive chat in your terminal, or as an HTTP API you
-deploy to a server. The same files work both ways with no rewrite.
+kdeps is an **AI appliance builder**. You describe an agent in YAML - which model
+to call, what to validate, what shape the answer takes - and kdeps packages the
+workflow, its tools, and the model into one self-contained unit you can run as a
+terminal REPL, an HTTP API, a Docker image, a Kubernetes deployment, a bootable
+ISO, or a single binary. The same files, no rewrite, no framework to import.
 
-You describe *what the agent does* - which model to call, what to validate, what
-shape the answer takes - in YAML. kdeps runs it. There is no application code to
-write and no framework to import.
+Because it runs open-source models by default, that unit has no per-token cost
+and no dependency on an external AI service - it works the same on your laptop
+and inside an air-gapped network.
 
 ## The problem it solves
 


### PR DESCRIPTION
Acting on positioning feedback (the site shows capability breadth, not a buyer).

- **Hero** -> "Build AI appliances that run anywhere": define once, package workflow + tools + model, deploy cloud / on-prem / edge / air-gapped. (Reverts the 'agents and APIs, not chatbots' line back toward the appliance framing that matches the book title.)
- **New section** `HomeWhoNeedsThis.vue`, placed first below the feature grid: three concrete use cases instead of a capability list - private enterprise AI (in-VPC RAG), edge / air-gapped (ISO / binary, no network at inference), AI APIs without the glue.
- **start/index.md + README** openings realigned to the appliance framing; open-source / no-per-token-cost hook kept.

No commercial / control-plane claims added - that's a product decision, not a docs edit. Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)