### PR TITLE
agent: goal/judges off by default; fix bracketed-paste splitting

### DIFF
--- a/docs/v2/agent/goals.md
+++ b/docs/v2/agent/goals.md
@@ -1,8 +1,13 @@
 # Goal-directed execution
 
-Every prompt in the [agent loop REPL](/agent/) becomes an explicit task list that Go code drives to completion.
+With goal-directed execution on, every prompt in the [agent loop REPL](/agent/) becomes an explicit task list that Go code drives to completion.
 
 *Applies to agent mode.*
+
+**Off by default.** Goal-directed execution adds a planning LLM call and extra
+output per turn, so it is opt-in: `/goal on` enables it for the session and
+persists the choice; `/goal off` turns it back off. Library and test callers
+always run the plain round loop.
 
 The loop walks a cursor through the list that only ever moves forward, so a model
 cannot circle back over finished work or stall on a task until a budget expires.
@@ -130,10 +135,8 @@ drop it, rather than silently resuming on your next prompt.
 /goal clear          # drop the current goal (a fresh one starts next prompt)
 ```
 
-The modeline shows `task:2/5` while a goal is active. Enforcement is on by
-default in the interactive REPL; `/goal off` turns it off entirely (persisted
-across sessions) so turns run as a plain tool loop. Library and test callers
-always keep the plain round loop. Tuning:
+The modeline shows `task:2/5` while a goal is active. `/goal on` and `/goal off`
+both persist across sessions. Tuning:
 `TaskRoundBudget` (default 25 rounds per task), `MaxUnproductiveRounds`
 (default 3), and `RequireTaskEvidence` (default `false`, opt-in).
 

--- a/docs/v2/agent/judges.md
+++ b/docs/v2/agent/judges.md
@@ -95,12 +95,12 @@ same way goal decomposition is. Any failure anywhere in the panel (a judge
 that errors, times out, or never calls `judge_verdict`) degrades to approval
 rather than blocking the turn.
 
-**On by default in the interactive REPL.** `AutoJudges` is enabled
-automatically when you start the REPL, the same way `GoalEnforcement` is - every turn gets an auto-generated review panel with no configuration needed.
+**Off by default.** An auto panel adds a roster-generation LLM call and a review
+pass per turn, so it is opt-in: `/judges auto on` enables it for the session and
+persists the choice; `/judges auto off` (or `/judges off`) turns it back off.
 Library and test callers get no panel unless they set `Config.Judges` or
-`Config.AutoJudges` explicitly. `/judges auto on|off` persists across
-sessions the same way `/tools full|lean` does; a hand-configured roster
-(`/judges add`/`remove`) is session-only.
+`Config.AutoJudges` explicitly. A hand-configured roster (`/judges add`/`remove`)
+is session-only.
 
 **From the REPL**, the same roster is managed with `/judges` - no restart
 needed:

--- a/docs/v2/agent/repl.md
+++ b/docs/v2/agent/repl.md
@@ -5,8 +5,11 @@ Runtime behaviors of the interactive agent loop REPL - pasting, rendering, notif
 ## Pasting
 
 Paste a block of text and the REPL treats it as **one prompt**, not one turn per
-line - it uses the terminal's bracketed-paste mode, so it works in any modern
-terminal, tmux, and screen. What happens next depends on the size:
+line - it uses the terminal's bracketed-paste mode, which the REPL re-enables
+before every prompt so a child process (an editor opened with `!`, a pager) or a
+terminal that resets it cannot leave a later paste splitting into per-line
+submissions. Works in any modern terminal, tmux, and screen. What happens next
+depends on the size:
 
 ```d2
 direction: right

--- a/pkg/agent/repl.go
+++ b/pkg/agent/repl.go
@@ -1804,7 +1804,11 @@ func (r *REPL) runLoop(rl *readline.Instance) error {
 		default:
 		}
 
-		fmt.Fprint(os.Stdout, ansiClearLine+r.modeline()+"\r\n")
+		// Re-assert bracketed-paste mode before every prompt: a child process
+		// (an editor via `!`, a pager), a full-screen redraw, or a terminal that
+		// resets it on its own can leave it off, and then a multi-line paste
+		// arrives as many separate submits instead of one prompt.
+		fmt.Fprint(os.Stdout, ansiEnableBracketedPaste+ansiClearLine+r.modeline()+"\r\n")
 		rl.SetPrompt(r.dynamicPrompt())
 		line, readErr := rl.Readline()
 		resetStealthInputTint()

