### PR TITLE
fix(agent): /compact always did nothing under the auto-compact budget

### DIFF
--- a/docs/v2/agent/commands.md
+++ b/docs/v2/agent/commands.md
@@ -22,7 +22,7 @@ Inside the [agent loop REPL](/agent/), type `/help` for the full list.
 | `/skills` | List loaded skills |
 | `/prompts` | List loaded prompt templates |
 | `/<skill-name> [prompt]` | Invoke a skill or prompt template directly |
-| `/compact` | Summarize history to free context |
+| `/compact` | Summarize older turns now, keeping the last few verbatim. Unlike auto-compaction it runs regardless of how large the session is; it only shrinks the saved conversation, not a single turn's own tool output |
 | `/history` | Show conversation history |
 | `/thinking [off\|minimal\|low\|medium\|high\|xhigh\|auto]` | Enable extended reasoning (Claude only; warns if current model does not support it); persists across sessions |
 | `/prompt` | Show the exact LLM request for the last turn (system prompt, messages, tool schemas) |

--- a/docs/v2/agent/repl.md
+++ b/docs/v2/agent/repl.md
@@ -128,6 +128,17 @@ kdeps caps the in-flight transcript at roughly 24K tokens. Past that, the oldest
 
 The model keeps the most recent steps in full and a note that earlier ones were dropped. Tool *results* are separately capped at 16 KB each before they ever enter the transcript.
 
+### Compacting the saved conversation
+
+Only the user prompt and the final answer of each turn are saved to the session
+- a turn's own tool transcript is never persisted. `/compact` summarizes the
+older saved turns and keeps the last few verbatim; it runs whenever the session
+has more than a handful of turns, regardless of size. Auto-compaction between
+turns fires only once the saved conversation exceeds the token budget (`/model
+tool set compact-threshold <n>`), which for a long run of short-but-tool-heavy
+turns may never happen - use `/compact` directly. Neither affects a running
+turn's tool output; that is bounded by the in-flight window above.
+
 ## Sessions
 
 Every conversation is saved as a JSONL file under `~/.kdeps/sessions/`. The session ID is shown at the start of each run. Resume one with:

