### PR TITLE
fix(agent): decompose the goal without the model when it won't

### DIFF
--- a/docs/v2/agent/goals.md
+++ b/docs/v2/agent/goals.md
@@ -16,9 +16,18 @@ prompt -> decompose into tasks -> confirm -> [task 1] -> [task 2] -> ... -> answ
 natural steps - one task per distinct action it names or implies, typically two
 to six. If the first attempt just returns the whole request restated as a single
 task, the loop retries once with an explicit "break this into at least two
-steps" instruction before accepting a one-task plan. A weak local model (for
-example the default `llama3.2:1b`) may still fail to produce a real breakdown;
-switch to a larger model or the router for better plans.
+steps" instruction.
+
+If the model is unavailable, times out, or still will not decompose, kdeps
+falls back to a **mechanical split** that uses only the request's own wording:
+numbered lines (`1. ... 2. ...`), bullet lines (`- ...`), and sequencing phrases
+(`; `, `then`, `and then`, `after that`, `finally`) each start a new task. Plain
+`and` is not a separator ("read the file and print it" stays one step). A
+request with no such structure and a model that will not split it is kept as a
+single task - the loop still drives it, and the model breaks it down through its
+tool calls. A weak local model (for example the default `llama3.2:1b`) benefits
+most from writing the request as a numbered list or switching to a larger model
+or the router.
 
 **Skipping decomposition.** A short remark (32 characters or fewer) or any
 question under ~120 characters is treated as chat and drives a single-task goal

--- a/pkg/agent/goal_enforce.go
+++ b/pkg/agent/goal_enforce.go
@@ -466,10 +466,12 @@ func (l *Loop) beginGoal(ctx context.Context, input string, w io.Writer) string 
 		}
 		goal = planGoal(ctx, l, input)
 		saveGoal(l.memoryStore, goal)
