### PR TITLE
fix(agent): window the in-turn tool transcript to bound token spend

### DIFF
--- a/docs/v2/agent/repl.md
+++ b/docs/v2/agent/repl.md
@@ -113,6 +113,18 @@ Only turns longer than a threshold alert, so quick replies stay quiet.
 
 Set the default at startup with the `KDEPS_GGUF_CTX_SIZE` (gguf) or `KDEPS_LLAMAFILE_CTX_SIZE` (file) environment variables. In resource YAML, `contextSize:` on a `chat:` block overrides per call; for Ollama only, `ollamaNumCtx:` is also accepted and takes precedence.
 
+### In-turn tool history
+
+A single turn can make many tool calls (`/model tool set rounds <n>`, default 200). The transcript of those calls and their results is re-sent to the model on every round, so a long tool loop can otherwise grow the request without bound - `/compact` and the auto-compaction that runs between turns do not fire mid-turn.
+
+kdeps caps the in-flight transcript at roughly 24K tokens. Past that, the oldest complete tool round-trips are dropped (the leading conversation and this turn's question are always kept), and long tool-call arguments on the older kept steps are replaced with a `[N chars omitted]` placeholder. When this happens you see:
+
+```
+[context] trimmed 3 old tool step(s) to fit the window
+```
+
+The model keeps the most recent steps in full and a note that earlier ones were dropped. Tool *results* are separately capped at 16 KB each before they ever enter the transcript.
+
 ## Sessions
 
 Every conversation is saved as a JSONL file under `~/.kdeps/sessions/`. The session ID is shown at the start of each run. Resume one with:

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -1783,6 +1783,16 @@ func (l *Loop) appendToolRoundTrip(
 	}
 
 	updated := *cfg
+	// Bound the in-flight transcript: auto-compaction only runs at turn
+	// boundaries, so a long tool loop (up to MaxToolRounds round trips in one
+	// turn) would otherwise re-send an ever-growing message array on every
+	// round. Drop the oldest round-trips once the array exceeds the budget.
+	history, droppedRTs := windowToolHistory(history, l.config.Model)
+	if droppedRTs > 0 {
+		if pw := l.progressWriter(w); pw != nil {
+			fmt.Fprintf(pw, "\n[context] trimmed %d old tool step(s) to fit the window\n", droppedRTs)
+		}
+	}
 	if b, err := json.Marshal(history); err == nil {
 		updated.Messages = string(b)
 		updated.Prompt = "" // already in history

--- a/pkg/agent/tool_history_window.go
+++ b/pkg/agent/tool_history_window.go
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2026 Kdeps, KvK 94834768
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// toolLoopMessageBudget bounds the total estimated token size of the in-flight
+// message array during a single turn's tool loop. Past this, the oldest
+// complete tool round-trips are dropped so a long loop (many tool calls in one
+// turn) does not re-send an ever-growing transcript on every round -- the
+// dominant token cost in a long agent session. Auto-compaction only runs at
+// turn boundaries, so without this the transcript grows unbounded within a turn
+// up to MaxToolRounds (default 200) round trips.
+const toolLoopMessageBudget = 24 * 1024
+
+// toolRoundTripArgTruncateAt is the argument-string length past which a retained
+// (older) assistant tool-call's long string arguments are replaced with a
+// placeholder in windowed history. A large write_file / edit_file content
+// argument is pure re-sent weight once its result is in the transcript.
+const toolRoundTripArgTruncateAt = 256
+
+// windowKeepRecentRoundTrips is the number of most-recent kept round-trips whose
+// tool-call arguments are never truncated -- the model may still be acting on
+// them.
+const windowKeepRecentRoundTrips = 2
+
+func msgRole(m map[string]any) string {
+	r, _ := m["role"].(string)
+	return r
+}
+
+func msgHasToolCalls(m map[string]any) bool {
+	tc, ok := m["tool_calls"]
+	if !ok || tc == nil {
+		return false
+	}
+	switch v := tc.(type) {
+	case []any:
+		return len(v) > 0
+	case []map[string]any:
+		return len(v) > 0
+	default:
+		return true
+	}
+}
+
+// isRoundTripStart reports whether m is the assistant message that opens a tool
+// round-trip (assistant turn carrying one or more tool_calls).
+func isRoundTripStart(m map[string]any) bool {
+	return msgRole(m) == RoleAssistant && msgHasToolCalls(m)
+}
+
+func msgTokens(m map[string]any, model string) int {
+	b, err := json.Marshal(m)
+	if err != nil {
+		return 0
+	}
+	return countTokensSilent(model, string(b))
+}
+
+func msgsTokens(ms []map[string]any, model string) int {
+	total := 0
+	for _, m := range ms {
+		total += msgTokens(m, model)
+	}
+	return total
+}
+
+// historyBytes is a cheap upper-bound proxy for token size: the JSON-marshaled
+// length of every message. Used to skip the tokenizer on small transcripts.
+func historyBytes(ms []map[string]any) int {
+	total := 0
+	for _, m := range ms {
+		if b, err := json.Marshal(m); err == nil {
+			total += len(b)
+		}
+	}
+	return total
+}
+
+// windowToolHistory bounds the in-flight message array during a turn's tool
+// loop. When the transcript exceeds toolLoopMessageBudget it drops the oldest
+// complete tool round-trips (an assistant-with-tool_calls message plus every
+// tool result that follows it), keeps the newest round-trips that fit, and
+// truncates long string arguments on the older kept round-trips. The leading
+// conversation -- session history plus this turn's user question -- is always
+// kept intact, and at least one full round-trip is always retained even if it
+// alone exceeds the budget. A dropped span is announced by a short note
+// prepended to the first kept round-trip's assistant content, so no extra
+// message (and no consecutive same-role pair) is introduced.
+//
+// Returns the windowed history and the number of round-trips dropped.
+func windowToolHistory(history []map[string]any, model string) ([]map[string]any, int) {
+	if len(history) == 0 {
+		return history, 0
+	}
+	// Cheap byte-length pre-check: at ~2 bytes/token minimum, a transcript under
+	// budget*2 bytes cannot exceed the token budget, so skip the (per-round)
+	// tokenizer pass entirely in the common case.
+	if historyBytes(history) <= toolLoopMessageBudget*2 {
+		return history, 0
+	}
+	if msgsTokens(history, model) <= toolLoopMessageBudget {
+		return history, 0
+	}
+
+	head := 0
+	for head < len(history) && !isRoundTripStart(history[head]) {
+		head++
+	}
+	if head == len(history) {
+		return history, 0 // nothing but conversation; not ours to trim
+	}
+	headMsgs := history[:head]
+	rest := history[head:]
+
+	// Segment the tail into round-trips: each starts at an assistant tool-call
+	// message and runs through the tool results that follow it.
+	var rts [][]map[string]any
+	for i := 0; i < len(rest); {
+		j := i + 1
+		for j < len(rest) && msgRole(rest[j]) == roleTool {
+			j++
+		}
+		rts = append(rts, rest[i:j])
+		i = j
+	}
+	if len(rts) <= 1 {
+		return history, 0 // can't drop the only round-trip
+	}
+
+	budget := toolLoopMessageBudget - msgsTokens(headMsgs, model)
+	if budget < 0 {
+		budget = 0
+	}
+
+	keptCount, used := 0, 0
+	for k := len(rts) - 1; k >= 0; k-- {
+		segTok := msgsTokens(rts[k], model)
+		if keptCount > 0 && used+segTok > budget {
+			break
+		}
+		used += segTok
+		keptCount++
+	}
+	if keptCount < 1 {
+		keptCount = 1
+	}
+	dropped := len(rts) - keptCount
+	if dropped <= 0 {
+		return history, 0
+	}
+
+	keptRTs := rts[len(rts)-keptCount:]
+	for idx := range max(0, len(keptRTs)-windowKeepRecentRoundTrips) {
+		truncateRoundTripArgs(keptRTs[idx])
+	}
+	prependDroppedNote(keptRTs[0], dropped)
+
+	out := make([]map[string]any, 0, len(history))
+	out = append(out, headMsgs...)
+	for _, seg := range keptRTs {
+		out = append(out, seg...)
+	}
+	return out, dropped
+}
+
+const roleTool = "tool"
+
+func prependDroppedNote(seg []map[string]any, dropped int) {
+	if len(seg) == 0 {
+		return
+	}
+	prev, _ := seg[0][toolParamContent].(string)
+	note := fmt.Sprintf(
+		"[note: %d earlier tool round-trip(s) from this turn were dropped to fit the context window]",
+		dropped)
+	if prev != "" {
+		note += "\n" + prev
+	}
+	seg[0][toolParamContent] = note
+}
+
+// truncateRoundTripArgs replaces long string values inside a retained assistant
+// message's tool-call arguments with a "[N chars omitted]" placeholder, keeping
+// the arguments valid JSON and preserving short identifying fields (file_path,
+// url, query, ...).
+func truncateRoundTripArgs(seg []map[string]any) {
+	if len(seg) == 0 {
+		return
+	}
+	raw, isArr := seg[0]["tool_calls"].([]any)
+	if !isArr {
+		return
+	}
+	for _, item := range raw {
+		if fn := callArgsFn(item); fn != nil {
+			shrinkArgFields(fn)
+		}
+	}
+}
+
+// callArgsFn returns the "function" map of one tool_calls entry, or nil.
+func callArgsFn(item any) map[string]any {
+	call, isMap := item.(map[string]any)
+	if !isMap {
+		return nil
+	}
+	fn, isMap := call["function"].(map[string]any)
+	if !isMap {
+		return nil
+	}
+	return fn
+}
+
+// shrinkArgFields parses fn["arguments"] (a JSON object string) and swaps any
+// long string value for a placeholder, re-marshaling in place.
+func shrinkArgFields(fn map[string]any) {
+	args, isStr := fn["arguments"].(string)
+	if !isStr {
+		return
+	}
+	var parsed map[string]any
+	if json.Unmarshal([]byte(args), &parsed) != nil {
+		return
+	}
+	changed := false
+	for k, v := range parsed {
+		s, ok := v.(string)
+		if !ok || len(s) <= toolRoundTripArgTruncateAt {
+			continue
+		}
+		parsed[k] = fmt.Sprintf("[%d chars omitted; see the tool result]", len(s))
+		changed = true
+	}
+	if changed {
+		if b, err := json.Marshal(parsed); err == nil {
+			fn["arguments"] = string(b)
+		}
+	}
+}

--- a/pkg/agent/tool_history_window_test.go
+++ b/pkg/agent/tool_history_window_test.go
@@ -1,0 +1,294 @@
+/*
+ * Copyright 2026 Kdeps, KvK 94834768
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/kdeps/kdeps/v2/pkg/domain"
+	"github.com/kdeps/kdeps/v2/pkg/executor"
+	"github.com/kdeps/kdeps/v2/pkg/tools"
+)
+
+func rtAssistant(id string, argChars int) map[string]any {
+	args := `{"file_path":"a.txt"}`
+	if argChars > 0 {
+		args = `{"file_path":"a.txt","content":"` + strings.Repeat("x", argChars) + `"}`
+	}
+	return map[string]any{
+		"role":    RoleAssistant,
+		"content": "",
+		"tool_calls": []any{
+			map[string]any{
+				"id":   id,
+				"type": "function",
+				"function": map[string]any{
+					"name":      "write_file",
+					"arguments": args,
+				},
+			},
+		},
+	}
+}
+
+func rtTool(id string, resultChars int) map[string]any {
+	return map[string]any{
+		"role":         roleTool,
+		"tool_call_id": id,
+		"name":         "write_file",
+		"content":      strings.Repeat("y", resultChars),
+	}
+}
+
+func TestWindowToolHistory_UnderBudgetUnchanged(t *testing.T) {
+	h := []map[string]any{
+		{"role": RoleUser, "content": "do a thing"},
+		rtAssistant("c1", 0),
+		rtTool("c1", 50),
+	}
+	out, dropped := windowToolHistory(h, "")
+	if dropped != 0 || len(out) != len(h) {
+		t.Fatalf("expected no change, got dropped=%d len=%d", dropped, len(out))
+	}
+}
+
+func TestWindowToolHistory_DropsOldestKeepsHeadAndRecent(t *testing.T) {
+	h := []map[string]any{
+		{"role": RoleUser, "content": "the question"},
+	}
+	// 20 round-trips, each ~2k tokens of result -> ~40k, well over the 24k budget.
+	for i := range 20 {
+		id := "c" + string(rune('A'+i))
+		h = append(h, rtAssistant(id, 0), rtTool(id, 8*1024))
+	}
+	out, dropped := windowToolHistory(h, "")
+	if dropped == 0 {
+		t.Fatal("expected round-trips to be dropped")
+	}
+
+	// Head (the user question) must be preserved as message 0.
+	if msgRole(out[0]) != RoleUser || out[0]["content"] != "the question" {
+		t.Fatalf("head not preserved: %v", out[0])
+	}
+
+	// Result must be within budget.
+	if got := msgsTokens(out, ""); got > toolLoopMessageBudget {
+		t.Fatalf("windowed history %d tokens exceeds budget %d", got, toolLoopMessageBudget)
+	}
+
+	// Pairing must be valid: every tool message's tool_call_id must be answered
+	// by a preceding assistant tool_calls entry.
+	assertValidPairing(t, out)
+
+	// The first kept round-trip carries the dropped-count note.
+	firstRT := -1
+	for i, m := range out {
+		if isRoundTripStart(m) {
+			firstRT = i
+			break
+		}
+	}
+	if firstRT < 0 {
+		t.Fatal("no round-trip survived")
+	}
+	if note, _ := out[firstRT]["content"].(string); !strings.Contains(note, "dropped to fit") {
+		t.Fatalf("first kept round-trip missing drop note: %q", note)
+	}
+}
+
+func TestWindowToolHistory_AlwaysKeepsOneRoundTrip(t *testing.T) {
+	h := []map[string]any{
+		{"role": RoleUser, "content": "q"},
+		rtAssistant("c1", 0), rtTool("c1", 120*1024), // each ~30k tokens, alone over budget
+		rtAssistant("c2", 0), rtTool("c2", 120*1024),
+	}
+	out, dropped := windowToolHistory(h, "")
+	if dropped != 1 {
+		t.Fatalf("expected exactly 1 dropped, got %d", dropped)
+	}
+	assertValidPairing(t, out)
+	// The most recent round-trip (c2) must survive even though it alone busts
+	// the budget.
+	found := false
+	for _, m := range out {
+		if m["tool_call_id"] == "c2" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("most recent round-trip was dropped")
+	}
+}
+
+func TestWindowToolHistory_TruncatesOldArgsKeepsValidJSON(t *testing.T) {
+	h := []map[string]any{{"role": RoleUser, "content": "q"}}
+	for i := range 12 {
+		id := "c" + string(rune('A'+i))
+		h = append(h, rtAssistant(id, 20*1024), rtTool(id, 1024)) // big args
+	}
+	out, dropped := windowToolHistory(h, "")
+	if dropped == 0 {
+		t.Fatal("expected drops")
+	}
+
+	// Find kept round-trip assistant messages in order.
+	var kept []map[string]any
+	for _, m := range out {
+		if isRoundTripStart(m) {
+			kept = append(kept, m)
+		}
+	}
+	if len(kept) < 3 {
+		t.Skipf("only %d kept; truncation test needs >=3", len(kept))
+	}
+	// All but the last windowKeepRecentRoundTrips must have truncated args, and
+	// every args string must remain valid JSON.
+	for i, m := range kept {
+		raw := m["tool_calls"].([]any)
+		fn := raw[0].(map[string]any)["function"].(map[string]any)
+		args := fn["arguments"].(string)
+		var parsed map[string]any
+		if err := json.Unmarshal([]byte(args), &parsed); err != nil {
+			t.Fatalf("kept round-trip %d has invalid JSON args: %v", i, err)
+		}
+		if _, ok := parsed["file_path"]; !ok {
+			t.Fatalf("kept round-trip %d lost its identifying file_path field", i)
+		}
+		older := i < len(kept)-windowKeepRecentRoundTrips
+		content, _ := parsed["content"].(string)
+		if older && !strings.Contains(content, "chars omitted") {
+			t.Fatalf("older kept round-trip %d args not truncated: %q", i, content)
+		}
+		if !older && strings.Contains(content, "chars omitted") {
+			t.Fatalf("recent kept round-trip %d args wrongly truncated", i)
+		}
+	}
+}
+
+func TestWindowToolHistory_NoRoundTripsUnchanged(t *testing.T) {
+	h := []map[string]any{
+		{"role": RoleUser, "content": strings.Repeat("q ", 20*1024)},
+		{"role": RoleAssistant, "content": strings.Repeat("a ", 20*1024)},
+	}
+	out, dropped := windowToolHistory(h, "")
+	if dropped != 0 || len(out) != 2 {
+		t.Fatalf("plain conversation must not be windowed: dropped=%d len=%d", dropped, len(out))
+	}
+}
+
+func TestWindowToolHistory_Empty(t *testing.T) {
+	out, dropped := windowToolHistory(nil, "")
+	if dropped != 0 || out != nil {
+		t.Fatalf("nil in, nil out expected")
+	}
+}
+
+// capturingStreamer records the messages array sent on the most recent call and
+// replays a fixed sequence of tool-call rounds.
+type capturingStreamer struct {
+	responses []mockStreamResponse
+	callCount int
+	lastMsgs  string
+}
+
+func (c *capturingStreamer) StreamChat(
+	_ context.Context, cfg *domain.ChatConfig, w io.Writer,
+) (string, []domain.StreamedToolCall, error) {
+	c.lastMsgs = cfg.Messages
+	if c.callCount >= len(c.responses) {
+		return "", nil, nil
+	}
+	r := c.responses[c.callCount]
+	c.callCount++
+	_, _ = io.WriteString(w, r.content)
+	return r.content, r.toolCalls, nil
+}
+
+// TestRunStreaming_ToolLoopHistoryStaysBounded verifies the mid-loop windowing
+// is wired: a long tool loop where every result is large must not let the
+// re-sent message array grow without bound.
+func TestRunStreaming_ToolLoopHistoryStaysBounded(t *testing.T) {
+	const rounds = 40
+	responses := make([]mockStreamResponse, 0, rounds+1)
+	for i := range rounds {
+		responses = append(responses, mockStreamResponse{
+			toolCalls: []domain.StreamedToolCall{{
+				ID:        strconv.Itoa(i),
+				Name:      "bigout",
+				Arguments: `{"i":` + strconv.Itoa(i) + `}`,
+			}},
+		})
+	}
+	responses = append(responses, mockStreamResponse{content: "done"})
+
+	cs := &capturingStreamer{responses: responses}
+	eng := executor.NewEngine(nil)
+	reg := tools.NewRegistry()
+	reg.Register(&tools.Tool{
+		Name:        "bigout",
+		Description: "returns a large payload",
+		Execute: func(map[string]any) (string, error) {
+			return strings.Repeat("payload line\n", 4096), nil // ~48 KB per call
+		},
+	})
+	loop := New(eng, newTestWorkflowForSession(), reg, Config{
+		Model: "test", Streamer: cs, MaxToolRounds: rounds + 2,
+	})
+
+	var buf strings.Builder
+	if _, err := loop.RunStreaming(context.Background(), "go", &buf); err != nil {
+		t.Fatalf("RunStreaming: %v", err)
+	}
+	if cs.callCount < rounds {
+		t.Fatalf("loop stopped early at %d rounds", cs.callCount)
+	}
+
+	sentTokens := countTokensSilent("", cs.lastMsgs)
+	// Without windowing this would be ~rounds * (16 KB cap / 4) ~= 160k tokens.
+	// With it, the array is held near toolLoopMessageBudget plus at most one
+	// fresh round-trip of slack.
+	if sentTokens > toolLoopMessageBudget*2 {
+		t.Fatalf("in-flight history grew to %d tokens; windowing not bounding it", sentTokens)
+	}
+}
+
+// assertValidPairing checks that every role:tool message is preceded (anywhere
+// earlier) by an assistant message whose tool_calls include its tool_call_id.
+func assertValidPairing(t *testing.T, msgs []map[string]any) {
+	t.Helper()
+	known := map[string]bool{}
+	for _, m := range msgs {
+		if isRoundTripStart(m) {
+			for _, tc := range m["tool_calls"].([]any) {
+				if id, ok := tc.(map[string]any)["id"].(string); ok {
+					known[id] = true
+				}
+			}
+		}
+		if msgRole(m) == roleTool {
+			id, _ := m["tool_call_id"].(string)
+			if !known[id] {
+				t.Fatalf("orphan tool message: tool_call_id %q has no preceding assistant call", id)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Investigation of "kdeps agent consumes too many tokens in one session" found the dominant cause: `runToolRounds` makes up to `MaxToolRounds` (default 200) LLM calls for a single user turn and re-sends the entire growing message array on every round. Auto-compaction only runs at turn boundaries, never inside the loop, and nothing else bounds the in-flight transcript. Cumulative input-token cost within one turn is O(n²).

(Tool *results* were already capped at 16 KB each; tool-call *arguments* and the sheer count of retained round-trips were not.)

## Fix

`windowToolHistory` (new, `pkg/agent/tool_history_window.go`), called from `appendToolRoundTrip` after each round trip:

- when the transcript exceeds ~24 KB tokens, drop the oldest complete tool round-trips (assistant-with-`tool_calls` + the `tool` results that follow it) as units
- always keep the leading conversation + this turn's question, and at least one full round-trip
- on kept round-trips older than the last 2, replace long string values in tool-call `arguments` with `[N chars omitted; see the tool result]` — stays valid JSON, keeps `file_path`/`url`/`query`
- prints `[context] trimmed N old tool step(s) to fit the window`
- a cheap byte-length pre-check skips the tokenizer on normal-size loops

## Tests

`pkg/agent/tool_history_window_test.go` — 7 tests: under-budget no-op, drop-oldest-keep-head-and-recent, always-keep-one, arg truncation keeps valid JSON, plain-conversation untouched, empty input, and `TestRunStreaming_ToolLoopHistoryStaysBounded` (40-round loop with 48 KB results stays bounded).

`pkg/agent` full package green (130s); `cmd/` green (1715); `make lint` 0 issues; docs build clean.

## Docs

`docs/v2/agent/repl.md` → new "In-turn tool history" subsection under Context window size.

## Deferred

- non-Anthropic backends re-send the (static) system preamble uncached every round — OpenAI auto-caches a stable prefix already; Ollama/local/Groq have no caching hook to add safely
- the known-model auto-compact trigger (`contextWindow - 16k`) is deliberate pi-parity