### PR TITLE
chore: bump docs version to 2.23.2 for release

### DIFF
--- a/docs/v2/package.json
+++ b/docs/v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kdeps-docs",
-  "version": "2.23.1",
+  "version": "2.23.2",
   "description": "kdeps Documentation",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Release prep. Since v2.23.1: agent-loop token consumption fix (#781, in-turn tool-transcript windowing) and goal-planner decomposition fix (#782). No new features, no API changes - patch bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)