### PR TITLE
docs: lead with git-native AI appliances

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 
 > Before moving on, please consider giving us a GitHub star ⭐️. Thank you!
 
-**AI Appliance Builder** - define an agent once in YAML; ship the workflow, tools, and model as one self-contained deployment that runs anywhere.
+**Git-native AI Appliance Builder** - your agent is YAML in your repo; ship the workflow, tools, and model as one self-contained deployment that runs anywhere.
 
-kdeps packages an AI workload - agent or deterministic API, not a chatbot - into a unit you can run as a terminal REPL, an HTTP API, a Docker image, Kubernetes manifests, a bootable ISO, or a single binary. One YAML file replaces a Python script wiring together an LLM SDK, a web server, retry logic, and a Dockerfile. It runs open-source, self-hosted models by default, so the built appliance has no per-token cost and no dependency on an external AI service - it works the same on a laptop and inside an air-gapped network. kdeps is a small number of bounded pieces - pick the one you need:
+kdeps packages an AI workload - agent or deterministic API, not a chatbot - into a unit you can run as a terminal REPL, an HTTP API, a Docker image, Kubernetes manifests, a bootable ISO, or a single binary. The definition is text you commit: reviewed as a pull request, versioned by git tag, installed with `kdeps registry install owner/repo`, built reproducibly from a commit in CI. One YAML file replaces a Python script wiring together an LLM SDK, a web server, retry logic, and a Dockerfile. It runs open-source, self-hosted models by default, so the built appliance has no per-token cost and no dependency on an external AI service - it works the same on a laptop and inside an air-gapped network. kdeps is a small number of bounded pieces - pick the one you need:
 
 - **[kdeps agent](https://kdeps.com/agent/)** - run `kdeps` and you are in an autonomous AI REPL: tool use, memory, fully offline against a local model. No config, no API key.
 - **[kdeps workflow](https://kdeps.com/workflow/)** - define what the agent does in one `workflow.yaml` and run it as an HTTP API, a bot, or a file processor. Same file, laptop or server.

--- a/docs/v2/.vitepress/theme/HomeGitNative.vue
+++ b/docs/v2/.vitepress/theme/HomeGitNative.vue
@@ -1,0 +1,114 @@
+<!--
+  Copyright 2026 Kdeps, KvK 94834768
+  Licensed under the Apache License, Version 2.0
+-->
+<template>
+  <section class="git-native">
+    <div class="container">
+      <p class="section-eyebrow">git-native</p>
+      <h2 class="section-title">The agent is text in your repo</h2>
+      <p class="section-sub">No hidden state, no proprietary format. Everything kdeps runs is YAML you commit.</p>
+
+      <div class="cards">
+        <div class="card">
+          <h3>Reviewable</h3>
+          <p>A change to an agent is a diff: a new resource, a tightened validation, a swapped model. Review it in a pull request like any other code.</p>
+        </div>
+        <div class="card">
+          <h3>Versioned</h3>
+          <p>A git tag is a release. <code>kdeps registry install scraper@2.1.0</code> resolves to that tag; the built appliance pins the runtime and the model too.</p>
+        </div>
+        <div class="card">
+          <h3>Distributable</h3>
+          <p><code>kdeps registry install owner/repo</code> pulls an agent or component straight from its GitHub repo. Publishing is a tag plus a one-line formula PR.</p>
+        </div>
+        <div class="card">
+          <h3>Reproducible</h3>
+          <p>Point CI at a tag: <code>kdeps validate</code>, <code>kdeps bundle build</code>, push the image. The same commit produces the same appliance every time.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.git-native {
+  padding: 72px 24px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.section-eyebrow {
+  font-family: var(--vp-font-family-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vp-c-brand-1);
+  margin: 0 0 10px;
+}
+
+.section-title {
+  font-size: 36px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--vp-c-text-1);
+  margin: 0 0 8px;
+}
+
+.section-sub {
+  font-size: 16px;
+  color: var(--vp-c-text-2);
+  margin: 0 0 48px;
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
+  gap: 16px;
+}
+
+.card {
+  background: var(--vp-c-bg-soft);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 2px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.card h3 {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--vp-c-text-1);
+  margin: 0;
+}
+
+.card p {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--vp-c-text-2);
+  margin: 0;
+}
+
+.card code {
+  font-family: var(--vp-font-family-mono);
+  font-size: 12px;
+  background: rgba(255, 255, 255, 0.05);
+  padding: 1px 5px;
+  border-radius: 2px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: #00E5FF;
+  word-break: break-word;
+}
+
+@media (max-width: 768px) {
+  .git-native { padding: 48px 16px; }
+  .cards { grid-template-columns: 1fr; }
+}
+</style>

--- a/docs/v2/.vitepress/theme/index.ts
+++ b/docs/v2/.vitepress/theme/index.ts
@@ -24,6 +24,7 @@ import type { Theme } from 'vitepress'
 import HeroInfo from './HeroInfo.vue'
 import HeroCode from './HeroCode.vue'
 import HomeWhoNeedsThis from './HomeWhoNeedsThis.vue'
+import HomeGitNative from './HomeGitNative.vue'
 import HomeHowItWorks from './HomeHowItWorks.vue'
 import HomeCapabilities from './HomeCapabilities.vue'
 import HomeComparison from './HomeComparison.vue'
@@ -40,6 +41,7 @@ export default {
       'home-hero-after': () => h(HeroCode),
       'home-features-after': () => [
         h(HomeWhoNeedsThis),
+        h(HomeGitNative),
         h(HomeHowItWorks),
         h(HomeCapabilities),
         h(HomeComparison),

--- a/docs/v2/index.md
+++ b/docs/v2/index.md
@@ -3,8 +3,8 @@ layout: home
 
 hero:
   name: kdeps
-  text: Build AI appliances that run anywhere
-  tagline: "Define your agent once in YAML. kdeps packages the workflow, tools, and model into one self-contained deployment - cloud, on-prem, edge, or air-gapped. Open-source models by default: no per-token cost, no external AI dependency."
+  text: Build git-native AI appliances
+  tagline: "Your agent is YAML in your repo. Review it as a pull request, version it with a tag, install it with `owner/repo`. kdeps packages the workflow, tools, and open-source model into one self-contained deployment for cloud, on-prem, edge, or air-gapped - no per-token cost, no external AI dependency."
   announcement: Scaffold YAML from Claude Code, Cursor, or Grok
   announcementLink: /agent/ai-assisted-authoring
   actions:

--- a/docs/v2/start/index.md
+++ b/docs/v2/start/index.md
@@ -5,11 +5,13 @@ description: kdeps in plain English - what it is, the problem it solves, and the
 
 # What is kdeps?
 
-kdeps is an **AI appliance builder**. You describe an agent in YAML - which model
-to call, what to validate, what shape the answer takes - and kdeps packages the
-workflow, its tools, and the model into one self-contained unit you can run as a
-terminal REPL, an HTTP API, a Docker image, a Kubernetes deployment, a bootable
-ISO, or a single binary. The same files, no rewrite, no framework to import.
+kdeps is a **git-native AI appliance builder**. You describe an agent in YAML -
+which model to call, what to validate, what shape the answer takes - and those
+files live in your repo: reviewed as pull requests, versioned by tag, installed
+with `owner/repo`. kdeps packages the workflow, its tools, and the model into one
+self-contained unit you can run as a terminal REPL, an HTTP API, a Docker image,
+a Kubernetes deployment, a bootable ISO, or a single binary. The same files, no
+rewrite, no framework to import.
 
 Because it runs open-source models by default, that unit has no per-token cost
 and no dependency on an external AI service - it works the same on your laptop

--- a/docs/v2/start/why-kdeps.md
+++ b/docs/v2/start/why-kdeps.md
@@ -38,6 +38,26 @@ If the input is wrong, the workflow fails fast with a clear error instead of hal
 
 Agent mode is the opposite: there the model decides which resources run and in what order.
 
+## Git-native
+
+Everything kdeps runs is YAML in your repository. There is no database of agent
+state, no proprietary project file, no web console that owns the source of truth.
+
+- **Review** an agent change the way you review code - a diff of resources,
+  validations, and prompts in a pull request.
+- **Version** with a git tag. `kdeps registry install scraper@2.1.0` resolves to
+  that tag; the formula pulls the tarball straight from
+  `github.com/owner/repo/archive/refs/tags/v2.1.0.tar.gz`.
+- **Distribute** by pointing at a repo: `kdeps registry install owner/repo`
+  works with no registry entry at all. Publishing is a tag plus a one-line
+  formula PR to [kdeps/registry](https://github.com/kdeps/registry).
+- **Build reproducibly** in CI: `kdeps validate` -> `kdeps bundle build` ->
+  `docker push`, triggered on tag. The same commit yields the same appliance,
+  runtime and model pinned.
+
+The [`git:` resource](/workflow/resources/git) also lets an agent read and write
+repository state as part of its pipeline - status, diff, log, commit, branch.
+
 ## Two modes, one workflow file
 
 ```d2


### PR DESCRIPTION
"git-native" is a specific, verifiable differentiator the docs weren't naming:

- agent = YAML in your repo (clean diffs, PR review)
- `kdeps registry install owner/repo` / `name@version` -> git tag; formula pulls the tag tarball
- CI on tag: validate -> build -> push, reproducible from a commit
- `git:` resource for agents that operate on repos

Changes: hero line, new `HomeGitNative.vue` landing section (reviewable / versioned / distributable / reproducible), a "Git-native" section in why-kdeps.md, start/ + README openings. Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)