### PR TITLE
docs: git-native sections lead with "the YAML is the behavior spec"

### DIFF
--- a/docs/v2/.vitepress/theme/HomeGitNative.vue
+++ b/docs/v2/.vitepress/theme/HomeGitNative.vue
@@ -6,13 +6,13 @@
   <section class="git-native">
     <div class="container">
       <p class="section-eyebrow">git-native</p>
-      <h2 class="section-title">The agent is text in your repo</h2>
-      <p class="section-sub">No hidden state, no proprietary format. Everything kdeps runs is YAML you commit.</p>
+      <h2 class="section-title">The YAML is the behavior spec</h2>
+      <p class="section-sub">What the appliance does - model, validation, step order, response shape - is defined entirely by the YAML in your repo. Change it, commit, and it behaves differently; your git history is the changelog of the agent's behavior. Only the model binding lives outside the repo, so the same commit runs local on a laptop and cloud in production.</p>
 
       <div class="cards">
         <div class="card">
           <h3>Reviewable</h3>
-          <p>A change to an agent is a diff: a new resource, a tightened validation, a swapped model. Review it in a pull request like any other code.</p>
+          <p>A change to an agent is a diff: a new resource, a tightened validation, a reshaped response. Review it in a pull request like any other code.</p>
         </div>
         <div class="card">
           <h3>Versioned</h3>

--- a/docs/v2/start/why-kdeps.md
+++ b/docs/v2/start/why-kdeps.md
@@ -40,8 +40,22 @@ Agent mode is the opposite: there the model decides which resources run and in w
 
 ## Git-native
 
-Everything kdeps runs is YAML in your repository. There is no database of agent
-state, no proprietary project file, no web console that owns the source of truth.
+**The YAML is the behavior spec.** What your appliance does - which model it
+calls, what it validates, which steps run in what order, the shape of the
+response - is entirely defined by the `workflow.yaml` and `resources/*.yaml` in
+your repository. There is no database of agent state, no proprietary project
+file, no web console that owns the source of truth. Change the YAML, commit, and
+the appliance behaves differently. Your git history is the changelog of the
+agent's behavior.
+
+The one thing that lives *outside* the repo is the backend binding - the LLM
+backend, model names, API keys, and database or SMTP connections in
+`~/.kdeps/config.yaml` and environment variables. That is deliberate: the same
+repo runs against a local llamafile on your laptop and a cloud model in
+production with no diff. Your agent's logic is in git; only its wiring to a
+specific model is not.
+
+Because the definition is plain text under version control:
 
 - **Review** an agent change the way you review code - a diff of resources,
   validations, and prompts in a pull request.


### PR DESCRIPTION
Retune per the author's disambiguation of "git-native": the point is that the YAML committed to the repo *is* the behavior spec - change it and the appliance behaves differently; git history is the behavior changelog.

- HomeGitNative.vue: title "The YAML is the behavior spec"; sub states the claim + the one exception (model binding lives in config, not the repo, so the same commit runs local or cloud). The 4 tiles (review/version/distribute/reproduce) stay as consequences.
- why-kdeps.md "Git-native": same lead paragraph + the config-layer caveat, then "because the definition is plain text under version control:" before the bullets.

Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)