--- a/go.mod
+++ b/go.mod
@@ -208,7 +208,7 @@ require (
 	google.golang.org/genproto v0.0.0-20260618152121-87f3d3e198d3 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260618152121-87f3d3e198d3 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260618152121-87f3d3e198d3 // indirect
-	google.golang.org/grpc v1.83.1 // indirect
+	google.golang.org/grpc v1.83.2 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gotest.tools/v3 v3.5.2 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -660,8 +660,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260618152121-87f3d3e198d3 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260618152121-87f3d3e198d3/go.mod h1:Z4WJ5pJOYWFWcHEQUelD5QaZDknIQkpIL/+fyJOT9+A=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260618152121-87f3d3e198d3 h1:phvBWCAQMGN1945mp5fjCXP6jEF0+a0+4TjokS4sxNY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260618152121-87f3d3e198d3/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.83.1 h1:HIO0+BEtBP6soyqvqC8sNUjZ7bTs+0hFQuFF+RAy++Y=
-google.golang.org/grpc v1.83.1/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
+google.golang.org/grpc v1.83.2 h1:EManeRomTObA0BU7I8vXgg/78uE5MJ9M8B39EX2WscU=
+google.golang.org/grpc v1.83.2/go.mod h1:YPI1hK3kDked6iHvgX3tR0y+nX/qpMFKhPgFsokw1S8=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=

--- a/pkg/agent/compact.go
+++ b/pkg/agent/compact.go
@@ -212,6 +212,26 @@ func findCutIndex(messages []SessionMessage, keepRecentTokens int, modelHint str
 	return cutIdx
 }
 
+// forceKeepTurns is how many recent turns a manual /compact leaves untouched.
+const forceKeepTurns = 3
+
+// forcedCutIndex is findCutIndex for a user-invoked /compact: it summarizes
+// everything except the last forceKeepTurns turns, ignoring the token budget, so
+// the command always does something once there is at least one turn to fold in.
+// Returns 0 only when the session is not longer than forceKeepTurns+1 turns.
+func forcedCutIndex(messages []SessionMessage) int {
+	n := len(messages)
+	keep := sessionMsgsPer * forceKeepTurns
+	if n <= keep+sessionMsgsPer {
+		return 0
+	}
+	cut := n - keep
+	if cut%sessionMsgsPer != 0 { // land on a user-message boundary
+		cut--
+	}
+	return cut
+}
+
 // estimateSessionTokens returns the total estimated token count for all messages.
 func estimateSessionTokens(messages []SessionMessage, modelHint string) int {
 	var total int

--- a/pkg/agent/compact_test.go
+++ b/pkg/agent/compact_test.go
@@ -529,3 +529,34 @@ func TestPreviousCompactionSummary_StripsPrefixSuffix(t *testing.T) {
 		t.Fatalf("expected unwrapped 'summary text', got %q", got)
 	}
 }
+
+func TestForcedCutIndex(t *testing.T) {
+	t.Parallel()
+	mk := func(turns int) []SessionMessage {
+		m := make([]SessionMessage, 0, turns*sessionMsgsPer)
+		for range turns {
+			m = append(m,
+				SessionMessage{Role: "user", Content: "q"},
+				SessionMessage{Role: "assistant", Content: "a"})
+		}
+		return m
+	}
+	// Too short: forceKeepTurns + 1 or fewer turns -> nothing to fold in.
+	for _, turns := range []int{0, 1, forceKeepTurns, forceKeepTurns + 1} {
+		if got := forcedCutIndex(mk(turns)); got != 0 {
+			t.Errorf("%d turns: forcedCutIndex = %d, want 0", turns, got)
+		}
+	}
+	// Longer: keep exactly the last forceKeepTurns turns, summarize the rest,
+	// and land on a user boundary (even index).
+	for _, turns := range []int{forceKeepTurns + 2, 10, 100} {
+		got := forcedCutIndex(mk(turns))
+		wantKept := sessionMsgsPer * forceKeepTurns
+		if got != turns*sessionMsgsPer-wantKept {
+			t.Errorf("%d turns: forcedCutIndex = %d, want %d", turns, got, turns*sessionMsgsPer-wantKept)
+		}
+		if got%sessionMsgsPer != 0 {
+			t.Errorf("%d turns: cut %d not on a turn boundary", turns, got)
+		}
+	}
+}

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -2986,14 +2986,29 @@ func (l *Loop) Config() Config { return l.config }
 // them with a structured summary, keeping recent turns intact. It returns the
 // summary text. Falls back to truncation-only Compact() if the LLM call fails.
 func (l *Loop) CompactWithLLM(ctx context.Context) (string, error) {
+	return l.compactWithLLM(ctx, false)
+}
+
+// ForceCompact summarizes the older turns on demand (the /compact command). It
+// keeps only the most recent few turns regardless of the token budget, so a
+// manual compact always does something when there is history to compact --
+// unlike auto-compaction, which only fires once the session exceeds the budget.
+func (l *Loop) ForceCompact(ctx context.Context) (string, error) {
+	return l.compactWithLLM(ctx, true)
+}
+
+func (l *Loop) compactWithLLM(ctx context.Context, force bool) (string, error) {
 	msgs := l.session.RawMessages()
 	if len(msgs) == 0 {
 		return "", nil
 	}
 
 	cutIdx := findCutIndex(msgs, l.config.CompactTokenBudget, l.config.Model)
+	if force {
+		cutIdx = forcedCutIndex(msgs)
+	}
 	if cutIdx == 0 {
-		// Not enough turns to compact.
+		// Nothing worth compacting (or, when forced, too few turns).
 		return "", nil
 	}
 

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -627,3 +627,48 @@ func TestLoop_Config(t *testing.T) {
 		t.Fatalf("expected MaxTurns=10, got %d", loop.Config().MaxTurns)
 	}
 }
+
+// ForceCompact (the /compact command) summarizes older turns even when the
+// session is well under the token budget -- CompactWithLLM would return "" and
+// the REPL would (wrongly) report "no compaction needed".
+func TestLoop_ForceCompact_CompactsUnderBudget(t *testing.T) {
+	const fakeSummary = "## Progress\n- did things"
+	eng := executor.NewEngine(nil)
+	eng.SetExecuteFunc(func(_ *domain.Workflow, _ interface{}) (interface{}, error) {
+		return fakeSummary, nil
+	})
+	loop := agent.New(eng, newTestWorkflow(), tools.NewRegistry(), agent.Config{
+		Model:              "llama3.2",
+		CompactTokenBudget: 1_000_000, // effectively unlimited: auto-compact never fires
+	})
+	for range 8 {
+		if _, err := loop.Run(context.Background(), "hi"); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+	}
+
+	// Auto path: nothing, because the session is tiny relative to the budget.
+	if s, err := loop.CompactWithLLM(context.Background()); err != nil || s != "" {
+		t.Fatalf("CompactWithLLM under budget: got (%q, %v), want (\"\", nil)", s, err)
+	}
+	// Forced path: summarizes and keeps only the recent turns.
+	s, err := loop.ForceCompact(context.Background())
+	if err != nil {
+		t.Fatalf("ForceCompact: %v", err)
+	}
+	if s != fakeSummary {
+		t.Fatalf("ForceCompact summary = %q, want %q", s, fakeSummary)
+	}
+}
+
+// ForceCompact still does nothing for a session too short to fold anything in.
+func TestLoop_ForceCompact_TooShort(t *testing.T) {
+	eng := newTestEngine("summary", nil)
+	loop := agent.New(eng, newTestWorkflow(), tools.NewRegistry(), agent.Config{})
+	loop.Run(context.Background(), "q1") //nolint:errcheck
+	loop.Run(context.Background(), "q2") //nolint:errcheck
+	s, err := loop.ForceCompact(context.Background())
+	if err != nil || s != "" {
+		t.Fatalf("ForceCompact too-short: got (%q, %v), want (\"\", nil)", s, err)
+	}
+}

--- a/pkg/agent/repl.go
+++ b/pkg/agent/repl.go
@@ -3768,12 +3768,15 @@ func (r *REPL) cmdInvokePrompt(pt *PromptTemplate, args []string) error {
 func (r *REPL) cmdCompact() error {
 	fmt.Fprintln(os.Stdout, styleReplMeta.Render("Compacting conversation history..."))
 
-	summary, err := r.loop.CompactWithLLM(r.ctx)
+	summary, err := r.loop.ForceCompact(r.ctx)
 	if err != nil {
 		return fmt.Errorf("compact: %w", err)
 	}
 	if summary == "" {
-		fmt.Fprintln(os.Stdout, styleReplMeta.Render("No compaction needed."))
+		fmt.Fprintf(os.Stdout, "%s\n", styleReplMeta.Render(fmt.Sprintf(
+			"Nothing to compact — the session has %d turn(s); need more than %d to fold any in. "+
+				"Note: /compact only shrinks the saved conversation, not a turn's own tool output.",
+			r.loop.Session().TurnCount(), forceKeepTurns)))
 		return nil
 	}
 	fmt.Fprintf(os.Stdout, "%s\n\n%s\n",


### PR DESCRIPTION
`/compact` reused auto-compaction's budget check, so it reported "No compaction needed" whenever the *saved* session fit within `CompactTokenBudget`. Only the user prompt + final answer of each turn are saved (a turn's tool transcript never is), so a long run of short-but-tool-heavy turns stays under budget forever.

- `forcedCutIndex` keeps only the last 3 turns and summarizes the rest, ignoring the budget.
- `Loop.ForceCompact` / `compactWithLLM(ctx, force)`; `/compact` calls it, auto-compaction (4 call sites) is unchanged.
- The empty-summary message explains the turn count and that `/compact` only shrinks the saved conversation, not a turn's own tool output.

Tests: `TestForcedCutIndex`, `TestLoop_ForceCompact_CompactsUnderBudget`, `TestLoop_ForceCompact_TooShort`. pkg/agent green; make lint 0. Docs: commands.md, repl.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)