### PR TITLE
fix(agent): make the goal planner actually decompose the request

### DIFF
--- a/docs/v2/agent/goals.md
+++ b/docs/v2/agent/goals.md
@@ -12,14 +12,29 @@ prompt -> decompose into tasks -> confirm -> [task 1] -> [task 2] -> ... -> answ
                                      ^ only the active task is in scope
 ```
 
+**Decomposing the prompt.** The planner is asked to break the request into its
+natural steps - one task per distinct action it names or implies, typically two
+to six. If the first attempt just returns the whole request restated as a single
+task, the loop retries once with an explicit "break this into at least two
+steps" instruction before accepting a one-task plan. A weak local model (for
+example the default `llama3.2:1b`) may still fail to produce a real breakdown;
+switch to a larger model or the router for better plans.
+
+**Skipping decomposition.** A short remark (32 characters or fewer) or any
+question under ~120 characters is treated as chat and drives a single-task goal
+without a planning call, so ordinary conversation costs nothing extra. A longer
+imperative one-liner - "clean up the logging package and wire it into startup" -
+is planned even without an explicit "then"/"and then" marker.
+
 **Confirming the plan.** Reaching the original prompt's goal can take several
 intermediate tasks, and a single decomposition call can misorder, omit, or
 invent a step. Once decomposition produces more than one task, an independent
 second LLM call reviews the candidate list against the original request and
 either approves it unchanged or returns a corrected list - the plan the loop
 actually runs is always the confirmed one. A single-task plan skips this
-(nothing to reorder), and a failed or unparsable confirmation falls back to
-the original candidate rather than blocking the turn.
+(nothing to reorder); a confirmation that tries to collapse a multi-step plan
+back to one task is ignored; and a failed or unparsable confirmation falls back
+to the original candidate rather than blocking the turn.
 
 **How a task is settled.** The model cannot finish a task by saying so in prose.
 It calls one of two tools and the code validates the id against the active task:

--- a/pkg/agent/coverage_wave6_test.go
+++ b/pkg/agent/coverage_wave6_test.go
@@ -31,7 +31,7 @@ import (
 func TestRequestPlan_NoLocalServer(t *testing.T) {
 	for _, backend := range []string{"", "file", "gguf"} {
 		l := &Loop{config: Config{Backend: backend}}
-		if got := requestPlan(l, "do something", false); got != nil {
+		if got := requestPlan(l, "do something", ""); got != nil {
 			t.Fatalf("backend %q: %v", backend, got)
 		}
 	}

--- a/pkg/agent/goal_planner.go
+++ b/pkg/agent/goal_planner.go
@@ -42,17 +42,22 @@ const goalPlanActionID = "agent_loop_plan"
 // and just multiply per-task budgets.
 const maxPlanTasks = 12
 
-const goalPlanSystemPrompt = `You decompose a user request into an ordered task list.
+const goalPlanSystemPrompt = `You break a user request into an ordered list of concrete steps.
 
 Reply with ONLY a JSON object, no prose and no code fence:
-{"tasks":["first concrete step","second concrete step"]}
+{"tasks":["first concrete step","second concrete step","third concrete step"]}
 
 Rules:
-- Each task is one concrete, verifiable step stated as an imperative.
-- Order them so each can start once the previous is done.
-- Emit the FEWEST tasks that actually complete the request. A simple question is ONE task.
-- Never include meta-steps like "understand the request" or "plan the work".
-- Maximum 12 tasks.`
+- Each task is one concrete, verifiable action stated as an imperative ("Read X", "Add Y", "Run the tests").
+- Break the request into its natural steps: one task per distinct action it names or implies. A typical request is 2 to 6 tasks.
+- Do NOT return the whole request as a single task, and do NOT restate it - decompose it.
+- Order the tasks so each can start once the previous is done.
+- Never pad with meta-steps like "understand the request", "plan the work", or "review the result".
+- Maximum 12 tasks.
+
+Example
+Request: Add a --dry-run flag to the sync command and cover it with a test
+{"tasks":["Add a --dry-run boolean flag to the sync command definition","Guard the write path so --dry-run logs the planned actions instead of applying them","Add a unit test that runs sync with --dry-run and asserts nothing was written","Run the test suite"]}`
 
 // planGoal decomposes input into a Goal. It never returns nil and never returns
 // an error: a failed or unparsable decomposition degrades to a single task
@@ -69,10 +74,18 @@ func planGoal(ctx context.Context, l *Loop, input string) *Goal {
 		return NewGoal(input, nil)
 	}
 
-	tasks := requestPlan(l, input, false)
+	tasks := requestPlan(l, input, "")
 	if len(tasks) == 0 {
 		// One repair attempt with a stricter instruction before giving up.
-		tasks = requestPlan(l, input, true)
+		tasks = requestPlan(l, input, planRepairJSONHint)
+	}
+	// A lone task that just restates the request is a non-decomposition: the
+	// planner produced nothing to advance through. Try once more with an
+	// explicit "at least two steps" instruction before accepting it.
+	if isEchoPlan(tasks, input) {
+		if split := requestPlan(l, input, planForceSplitHint); len(split) > 1 {
+			tasks = split
+		}
 	}
 	// Reaching the original request from start to finish can take several
 	// intermediate tasks, and a single decomposition call can misorder,
@@ -98,9 +111,23 @@ func localModelNotServed(l *Loop) bool {
 	return backend == "" || backend == "file" || backend == "gguf"
 }
 
+// planRepairJSONHint is appended after an unparsable reply; planForceSplitHint
+// after a reply that returned the whole request as one task.
+const (
+	planRepairJSONHint = "Your previous reply was not valid JSON. Reply with the JSON object ONLY."
+	planForceSplitHint = "Your previous plan was a single task that restated the request. " +
+		"Break it into at least two concrete, ordered steps."
+)
+
+// echoWordOverlap is the fraction of a lone task's words that must also appear
+// in the request for the task to count as a restatement rather than a step.
+const echoWordOverlap = 0.8
+
 // requestPlan performs a single decomposition call and parses the task list.
-// Returns nil when the call fails or the reply cannot be parsed.
-func requestPlan(l *Loop, input string, repair bool) []string {
+// extraHint, when non-empty, is appended to the system prompt (used for the
+// repair and force-split retries). Returns nil when the call fails or the reply
+// cannot be parsed.
+func requestPlan(l *Loop, input, extraHint string) []string {
 	// Local models must be served before the planner can call them. If the
 	// first-use download was skipped/declined, degrade to a single-task goal
 	// instead of a failed agent_loop_plan with {error: ...}.
@@ -108,8 +135,8 @@ func requestPlan(l *Loop, input string, repair bool) []string {
 		return nil
 	}
 	system := goalPlanSystemPrompt
-	if repair {
-		system += "\n\nYour previous reply was not valid JSON. Reply with the JSON object ONLY."
+	if extraHint != "" {
+		system += "\n\n" + extraHint
 	}
 	chatCfg := &domain.ChatConfig{
 		Model:   l.config.Model,
@@ -193,7 +220,49 @@ func confirmPlan(l *Loop, input string, candidate []string) []string {
 	if len(confirmed) == 0 {
 		return candidate
 	}
+	// A review pass that collapses a multi-step plan down to a single task has
+	// almost certainly misread its instructions (it was asked to correct the
+	// list, not summarize the request). Keep the candidate.
+	if len(confirmed) == 1 && len(candidate) > 1 {
+		return candidate
+	}
 	return confirmed
+}
+
+// isEchoPlan reports whether tasks is a single "step" that merely restates the
+// request rather than decomposing it -- the signal that planning produced
+// nothing to advance through.
+func isEchoPlan(tasks []string, input string) bool {
+	if len(tasks) != 1 {
+		return false
+	}
+	task := wordSet(tasks[0])
+	req := wordSet(input)
+	if len(task) < 3 || len(req) == 0 {
+		return false
+	}
+	shared := 0
+	for w := range task {
+		if req[w] {
+			shared++
+		}
+	}
+	// The lone task carries almost nothing the request did not already say.
+	return float64(shared)/float64(len(task)) >= echoWordOverlap
+}
+
+// wordSet lowercases s and returns the set of its alphanumeric word tokens.
+func wordSet(s string) map[string]bool {
+	isWordChar := func(r rune) bool {
+		return ('a' <= r && r <= 'z') || ('0' <= r && r <= '9')
+	}
+	out := map[string]bool{}
+	for _, f := range strings.FieldsFunc(strings.ToLower(s), func(r rune) bool {
+		return !isWordChar(r)
+	}) {
+		out[f] = true
+	}
+	return out
 }
 
 // parsePlanTasks extracts the task list from a model reply, tolerating a code
@@ -234,9 +303,15 @@ func extractJSONObject(s string) string {
 	return s[start : end+1]
 }
 
-// trivialPromptMaxLen is the length under which a question is treated as chat
-// rather than a goal worth decomposing.
+// trivialPromptMaxLen caps how long a *question* can be and still be treated as
+// chat rather than a goal worth decomposing.
 const trivialPromptMaxLen = 120
+
+// trivialShortLen caps how long a non-question one-liner can be and still skip
+// decomposition. A longer imperative ("clean up X and wire it into Y") gets a
+// planning attempt even without an explicit multi-step marker -- length alone is
+// not proof a request is a single step.
+const trivialShortLen = 32
 
 // multiStepMarkers signal a request that spans several steps even when short.
 //
@@ -255,7 +330,15 @@ var multiStepMarkers = []string{
 // GoalTask that task_complete/task_fail apply to exactly as they would a
 // decomposed one.
 func looksTrivial(input string) bool {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return true
+	}
 	if len(input) > trivialPromptMaxLen {
+		return false
+	}
+	// Multi-line input is a spec, not a one-liner.
+	if strings.Contains(input, "\n") {
 		return false
 	}
 	lower := strings.ToLower(input)
@@ -264,6 +347,7 @@ func looksTrivial(input string) bool {
 			return false
 		}
 	}
-	// Multi-line input is a spec, not a one-liner.
-	return strings.Count(strings.TrimSpace(input), "\n") == 0
+	// A very short remark, or any question under the length cap, has nothing to
+	// decompose. A longer imperative one-liner still gets a planning attempt.
+	return len(input) <= trivialShortLen || strings.HasSuffix(input, "?")
 }

--- a/pkg/agent/goal_planner_test.go
+++ b/pkg/agent/goal_planner_test.go
@@ -17,6 +17,7 @@ package agent
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/kdeps/kdeps/v2/pkg/domain"
@@ -69,6 +70,8 @@ func TestLooksTrivial(t *testing.T) {
 		"fix the bug and then run the tests?",      // multi-step marker
 		"summarize this\nand also update the docs", // multi-line
 		"is this question long enough to be treated as a real request that spans well beyond the trivial length limit used for a single quick question?",
+		"clean up the logging package and wire it into the server startup", // long imperative one-liner, no marker
+		"refactor the auth middleware to use the new token store",          // ditto
 	}
 	for _, s := range notTrivial {
 		if looksTrivial(s) {
@@ -105,7 +108,11 @@ func TestConfirmPlan_ApprovesAsIs(t *testing.T) {
 	eng.SetExecuteFunc(func(*domain.Workflow, interface{}) (interface{}, error) {
 		return `{"tasks":["a","b"]}`, nil
 	})
-	l := &Loop{engine: eng, workflow: newTestWorkflowForSession(), config: Config{Backend: "openai"}}
+	l := &Loop{
+		engine:   eng,
+		workflow: newTestWorkflowForSession(),
+		config:   Config{Backend: "openai"},
+	}
 
 	got := confirmPlan(l, "do something", []string{"a", "b"})
 	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
@@ -120,7 +127,11 @@ func TestConfirmPlan_ReturnsCorrectedList(t *testing.T) {
 		gotActionID = wf.Metadata.TargetActionID
 		return `{"tasks":["a","missing step","b"]}`, nil
 	})
-	l := &Loop{engine: eng, workflow: newTestWorkflowForSession(), config: Config{Backend: "openai"}}
+	l := &Loop{
+		engine:   eng,
+		workflow: newTestWorkflowForSession(),
+		config:   Config{Backend: "openai"},
+	}
 
 	got := confirmPlan(l, "do something", []string{"a", "b"})
 	if len(got) != 3 || got[1] != "missing step" {
@@ -136,7 +147,11 @@ func TestConfirmPlan_FallsBackOnEngineError(t *testing.T) {
 	eng.SetExecuteFunc(func(*domain.Workflow, interface{}) (interface{}, error) {
 		return nil, errors.New("boom")
 	})
-	l := &Loop{engine: eng, workflow: newTestWorkflowForSession(), config: Config{Backend: "openai"}}
+	l := &Loop{
+		engine:   eng,
+		workflow: newTestWorkflowForSession(),
+		config:   Config{Backend: "openai"},
+	}
 
 	candidate := []string{"a", "b"}
 	got := confirmPlan(l, "do something", candidate)
@@ -150,7 +165,11 @@ func TestConfirmPlan_FallsBackOnUnparsableReply(t *testing.T) {
 	eng.SetExecuteFunc(func(*domain.Workflow, interface{}) (interface{}, error) {
 		return "not json at all", nil
 	})
-	l := &Loop{engine: eng, workflow: newTestWorkflowForSession(), config: Config{Backend: "openai"}}
+	l := &Loop{
+		engine:   eng,
+		workflow: newTestWorkflowForSession(),
+		config:   Config{Backend: "openai"},
+	}
 
 	candidate := []string{"a", "b"}
 	got := confirmPlan(l, "do something", candidate)
@@ -168,9 +187,17 @@ func TestPlanGoal_SkipsConfirmationForSingleTask(t *testing.T) {
 		calls++
 		return `{"tasks":["only step"]}`, nil
 	})
-	l := &Loop{engine: eng, workflow: newTestWorkflowForSession(), config: Config{Backend: "openai"}}
+	l := &Loop{
+		engine:   eng,
+		workflow: newTestWorkflowForSession(),
+		config:   Config{Backend: "openai"},
+	}
 
-	g := planGoal(context.Background(), l, "first do step one; then do step two; then verify everything works")
+	g := planGoal(
+		context.Background(),
+		l,
+		"first do step one; then do step two; then verify everything works",
+	)
 	if len(g.Tasks) != 1 {
 		t.Fatalf("expected a single task, got %+v", g.Tasks)
 	}
@@ -191,13 +218,22 @@ func TestPlanGoal_ConfirmsMultiTaskPlan(t *testing.T) {
 		}
 		return `{"tasks":["step one","step two"]}`, nil
 	})
-	l := &Loop{engine: eng, workflow: newTestWorkflowForSession(), config: Config{Backend: "openai"}}
+	l := &Loop{
+		engine:   eng,
+		workflow: newTestWorkflowForSession(),
+		config:   Config{Backend: "openai"},
+	}
 
-	g := planGoal(context.Background(), l, "first do step one; then do step two; then verify everything works")
+	g := planGoal(
+		context.Background(),
+		l,
+		"first do step one; then do step two; then verify everything works",
+	)
 	if len(g.Tasks) != 3 {
 		t.Fatalf("expected the confirmed 3-task plan, got %+v", g.Tasks)
 	}
-	if len(actionIDs) != 2 || actionIDs[0] != goalPlanActionID || actionIDs[1] != goalConfirmActionID {
+	if len(actionIDs) != 2 || actionIDs[0] != goalPlanActionID ||
+		actionIDs[1] != goalConfirmActionID {
 		t.Fatalf("expected [plan, confirm] action id order, got %v", actionIDs)
 	}
 }
@@ -229,5 +265,108 @@ func TestFormatLoopResult_MessageMap(t *testing.T) {
 	want := `{"tasks":["a","b"]}`
 	if got != want {
 		t.Fatalf("message map: got %q, want %q", got, want)
+	}
+}
+
+func TestIsEchoPlan(t *testing.T) {
+	t.Parallel()
+	req := "refactor the auth middleware and add tests for the new token path"
+	cases := []struct {
+		name  string
+		tasks []string
+		want  bool
+	}{
+		{"exact restatement", []string{req}, true},
+		{
+			"restatement reworded lightly",
+			[]string{"Refactor the auth middleware and add tests for the token path"},
+			true,
+		},
+		{
+			"genuine decomposition, one step shown",
+			[]string{"Extract the token check into its own function"},
+			false,
+		},
+		{"multi-task never an echo", []string{req, "and more"}, false},
+		{"empty", nil, false},
+		{"tiny task", []string{"do it"}, false},
+	}
+	for _, c := range cases {
+		if got := isEchoPlan(c.tasks, req); got != c.want {
+			t.Errorf("%s: isEchoPlan = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// planGoal retries with a force-split hint when the first decomposition just
+// echoes the request, and adopts the split if it has more than one task.
+func TestPlanGoal_RetriesOnEchoPlan(t *testing.T) {
+	req := "clean up the logging package and wire it into the server startup"
+	var systems []string
+	calls := 0
+	eng := executor.NewEngine(nil)
+	eng.SetExecuteFunc(func(wf *domain.Workflow, _ interface{}) (interface{}, error) {
+		calls++
+		systems = append(systems, wf.Resources[0].Chat.Scenario[0].Prompt)
+		if calls == 1 {
+			// First pass: echoes the request as one task.
+			return `{"tasks":["Clean up the logging package and wire it into the server startup"]}`, nil
+		}
+		// Force-split retry: a real breakdown.
+		return `{"tasks":["Simplify the logging package API","Wire the logger into server startup"]}`, nil
+	})
+	l := &Loop{
+		engine:   eng,
+		workflow: newTestWorkflowForSession(),
+		config:   Config{Backend: "openai"},
+	}
+
+	g := planGoal(context.Background(), l, req)
+	if len(g.Tasks) != 2 {
+		t.Fatalf("expected the 2-task split to be adopted, got %+v", g.Tasks)
+	}
+	if calls < 2 {
+		t.Fatalf("expected a force-split retry, got %d calls", calls)
+	}
+	if !strings.Contains(systems[1], "single task that restated") {
+		t.Fatalf("retry system prompt missing the force-split hint: %q", systems[1])
+	}
+}
+
+// planGoal keeps the echo task when the retry still fails to split.
+func TestPlanGoal_KeepsEchoWhenRetryDoesNotSplit(t *testing.T) {
+	req := "update the readme and the changelog for the release"
+	eng := executor.NewEngine(nil)
+	eng.SetExecuteFunc(func(*domain.Workflow, interface{}) (interface{}, error) {
+		return `{"tasks":["Update the readme and the changelog for the release"]}`, nil
+	})
+	l := &Loop{
+		engine:   eng,
+		workflow: newTestWorkflowForSession(),
+		config:   Config{Backend: "openai"},
+	}
+
+	g := planGoal(context.Background(), l, req)
+	if len(g.Tasks) != 1 {
+		t.Fatalf("expected the single task to stand, got %+v", g.Tasks)
+	}
+}
+
+// confirmPlan must not let a review pass collapse a multi-task plan to one task.
+func TestConfirmPlan_RejectsCollapseToSingleTask(t *testing.T) {
+	eng := executor.NewEngine(nil)
+	eng.SetExecuteFunc(func(*domain.Workflow, interface{}) (interface{}, error) {
+		return `{"tasks":["Do the whole thing"]}`, nil
+	})
+	l := &Loop{
+		engine:   eng,
+		workflow: newTestWorkflowForSession(),
+		config:   Config{Backend: "openai"},
+	}
+
+	candidate := []string{"step one", "step two", "step three"}
+	got := confirmPlan(l, "do a multi-step thing", candidate)
+	if len(got) != 3 {
+		t.Fatalf("expected the 3-task candidate kept, got %v", got)
 	}
 }

--- a/pkg/agent/max_tokens_test.go
+++ b/pkg/agent/max_tokens_test.go
@@ -254,7 +254,7 @@ func TestRequestPlan_MaxTokens_LocalBackend(t *testing.T) {
 		Model: "test-gguf", Backend: executorLLM.BackendGGUF, BaseURL: "http://127.0.0.1:9",
 	}}
 
-	requestPlan(l, "do something", false)
+	requestPlan(l, "do something", "")
 	require.NotNil(t, captured, "plan-request workflow was not captured")
 	require.NotNil(t, captured.Resources[0].Chat.MaxTokens)
 	assert.Equal(t, 16384, *captured.Resources[0].Chat.MaxTokens)
@@ -271,7 +271,7 @@ func TestRequestPlan_MaxTokens_CloudBackend(t *testing.T) {
 		Model: "gpt-5.5", Backend: "openai",
 	}}
 
-	requestPlan(l, "do something", false)
+	requestPlan(l, "do something", "")
 	require.NotNil(t, captured, "plan-request workflow was not captured")
 	assert.Nil(t, captured.Resources[0].Chat.MaxTokens)
 }


### PR DESCRIPTION
## Problem

The agent-loop Goal Planner was producing a single "Goal 1" equal to the raw prompt instead of an actionable task list.

## Causes

1. `looksTrivial` skipped the planning call for **any** single-line request under 120 chars without an explicit `then` / `and then` / `;` marker — so most short imperatives were never decomposed, and `NewGoal` just wrapped the prompt as task 1.
2. `goalPlanSystemPrompt` pushed for minimalism ("Emit the FEWEST tasks", "A simple question is ONE task") — a weak model reads that and restates the request as one task.
3. `confirmPlan` could collapse a good multi-task plan back to one.

## Fix

- **`looksTrivial`** — trivial only when ≤32 chars **or** a question (still ≤120, single-line, marker-free). `"clean up the logging package and wire it into startup"` is now planned.
- **Prompt rewrite** — "break into natural steps, one per action, 2–6 typical, do NOT restate the request", with a worked example.
- **`isEchoPlan`** — a lone task sharing ≥80% of its words with the request is a non-decomposition; retry once with an explicit "at least two concrete, ordered steps" instruction and adopt the split.
- **`confirmPlan`** — ignore a confirmation that shrinks a multi-step plan to a single task.
- `requestPlan` signature: `repair bool` → `extraHint string`.

A weak local model (default `llama3.2:1b`) may still not decompose well — the docs now point to a larger model or the router.

## Tests

`TestIsEchoPlan`, `TestPlanGoal_RetriesOnEchoPlan`, `TestPlanGoal_KeepsEchoWhenRetryDoesNotSplit`, `TestConfirmPlan_RejectsCollapseToSingleTask`, updated `TestLooksTrivial`. Full `pkg/agent` green; `make lint` 0 issues.

## Docs

`docs/v2/agent/goals.md` — new "Decomposing the prompt" / "Skipping decomposition" paragraphs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)