### PR TITLE
chore: bump docs version to 2.24.1 for release

### DIFF
--- a/docs/v2/package.json
+++ b/docs/v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kdeps-docs",
-  "version": "2.24.0",
+  "version": "2.24.1",
   "description": "kdeps Documentation",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Release prep. Since v2.24.0: #787 - goal enforcement + auto-judges off by default (opt in with /goal on, /judges auto on, persisted), and a fix for multi-line paste being processed one submit per line (bracketed-paste mode re-asserted before every prompt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)