### PR TITLE
docs: make clear the registry is optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@
 
 **Git-native AI Appliance Builder** - your agent is YAML in your repo; ship the workflow, tools, and model as one self-contained deployment that runs anywhere.
 
-kdeps packages an AI workload - agent or deterministic API, not a chatbot - into a unit you can run as a terminal REPL, an HTTP API, a Docker image, Kubernetes manifests, a bootable ISO, or a single binary. The definition is text you commit: reviewed as a pull request, versioned by git tag, installed with `kdeps registry install owner/repo`, built reproducibly from a commit in CI. One YAML file replaces a Python script wiring together an LLM SDK, a web server, retry logic, and a Dockerfile. It runs open-source, self-hosted models by default, so the built appliance has no per-token cost and no dependency on an external AI service - it works the same on a laptop and inside an air-gapped network. kdeps is a small number of bounded pieces - pick the one you need:
+kdeps packages an AI workload - agent or deterministic API, not a chatbot - into a unit you can run as a terminal REPL, an HTTP API, a Docker image, Kubernetes manifests, a bootable ISO, or a single binary. The definition is text you commit: reviewed as a pull request, versioned by git tag, built reproducibly from a commit in CI. Change the YAML, and the appliance behaves differently - your git history is the changelog of the agent's behavior. One YAML file replaces a Python script wiring together an LLM SDK, a web server, retry logic, and a Dockerfile. It runs open-source, self-hosted models by default, so the built appliance has no per-token cost and no dependency on an external AI service - it works the same on a laptop and inside an air-gapped network. kdeps is a small number of bounded pieces - pick the one you need:
 
 - **[kdeps agent](https://kdeps.com/agent/)** - run `kdeps` and you are in an autonomous AI REPL: tool use, memory, fully offline against a local model. No config, no API key.
 - **[kdeps workflow](https://kdeps.com/workflow/)** - define what the agent does in one `workflow.yaml` and run it as an HTTP API, a bot, or a file processor. Same file, laptop or server.
 - **[kdeps agencies](https://kdeps.com/agencies/)** - coordinate several specialized agents as one system, delegating work through the `agent:` resource.
 - **[kdeps LLM server](https://kdeps.com/llm-server/)** - provision a standalone OpenAI-compatible inference appliance, no workflow path required.
 - **[kdeps deploy](https://kdeps.com/deploy/)** - ship a workflow unchanged as a Docker image, Kubernetes manifests, a bootable ISO, or a single binary.
-- **[kdeps registry](https://kdeps.com/registry/)** - find, install, and publish shared agents and components.
+- **[kdeps registry](https://kdeps.com/registry/)** *(optional)* - find, install, and publish shared agents and components by name. Not needed to build or run your own.
 
 ## Quickstart
 

--- a/docs/v2/.vitepress/theme/HomeGitNative.vue
+++ b/docs/v2/.vitepress/theme/HomeGitNative.vue
@@ -16,15 +16,15 @@
         </div>
         <div class="card">
           <h3>Versioned</h3>
-          <p>A git tag is a release. <code>kdeps registry install scraper@2.1.0</code> resolves to that tag; the built appliance pins the runtime and the model too.</p>
-        </div>
-        <div class="card">
-          <h3>Distributable</h3>
-          <p><code>kdeps registry install owner/repo</code> pulls an agent or component straight from its GitHub repo. Publishing is a tag plus a one-line formula PR.</p>
+          <p>A git tag is a release. <code>kdeps validate</code> and <code>kdeps bundle build</code> run against any checkout or tag; the built appliance pins the runtime and the model too.</p>
         </div>
         <div class="card">
           <h3>Reproducible</h3>
           <p>Point CI at a tag: <code>kdeps validate</code>, <code>kdeps bundle build</code>, push the image. The same commit produces the same appliance every time.</p>
+        </div>
+        <div class="card">
+          <h3>Shareable, optionally</h3>
+          <p>The <a href="/registry/">registry</a> is a convenience for installing and publishing agents by name - <code>kdeps registry install owner/repo</code> pulls from a GitHub repo. You never need it to build or deploy your own.</p>
         </div>
       </div>
     </div>

--- a/docs/v2/index.md
+++ b/docs/v2/index.md
@@ -40,7 +40,7 @@ features:
     link: /deploy/
     linkText: Ship it
   - title: kdeps registry
-    details: Find, install, and publish shared agents and components. Pull a published workflow into your project with one command, or publish your own.
+    details: Optional. A convenience layer for finding, installing, and publishing shared agents and components by name. You never need it to build or run your own.
     link: /registry/
     linkText: Browse the registry
 ---

--- a/docs/v2/registry/index.md
+++ b/docs/v2/registry/index.md
@@ -5,9 +5,10 @@ description: Find, install, and publish shared kdeps agents and components.
 
 # kdeps registry
 
-**A package registry for kdeps agents and components.** Pull a published
-workflow, agency, or component into your project with one command, or publish
-your own for others to reuse.
+**An optional package registry for kdeps agents and components.** Pull a
+published workflow, agency, or component into your project with one command, or
+publish your own for others to reuse. Building, running, and deploying your own
+agent never touches the registry - it is purely a way to share work by name.
 
 ```bash
 kdeps registry search scraper            # find packages

--- a/docs/v2/start/index.md
+++ b/docs/v2/start/index.md
@@ -99,7 +99,7 @@ kdeps is a small number of bounded things. Pick one.
 | To orchestrate several agents/workflows as one system | [kdeps agencies](/agencies/) |
 | Just a self-hosted OpenAI-compatible endpoint, no workflow | [kdeps LLM server](/llm-server/) |
 | To ship a tested workflow as Docker / K8s / ISO / a binary | [kdeps deploy](/deploy/) |
-| To find, install, or publish shared agents and components | [kdeps registry](/registry/) |
+| To find, install, or publish shared agents and components (optional) | [kdeps registry](/registry/) |
 
 ## First steps
 

--- a/docs/v2/start/why-kdeps.md
+++ b/docs/v2/start/why-kdeps.md
@@ -21,12 +21,14 @@ kdeps is a small number of bounded pieces. Most people need one or two.
 | [kdeps agencies](/agencies/) | Several agents composed into one system via the `agent:` resource | `kdeps run ./my-agency/` |
 | [kdeps LLM server](/llm-server/) | Standalone OpenAI-compatible inference appliance, no workflow | `kdeps llm wizard` |
 | [kdeps deploy](/deploy/) | Ship a tested workflow as Docker, K8s, ISO, or a binary | `kdeps bundle build .` |
-| [kdeps registry](/registry/) | Find, install, and publish shared agents and components | `kdeps registry search` |
+| [kdeps registry](/registry/) *(optional)* | Find, install, and publish shared agents and components | `kdeps registry search` |
 
 You don't need Docker or even a YAML file to start: run `kdeps` and you have an
 agent REPL against a local model. Add a `workflow.yaml` when you want a
 deterministic pipeline you can deploy; reach for the rest as the work grows. The
-[two modes](#two-modes-one-workflow-file) below apply to whichever you use.
+registry is optional - it is a way to share agents by name, not a step in
+building or running your own. The [two modes](#two-modes-one-workflow-file) below
+apply to whichever you use.
 
 ---
 
@@ -55,19 +57,20 @@ repo runs against a local llamafile on your laptop and a cloud model in
 production with no diff. Your agent's logic is in git; only its wiring to a
 specific model is not.
 
-Because the definition is plain text under version control:
+The core loop needs nothing but git and the `kdeps` binary: edit YAML, commit,
+`kdeps run` or `kdeps bundle build`. Everything below builds on that.
 
 - **Review** an agent change the way you review code - a diff of resources,
   validations, and prompts in a pull request.
-- **Version** with a git tag. `kdeps registry install scraper@2.1.0` resolves to
-  that tag; the formula pulls the tarball straight from
-  `github.com/owner/repo/archive/refs/tags/v2.1.0.tar.gz`.
-- **Distribute** by pointing at a repo: `kdeps registry install owner/repo`
-  works with no registry entry at all. Publishing is a tag plus a one-line
-  formula PR to [kdeps/registry](https://github.com/kdeps/registry).
+- **Version** with a git tag. A tag is a release; `kdeps validate` and
+  `kdeps bundle build` run against any checkout or tag.
 - **Build reproducibly** in CI: `kdeps validate` -> `kdeps bundle build` ->
   `docker push`, triggered on tag. The same commit yields the same appliance,
   runtime and model pinned.
+- **Share, optionally.** [kdeps registry](/registry/) is a convenience layer for
+  installing and publishing agents and components by name -
+  `kdeps registry install owner/repo` pulls straight from a GitHub repo, no
+  registry entry required. You never need it to build or deploy your own agent.
 
 The [`git:` resource](/workflow/resources/git) also lets an agent read and write
 repository state as part of its pipeline - status, diff, log, commit, branch.


### PR DESCRIPTION
The git-native framing implied the registry is part of the core loop (versioning + distribution routed through `kdeps registry install`). It isn't - edit YAML -> commit -> `kdeps run` / `kdeps bundle build` needs only git and the binary.

- why-kdeps "Git-native": bullets now lead with "the core loop needs nothing but git and the kdeps binary"; registry demoted to a "Share, optionally" bullet
- six-products table + start/ product table: registry marked *(optional)*
- HomeGitNative: "Distributable" tile -> "Shareable, optionally"; Versioned/Reproducible stand on tag + bundle build
- registry/index.md + README: registry = optional share layer, not a build step

Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)