### PR TITLE
chore: bump docs version to 2.23.1 for release

### DIFF
--- a/docs/v2/package.json
+++ b/docs/v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kdeps-docs",
-  "version": "2.23.0",
+  "version": "2.23.1",
   "description": "kdeps Documentation",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Release prep. Since v2.23.0: WASM conditional-compile remnant purge (#757), docs product-split into 6 sections (#763), landing/positioning rework (#765-#776), coverage-badge CI fix (#758), harvester data refresh. No new features, no behavior or API changes - patch bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)