-		// Print the plan as soon as it exists. A single-task decomposition is
-		// still a result the user asked to see; only skip ordinary chat
-		// (looksTrivial) where the "plan" would just restate the prompt.
-		if !looksTrivial(input) {
+		// Print the plan once it exists - but only when decomposition actually
+		// happened. A single task equal to the prompt is not a plan, it is the
+		// prompt echoed back; showing it as "[goal] plan generated: 1. <prompt>"
+		// is noise. The task still drives the loop; the model breaks it down via
+		// its tool calls.
+		if !looksTrivial(input) && !isNonPlan(goal, input) {
 			l.reportGoalSummary(w, goal)
 		}
 	default:

--- a/pkg/agent/goal_planner.go
+++ b/pkg/agent/goal_planner.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/kdeps/kdeps/v2/pkg/domain"
@@ -64,28 +65,33 @@ Request: Add a --dry-run flag to the sync command and cover it with a test
 // covering the prompt, because planning must not be able to block a turn.
 func planGoal(ctx context.Context, l *Loop, input string) *Goal {
 	input = strings.TrimSpace(input)
-	if input == "" {
+	if input == "" || looksTrivial(input) {
+		// A short question or remark has nothing to decompose; enforcement still
+		// wraps it as a single task via NewGoal.
 		return NewGoal(input, nil)
 	}
-	// Pure-code fast path: a short question needs no decomposition, so trivial
-	// chat costs no extra LLM call even though enforcement is always on. A
-	// canceled turn skips planning for the same reason.
-	if looksTrivial(input) || l == nil || l.engine == nil || ctx.Err() != nil {
-		return NewGoal(input, nil)
-	}
+	canCallLLM := l != nil && l.engine != nil && ctx.Err() == nil
 
-	tasks := requestPlan(l, input, "")
-	if len(tasks) == 0 {
-		// One repair attempt with a stricter instruction before giving up.
-		tasks = requestPlan(l, input, planRepairJSONHint)
-	}
-	// A lone task that just restates the request is a non-decomposition: the
-	// planner produced nothing to advance through. Try once more with an
-	// explicit "at least two steps" instruction before accepting it.
-	if isEchoPlan(tasks, input) {
-		if split := requestPlan(l, input, planForceSplitHint); len(split) > 1 {
-			tasks = split
+	var tasks []string
+	if canCallLLM {
+		tasks = requestPlan(l, input, "")
+		if len(tasks) == 0 {
+			// One repair attempt with a stricter instruction before giving up.
+			tasks = requestPlan(l, input, planRepairJSONHint)
 		}
+	}
+	// The LLM planner produced nothing usable (unavailable, timed out, or a
+	// silently-swallowed error). If the request itself spells out its steps -
+	// numbered lines, bullets, "then"/"and then"/";" separators - split it
+	// mechanically so a multi-part request still decomposes without a model.
+	if len(tasks) == 0 {
+		tasks = mechanicalSplit(input)
+	}
+	// A lone task that just restates the request is a non-decomposition. Try the
+	// model once more with an explicit "at least two steps" instruction, then
+	// fall back to the mechanical split, before accepting the restatement.
+	if isEchoPlan(tasks, input) {
+		tasks = breakEcho(l, input, tasks, canCallLLM)
 	}
 	// Reaching the original request from start to finish can take several
 	// intermediate tasks, and a single decomposition call can misorder,
@@ -93,10 +99,26 @@ func planGoal(ctx context.Context, l *Loop, input string) *Goal {
 	// second pass before it drives the loop. Only worth the extra call once
 	// there is more than one task to get wrong; a single-task plan has
 	// nothing to reorder or split.
-	if len(tasks) > 1 {
+	if len(tasks) > 1 && canCallLLM {
 		tasks = confirmPlan(l, input, tasks)
 	}
 	return NewGoal(input, tasks)
+}
+
+// breakEcho takes a one-task restatement of the request and tries to turn it
+// into a real decomposition: one more model call with the force-split hint (when
+// the model is reachable), then a mechanical split. Returns the original tasks
+// unchanged if neither produces more than one step.
+func breakEcho(l *Loop, input string, tasks []string, canCallLLM bool) []string {
+	if canCallLLM {
+		if split := requestPlan(l, input, planForceSplitHint); len(split) > 1 {
+			return split
+		}
+	}
+	if mech := mechanicalSplit(input); len(mech) > 1 {
+		return mech
+	}
+	return tasks
 }
 
 // localModelNotServed reports whether the configured backend is a local
@@ -229,6 +251,16 @@ func confirmPlan(l *Loop, input string, candidate []string) []string {
 	return confirmed
 }
 
+// isNonPlan reports whether a Goal is just the prompt wrapped as one task
+// (no decomposition happened), so callers can skip presenting it as a "plan".
+func isNonPlan(g *Goal, input string) bool {
+	if g == nil || len(g.Tasks) != 1 {
+		return false
+	}
+	return strings.TrimSpace(g.Tasks[0].Desc) == strings.TrimSpace(input) ||
+		isEchoPlan([]string{g.Tasks[0].Desc}, input)
+}
+
 // isEchoPlan reports whether tasks is a single "step" that merely restates the
 // request rather than decomposing it -- the signal that planning produced
 // nothing to advance through.
@@ -285,6 +317,67 @@ func parsePlanTasks(reply string) []string {
 			continue
 		}
 		out = append(out, t)
+		if len(out) == maxPlanTasks {
+			break
+		}
+	}
+	return out
+}
+
+// listLineRe matches the leading marker of a numbered or bulleted list line.
+var listLineRe = regexp.MustCompile(`^\s*(?:\d+[.)]\s+|[-*•]\s+)(.+)$`)
+
+// sequencerRe splits a one-line request on explicit step separators. Plain
+// " and " is deliberately excluded ("read the file and print it" is one step);
+// only sequencing phrases qualify.
+var sequencerRe = regexp.MustCompile(`(?i)\s*(?:;|\band then\b|\bthen\b|\bafter that\b|\bfinally\b|\bnext,)\s+`)
+
+// minMechanicalStepLen drops split fragments too short to be a real step so
+// punctuation noise ("", "-", "ok") does not become a task, while still keeping
+// one-word imperatives like "rebuild".
+const minMechanicalStepLen = 4
+
+// mechanicalSplit breaks a request into steps using only its wording and
+// punctuation, for when the LLM planner is unavailable or refuses to decompose.
+// Returns nil unless it yields at least two non-trivial parts.
+func mechanicalSplit(input string) []string {
+	input = strings.TrimSpace(input)
+	if parts := splitListLines(input); len(parts) > 1 {
+		return parts
+	}
+	if parts := cleanSplit(sequencerRe.Split(input, -1)); len(parts) > 1 {
+		return parts
+	}
+	return nil
+}
+
+// splitListLines extracts the text of each numbered/bulleted line, or nil when
+// fewer than two lines carry a list marker.
+func splitListLines(input string) []string {
+	var out []string
+	for _, line := range strings.Split(input, "\n") {
+		if m := listLineRe.FindStringSubmatch(line); m != nil {
+			out = append(out, m[1])
+		}
+	}
+	return cleanSplit(out)
+}
+
+// cleanSplit trims each part, drops blanks and fragments under
+// minMechanicalStepLen, caps at maxPlanTasks, and upper-cases the first letter
+// so a fragment reads as an imperative step.
+func cleanSplit(parts []string) []string {
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(strings.Trim(p, ".,;:- "))
+		if len(p) < minMechanicalStepLen {
+			continue
+		}
+		if r := []rune(p); r[0] >= 'a' && r[0] <= 'z' {
+			r[0] -= 'a' - 'A'
+			p = string(r)
+		}
+		out = append(out, p)
 		if len(out) == maxPlanTasks {
 			break
 		}

--- a/pkg/agent/goal_planner_test.go
+++ b/pkg/agent/goal_planner_test.go
@@ -370,3 +370,95 @@ func TestConfirmPlan_RejectsCollapseToSingleTask(t *testing.T) {
 		t.Fatalf("expected the 3-task candidate kept, got %v", got)
 	}
 }
+
+func TestMechanicalSplit(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   string
+		want int // 0 = nil
+	}{
+		{"then-sequenced", "read the config; then validate it; then write the merged result", 3},
+		{"and then", "download the archive and then extract it and then run the installer", 3},
+		{"numbered list", "1. set up the database\n2. add the migration\n3. run the tests", 3},
+		{"bulleted list", "- clean the build dir\n- rebuild\n- verify the binary runs", 3},
+		{"single imperative with plain and", "read the file and print it", 0},
+		{"single clause", "refactor the auth middleware to use the new token store", 0},
+		{"empty", "", 0},
+	}
+	for _, c := range cases {
+		got := mechanicalSplit(c.in)
+		if c.want == 0 {
+			if got != nil {
+				t.Errorf("%s: expected nil, got %v", c.name, got)
+			}
+			continue
+		}
+		if len(got) != c.want {
+			t.Errorf("%s: got %d parts %v, want %d", c.name, len(got), got, c.want)
+		}
+	}
+}
+
+func TestMechanicalSplit_CapitalizesAndTrims(t *testing.T) {
+	t.Parallel()
+	got := mechanicalSplit("- clean the workspace\n- run the build")
+	if len(got) != 2 || got[0] != "Clean the workspace" || got[1] != "Run the build" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+// With no engine, planGoal still decomposes a request that spells out its steps.
+func TestPlanGoal_MechanicalSplitWithoutEngine(t *testing.T) {
+	g := planGoal(context.Background(), &Loop{}, "clone the repo; then build it; then run the smoke test")
+	if len(g.Tasks) != 3 {
+		t.Fatalf("expected a 3-task mechanical split, got %+v", g.Tasks)
+	}
+}
+
+// When the LLM planner returns nothing, planGoal falls back to the mechanical split.
+func TestPlanGoal_MechanicalSplitWhenPlannerEmpty(t *testing.T) {
+	eng := executor.NewEngine(nil)
+	eng.SetExecuteFunc(func(*domain.Workflow, interface{}) (interface{}, error) {
+		return map[string]any{"error": "model unavailable"}, nil // silently-swallowed failure
+	})
+	l := &Loop{engine: eng, workflow: newTestWorkflowForSession(), config: Config{Backend: "openai"}}
+
+	g := planGoal(context.Background(), l, "1. write the parser\n2. add the tests\n3. wire it into main")
+	if len(g.Tasks) != 3 {
+		t.Fatalf("expected the 3-task mechanical split, got %+v", g.Tasks)
+	}
+}
+
+// When the LLM echoes the request AND it has step separators, the mechanical
+// split wins over the restatement.
+func TestPlanGoal_MechanicalSplitOverEcho(t *testing.T) {
+	req := "read the log; then find the error; then propose a fix"
+	eng := executor.NewEngine(nil)
+	eng.SetExecuteFunc(func(*domain.Workflow, interface{}) (interface{}, error) {
+		return `{"tasks":["Read the log; then find the error; then propose a fix"]}`, nil
+	})
+	l := &Loop{engine: eng, workflow: newTestWorkflowForSession(), config: Config{Backend: "openai"}}
+
+	g := planGoal(context.Background(), l, req)
+	if len(g.Tasks) != 3 {
+		t.Fatalf("expected the mechanical split to override the echo, got %+v", g.Tasks)
+	}
+}
+
+func TestIsNonPlan(t *testing.T) {
+	t.Parallel()
+	mk := func(desc ...string) *Goal { return NewGoal("x", desc) }
+	if !isNonPlan(mk("refactor the widget"), "refactor the widget") {
+		t.Error("exact single-task match should be a non-plan")
+	}
+	if isNonPlan(mk("step a", "step b"), "step a and step b") {
+		t.Error("a real multi-task decomposition is a plan")
+	}
+	if isNonPlan(mk("extract the token check into a helper"), "refactor the auth middleware to use a new token store") {
+		t.Error("a genuinely different single task is a plan")
+	}
+	if isNonPlan(nil, "x") {
+		t.Error("nil goal")
+	}
+}


### PR DESCRIPTION
Follow-up to #782 — user reported the goal planner *still* shows "Goal 1" as a verbatim copy of the prompt.

#782 improved the prompt and added an echo-retry, but it can't force a model that won't decompose (or a silently-failing planner call).

## Changes

- **`mechanicalSplit(input)`** — a non-LLM decomposition from the request's own structure: numbered lines (`1. …`), bullet lines (`- …`), and sequencer phrases (`;`, `then`, `and then`, `after that`, `finally`, `next,`). Plain `and` is deliberately not a separator. Runs when the LLM planner returns nothing or an echo, and works with no engine.
- **`breakEcho`** — echo → force-split retry → mechanical split.
- **`isNonPlan(goal, input)`** — a single task equal to the prompt is not a plan; `beginGoal` no longer prints `[goal] plan generated: 1. <prompt>` for it. The task still drives the loop; the model breaks it down through tool calls.
- `planGoal` restructured around a `canCallLLM` gate so the mechanical path is reachable without an engine.

A prose request with no structure, and a model that won't split it, stays one task — now documented.

## Tests

`TestMechanicalSplit`, `TestMechanicalSplit_CapitalizesAndTrims`, `TestPlanGoal_MechanicalSplitWithoutEngine`, `TestPlanGoal_MechanicalSplitWhenPlannerEmpty`, `TestPlanGoal_MechanicalSplitOverEcho`, `TestIsNonPlan`. Full `pkg/agent` green; `make lint` 0.

## Docs

`docs/v2/agent/goals.md` — mechanical-split behavior and its limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)