--- a/pkg/agent/repl.go
+++ b/pkg/agent/repl.go
@@ -1621,15 +1621,13 @@ func (r *REPL) Run() error {
 	// Auto-raise the tool budget in interactive use so a long session
 	// never blocks on a prompt; library/test callers keep budget exhaustion.
 	r.loop.config.AutoToolAllocation = true
-	// Drive interactive turns through the goal/task state machine so the model
-	// advances instead of circling. Enabled here for the same reason as the
-	// budget: library and test callers keep the plain round loop.
-	r.loop.config.GoalEnforcement = true
-	// Auto-generate a judge panel per turn by default in interactive use, for
-	// the same reason: library/test callers get no panel unless they opt in via
-	// Config.Judges/AutoJudges. /judges auto off (or /judges clear) disables it
-	// for the rest of the session.
-	r.loop.config.AutoJudges = true
+	// Goal-directed execution and the auto judge panel are OFF by default: each
+	// adds a synthetic LLM call per turn (plan / roster) and extra output, which
+	// is unwanted overhead for ordinary use. Opt in with /goal on and
+	// /judges auto on -- both choices persist across sessions via applyToolTuning
+	// below, so a persisted "on" is restored here.
+	r.loop.config.GoalEnforcement = false
+	r.loop.config.AutoJudges = false
 	if r.persistedTuning != nil {
 		r.applyToolTuning(*r.persistedTuning)
 	}

--- a/pkg/agent/tool_monitor_test.go
+++ b/pkg/agent/tool_monitor_test.go
@@ -493,3 +493,33 @@ func TestToolTuning_StallOffRoundTrip(t *testing.T) {
 	r2.applyToolTuning(ToolTuning{ToolStallTimeout: "off"})
 	assert.EqualValues(t, -1, r2.loop.config.ToolStallTimeout)
 }
+
+// Goal enforcement and auto-judges are off by default; a persisted "on" choice
+// is restored, an unset (pre-feature) snapshot is not.
+func TestToolTuning_GoalAndJudgesOffByDefault(t *testing.T) {
+	r := &REPL{loop: &Loop{config: Config{}}}
+
+	// Fresh: an unconfigured snapshot leaves the off defaults alone.
+	r.applyToolTuning(ToolTuning{})
+	if r.loop.GoalEnforcementEnabled() || r.loop.config.AutoJudges {
+		t.Fatal("an empty snapshot must not enable goal enforcement or auto-judges")
+	}
+
+	// A snapshot from before GoalConfigured existed (ToolsConfigured set, but
+	// GoalConfigured/GoalEnforcementOff absent) must not flip goal enforcement on.
+	r.applyToolTuning(ToolTuning{ToolsConfigured: true})
+	if r.loop.GoalEnforcementEnabled() {
+		t.Fatal("a pre-GoalConfigured snapshot must not enable goal enforcement")
+	}
+
+	// An explicit persisted "/goal on" is restored.
+	r.applyToolTuning(ToolTuning{GoalConfigured: true, GoalEnforcementOff: false})
+	if !r.loop.GoalEnforcementEnabled() {
+		t.Fatal("a persisted /goal on must restore")
+	}
+	// ...and "/goal off".
+	r.applyToolTuning(ToolTuning{GoalConfigured: true, GoalEnforcementOff: true})
+	if r.loop.GoalEnforcementEnabled() {
+		t.Fatal("a persisted /goal off must restore")
+	}
+}

--- a/pkg/agent/tool_tuning.go
+++ b/pkg/agent/tool_tuning.go
@@ -54,19 +54,21 @@ type ToolTuning struct {
 	TuroArrows   bool
 	// ToolsFullMode persists the /tools full|lean choice (default: full).
 	ToolsFullMode bool
-	// AutoJudges persists the /judges auto choice (default: on).
+	// AutoJudges persists the /judges auto choice (default: off). A snapshot
+	// written while the old on-by-default was in effect carries true here and
+	// restores it -- an explicit /judges auto off then persists false.
 	AutoJudges bool
-	// GoalEnforcementOff persists the /goal off choice. Inverted (zero value =
-	// enforcement ON) so a snapshot saved before this field existed does not
-	// silently disable goal-directed execution on restore -- the same reason
-	// TuroOff is phrased as "off" rather than "on".
+	// GoalEnforcementOff persists the /goal off|on choice, and GoalConfigured is
+	// its "was this ever set" sentinel -- without it a snapshot from before this
+	// field existed (GoalEnforcementOff unmarshals to false) would restore as
+	// SetGoalEnforcement(!false) == on, flipping the off-by-default.
 	GoalEnforcementOff bool
+	GoalConfigured     bool
 	// ToolsConfigured is the "was this section ever saved" sentinel for
 	// ToolsFullMode/AutoJudges/AutoContextDetect, the same role TuroLevel !=
 	// "" plays for the turo fields above -- without it, a snapshot saved
-	// before this feature existed would carry zero values (lean/off) and
-	// silently override the full/auto-judges-on/auto-context-on defaults on
-	// every subsequent restore.
+	// before this feature existed would carry zero values and silently
+	// override the defaults Run() set on every subsequent restore.
 	ToolsConfigured bool
 	// AutoContextDetect persists the /autocontext choice (default: on).
 	AutoContextDetect bool
@@ -118,6 +120,7 @@ func (r *REPL) toolTuningSnapshot() ToolTuning {
 		ToolsFullMode:        r.toolsFullMode,
 		AutoJudges:           c.AutoJudges,
 		GoalEnforcementOff:   !c.GoalEnforcement,
+		GoalConfigured:       true,
 		ToolsConfigured:      true,
 		AutoContextDetect:    r.autoContextDetect,
 		PermissionMode:       string(c.PermissionMode),
@@ -199,8 +202,10 @@ func (r *REPL) applyToolTuningExtras(t ToolTuning) {
 			r.toolsFullMode = t.ToolsFullMode
 		}
 		c.AutoJudges = t.AutoJudges
-		r.loop.SetGoalEnforcement(!t.GoalEnforcementOff)
 		r.autoContextDetect = t.AutoContextDetect
+	}
+	if t.GoalConfigured {
+		r.loop.SetGoalEnforcement(!t.GoalEnforcementOff)
 	}
 	// PermissionMode empty is already the natural "unconfigured" value
 	// (resolvePermissionMode/checkToolPermission fall back to the env var or

--- a/pkg/tui/settings.go
+++ b/pkg/tui/settings.go
@@ -76,6 +76,7 @@ type AgentLoopTuning struct {
 	ToolsFullMode        bool   `yaml:"tools_full_mode,omitempty"`
 	AutoJudges           bool   `yaml:"auto_judges,omitempty"`
 	GoalEnforcementOff   bool   `yaml:"goal_enforcement_off,omitempty"`
+	GoalConfigured       bool   `yaml:"goal_configured,omitempty"`
 	ToolsConfigured      bool   `yaml:"tools_configured,omitempty"`
 	AutoContextDetect    bool   `yaml:"auto_context_detect,omitempty"`
 	PermissionMode       string `yaml:"permission_mode,omitempty"`


### PR DESCRIPTION
Two agent-loop fixes.

## Goal enforcement + auto-judges off by default

Both add a synthetic LLM call and extra per-turn output. Now opt-in:
- `Run()` sets `GoalEnforcement=false`, `AutoJudges=false`.
- Enable with `/goal on` / `/judges auto on`; both persist across sessions.
- `ToolTuning.GoalConfigured` sentinel so a pre-existing snapshot (where
  `GoalEnforcementOff` unmarshals to false) does not restore as
  `SetGoalEnforcement(!false) == on` and flip the new default. Mirrored in
  `tui.AgentLoopTuning`.

## Bracketed paste re-asserted per prompt

A multi-line paste was processed one line per submit. Bracketed-paste mode was
enabled once at REPL start; anything that turned it off afterward (an editor via
`!`, a pager, a terminal reset, a redraw) left later pastes splitting on
newlines. The read loop now re-emits `\033[?2004h` before every prompt.

## Tests / docs

`TestToolTuning_GoalAndJudgesOffByDefault`; full `agent + tui + cmd` green
(4147); `make lint` 0. Docs: `goals.md`, `judges.md`, `repl.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)