### PR TITLE
feat(agent): line-anchored editing in edit_file

### DIFF
--- a/docs/v2/agent/tools.md
+++ b/docs/v2/agent/tools.md
@@ -66,7 +66,7 @@ Always available. No environment variables required.
 |------|-------------|
 | `read_file` | Read file contents (plain text, plus PDF/DOCX/EPUB/RTF/ODT extraction) |
 | `write_file` | Write or overwrite a file |
-| `edit_file` | Replace a passage in a file (`old_string` -> `new_string`) |
+| `edit_file` | Replace part of a file - by line range (`start_line`/`end_line`) or by `old_string` |
 | `list_files` | List directory contents |
 | `md5_file` | Compute a file's MD5 hash - cheap way to check whether content actually changed |
 | `tail_file` | Read the last N lines of a file without loading the whole thing |
@@ -75,15 +75,34 @@ Always available. No environment variables required.
 
 `write_file` and `edit_file` print a **colored diff** of what changed under the tool call - removed lines in red, added lines in green, with a couple of context lines - so you can see every change the agent makes at a glance. Large diffs (e.g. writing a whole new file) are capped. The diff is shown in the terminal only; the model receives a concise result, not the ANSI-colored text.
 
-### edit_file whitespace tolerance
+### edit_file - two ways to point at the edit
 
-`edit_file` finds `old_string` by exact match first. If that fails it retries with progressively looser matching, so the model does not have to reproduce the file's whitespace byte-for-byte:
+**Line mode (preferred).** `read_file` prints every line with its number
+(`42⇥code`). Pass `start_line` and `end_line` (1-based, inclusive) plus
+`new_string` and exactly those lines are replaced - no need to reproduce the
+old text at all. Optionally pass `old_string` as a guard: if those lines no
+longer contain it (whitespace-insensitive), the edit is refused and the error
+shows the range's current numbered content so the model can re-read and retry.
+`new_string` with or without a trailing newline works; if it is flush-left and
+the target lines are indented, it is re-indented to match.
+
+```text
+start_line: 2, end_line: 3, new_string: "..."   -> lines 2-3 replaced
+start_line: 5                                    -> line 5 replaced (end_line defaults to start_line)
+```
+
+**String mode.** Omit the line numbers and pass `old_string` + `new_string`;
+the tool locates `old_string`, trying progressively looser matching so the
+model does not have to reproduce whitespace byte-for-byte:
 
 1. **exact** - literal substring match.
 2. **trailing-whitespace** - ignores trailing spaces/tabs and CRLF vs LF per line; also covers a missing or extra final newline.
-3. **indentation** - ignores leading whitespace per line (wrong indent width, tabs vs spaces, a block pasted flush-left). `new_string` is re-indented to the file's actual level before it is written.
+3. **indentation** - ignores leading whitespace per line (wrong indent width, tabs vs spaces, a block pasted flush-left). `new_string` is re-indented to the file's actual level.
 
-The match must still land on exactly one passage; pass `replace_all: true` to change every occurrence. If nothing matches, the error names the closest region in the file with line numbers so the model can copy the real text and retry. The line ending style of the file is preserved on write.
+The match must land on exactly one passage; pass `replace_all: true` to change
+every occurrence. If nothing matches, the error names the closest region in the
+file with line numbers. Either way, the file's line-ending style is preserved on
+write.
 
 ## Web and search
 

--- a/pkg/agent/builtin_tools.go
+++ b/pkg/agent/builtin_tools.go
@@ -604,10 +604,10 @@ func registerWriteFile(reg *kdepstools.Registry) {
 func registerEditFile(reg *kdepstools.Registry) {
 	tool := &kdepstools.Tool{
 		Name:         toolNameEditFile,
-		Description:  "Replace a passage in a file. Reads the file, finds old_string, and replaces it with new_string. Prefer copying old_string verbatim from read_file, but exact whitespace is not required: if a byte-for-byte match fails, the tool retries ignoring trailing whitespace / line endings, then ignoring indentation, and reindents new_string to match the file. Use for targeted edits without resending the whole file. Requires an absolute path. old_string must identify a single passage unless replace_all is set.",
+		Description:  "Replace part of a file. Most reliable: pass start_line and end_line (1-based, from read_file's numbered output) plus new_string, and exactly those lines are replaced; optionally pass old_string as a check that the range still holds the text you expect. Without line numbers, pass old_string + new_string and the tool finds it (whitespace and indentation matched loosely). Absolute path required.",
 		Category:     "code",
 		OutputFormat: "color diff of the change",
-		Constraints:  "old_string should be copied from the file but need not match whitespace exactly; must identify exactly one passage unless replace_all=true; read the file before editing",
+		Constraints:  "prefer start_line/end_line from read_file; old_string need not match whitespace exactly and must be unique unless replace_all=true; read the file before editing",
 		SeeAlso:      "write_file, read_file",
 		Parameters: map[string]domain.ToolParam{
 			toolParamFilePath: {
@@ -615,10 +615,20 @@ func registerEditFile(reg *kdepstools.Registry) {
 				Description: "Absolute path to the file to edit",
 				Required:    true,
 			},
+			"start_line": {
+				Type:        toolParamNumber,
+				Description: "1-based first line to replace (from read_file's numbered output). When set, line mode is used and old_string is only a guard.",
+				Required:    false,
+			},
+			"end_line": {
+				Type:        toolParamNumber,
+				Description: "1-based last line to replace, inclusive. Defaults to start_line.",
+				Required:    false,
+			},
 			"old_string": {
 				Type:        toolParamString,
-				Description: "The text to replace. Copy it from the file; whitespace and line endings are matched loosely if an exact match is not found.",
-				Required:    true,
+				Description: "Text to replace (string mode) or expect in the line range (guard, line mode). Whitespace/line endings matched loosely.",
+				Required:    false,
 			},
 			"new_string": {
 				Type:        toolParamString,
@@ -627,7 +637,7 @@ func registerEditFile(reg *kdepstools.Registry) {
 			},
 			"replace_all": {
 				Type:        toolParamBoolean,
-				Description: "Replace every occurrence instead of requiring old_string to be unique (default false)",
+				Description: "String mode only: replace every occurrence instead of requiring old_string to be unique (default false)",
 				Required:    false,
 			},
 		},
@@ -640,22 +650,12 @@ func registerEditFile(reg *kdepstools.Registry) {
 		if err = validateWorkspaceBoundary(filePath); err != nil {
 			return "", fmt.Errorf("edit_file: %w", err)
 		}
-		oldStr, _ := args["old_string"].(string)
-		newStr, _ := args["new_string"].(string)
-		replaceAll, _ := args["replace_all"].(bool)
-		if oldStr == "" {
-			return "", errors.New("edit_file: old_string is required")
-		}
-		if oldStr == newStr {
-			return "", errors.New("edit_file: old_string and new_string are identical")
-		}
-
 		data, err := afero.ReadFile(AppFS, filePath)
 		if err != nil {
 			return "", fmt.Errorf("edit_file: read %s: %w", filePath, err)
 		}
 
-		res, err := resolveEdit(string(data), oldStr, newStr, replaceAll)
+		res, err := planEdit(string(data), args)
 		if err != nil {
 			return "", fmt.Errorf("edit_file: %w (%s)%s", err, filePath, res.hint)
 		}
@@ -669,6 +669,33 @@ func registerEditFile(reg *kdepstools.Registry) {
 		return fmt.Sprintf("Edited %s (%d bytes%s)", filePath, len(res.newContent), res.note), nil
 	}
 	reg.Register(tool)
+}
+
+// planEdit dispatches an edit_file call to line mode (start_line/end_line) or
+// string mode (old_string), validating the args each mode needs. No I/O.
+func planEdit(content string, args map[string]any) (editResult, error) {
+	oldStr, _ := args["old_string"].(string)
+	newStr, hasNew := args["new_string"].(string)
+	if !hasNew {
+		return editResult{}, errors.New("new_string is required")
+	}
+
+	if startLine, ok := args["start_line"].(float64); ok && startLine > 0 {
+		endLine := int(startLine)
+		if e, eok := args["end_line"].(float64); eok && e > 0 {
+			endLine = int(e)
+		}
+		return resolveLineEdit(content, int(startLine), endLine, newStr, oldStr)
+	}
+
+	if oldStr == "" {
+		return editResult{}, errors.New("old_string is required (or pass start_line/end_line)")
+	}
+	if oldStr == newStr {
+		return editResult{}, errors.New("old_string and new_string are identical")
+	}
+	replaceAll, _ := args["replace_all"].(bool)
+	return resolveEdit(content, oldStr, newStr, replaceAll)
 }
 
 // editResult is the outcome of resolveEdit: the rewritten file plus the exact

--- a/pkg/agent/edit_match.go
+++ b/pkg/agent/edit_match.go
@@ -19,6 +19,7 @@
 package agent
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -226,6 +227,82 @@ func matchEOLStyle(s, fileContent string) string {
 		return s
 	}
 	return strings.ReplaceAll(s, "\n", "\r\n")
+}
+
+// resolveLineEdit replaces the 1-based inclusive line range [startLine, endLine]
+// of content with newStr. When guard is non-empty it must still be present in
+// that range (whitespace-lenient) or the edit is refused with the range's
+// current content. This is the reliable path: the model reads read_file's
+// numbered output and points at line numbers instead of reproducing text.
+func resolveLineEdit(content string, startLine, endLine int, newStr, guard string) (editResult, error) {
+	lines, offsets := splitLinesOffsets(content)
+	total := len(lines)
+	trailingNewline := total > 0 && lines[total-1] == ""
+	if trailingNewline {
+		total-- // the split's trailing "" is not a real line
+	}
+	if startLine < 1 || startLine > total {
+		return editResult{}, fmt.Errorf(
+			"start_line %d out of range: file has %d line(s)", startLine, total)
+	}
+	if endLine < startLine {
+		return editResult{}, fmt.Errorf(
+			"end_line %d is before start_line %d", endLine, startLine)
+	}
+	if endLine > total {
+		endLine = total
+	}
+
+	start := offsets[startLine-1]
+	var end int
+	if endLine == total && !trailingNewline {
+		end = len(content) // last line, no terminator to keep
+	} else {
+		end = offsets[endLine] - 1 // the '\n' after the last replaced line
+		if end-1 >= start && content[end-1] == '\r' {
+			end-- // and its preceding '\r' on a CRLF file
+		}
+	}
+	matchedText := content[start:end]
+
+	if guard != "" && !looseContains(matchedText, guard) {
+		return editResult{}, fmt.Errorf(
+			"old_string is not in lines %d-%d; they currently hold:\n%s",
+			startLine, endLine, numberLines(matchedText, startLine))
+	}
+
+	repl := strings.TrimSuffix(strings.TrimSuffix(newStr, "\n"), "\r")
+	if firstLineIndent(repl) == "" && firstLineIndent(matchedText) != "" {
+		repl = reindentReplacement(repl, "x", matchedText)
+	}
+	repl = matchEOLStyle(repl, content)
+
+	newContent := content[:start] + repl + content[end:]
+	if newContent == content {
+		return editResult{}, errors.New("replacement leaves the file unchanged")
+	}
+	return editResult{
+		newContent:  newContent,
+		matchedText: matchedText,
+		replacement: repl,
+		note:        fmt.Sprintf("; lines %d-%d", startLine, endLine),
+	}, nil
+}
+
+// looseContains reports whether needle appears in haystack once both are
+// whitespace-collapsed (indent width, tabs vs spaces, trailing spaces ignored).
+func looseContains(haystack, needle string) bool {
+	collapse := func(s string) string { return strings.Join(strings.Fields(s), " ") }
+	return strings.Contains(collapse(haystack), collapse(needle))
+}
+
+// numberLines renders text as read_file does: "<n>\t<line>", starting at from.
+func numberLines(text string, from int) string {
+	var b strings.Builder
+	for i, ln := range strings.Split(text, "\n") {
+		fmt.Fprintf(&b, "%d\t%s\n", from+i, ln)
+	}
+	return strings.TrimSuffix(b.String(), "\n")
 }
 
 // spliceMatches replaces every span (which must be sorted by start and

--- a/pkg/agent/edit_match_test.go
+++ b/pkg/agent/edit_match_test.go
@@ -281,3 +281,155 @@ func TestEditFile_MultilineReplacementReindented(t *testing.T) {
 	assert.Equal(t,
 		"func g() {\n    first()\n    second()\n    done()\n}\n", string(got))
 }
+
+// --- line-anchored mode (resolveLineEdit) ---
+
+func TestResolveLineEdit_SingleLine(t *testing.T) {
+	res, err := resolveLineEdit("a\nb\nc\n", 2, 2, "B", "")
+	require.NoError(t, err)
+	assert.Equal(t, "a\nB\nc\n", res.newContent)
+	assert.Equal(t, "b", res.matchedText)
+	assert.Contains(t, res.note, "lines 2-2")
+}
+
+func TestResolveLineEdit_Range(t *testing.T) {
+	res, err := resolveLineEdit("one\ntwo\nthree\nfour\n", 2, 3, "TWO\nTHREE\nEXTRA", "")
+	require.NoError(t, err)
+	assert.Equal(t, "one\nTWO\nTHREE\nEXTRA\nfour\n", res.newContent)
+}
+
+func TestResolveLineEdit_TrailingNewlineIrrelevant(t *testing.T) {
+	with, err1 := resolveLineEdit("a\nb\nc\n", 2, 2, "X\n", "")
+	without, err2 := resolveLineEdit("a\nb\nc\n", 2, 2, "X", "")
+	require.NoError(t, err1)
+	require.NoError(t, err2)
+	assert.Equal(t, without.newContent, with.newContent)
+	assert.Equal(t, "a\nX\nc\n", with.newContent)
+}
+
+func TestResolveLineEdit_CRLFPreserved(t *testing.T) {
+	res, err := resolveLineEdit("one\r\ntwo\r\nthree\r\n", 2, 2, "TWO", "")
+	require.NoError(t, err)
+	assert.Equal(t, "one\r\nTWO\r\nthree\r\n", res.newContent)
+}
+
+func TestResolveLineEdit_LastLineNoTrailingNewline(t *testing.T) {
+	res, err := resolveLineEdit("a\nb\nc", 3, 3, "C", "")
+	require.NoError(t, err)
+	assert.Equal(t, "a\nb\nC", res.newContent)
+}
+
+func TestResolveLineEdit_OutOfRange(t *testing.T) {
+	_, err := resolveLineEdit("a\nb\n", 5, 5, "x", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "file has 2 line(s)")
+
+	_, err = resolveLineEdit("a\nb\n", 2, 1, "x", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "before start_line")
+}
+
+func TestResolveLineEdit_EndClampedToFile(t *testing.T) {
+	res, err := resolveLineEdit("a\nb\nc\n", 2, 99, "X", "")
+	require.NoError(t, err)
+	assert.Equal(t, "a\nX\n", res.newContent)
+}
+
+func TestResolveLineEdit_Guard(t *testing.T) {
+	// Guard matches despite different indentation/spacing.
+	res, err := resolveLineEdit("if x {\n        return 1\n}\n", 2, 2, "return 42", "return 1")
+	require.NoError(t, err)
+	assert.Contains(t, res.newContent, "return 42")
+
+	// Guard mismatch -> error naming the current numbered content.
+	_, err = resolveLineEdit("if x {\n        return 1\n}\n", 2, 2, "return 42", "return 2")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "lines 2-2")
+	assert.Contains(t, err.Error(), "2\t        return 1")
+}
+
+func TestResolveLineEdit_ReindentFlushLeft(t *testing.T) {
+	// Target indented, new_string flush-left -> reindented to match.
+	res, err := resolveLineEdit("func f() {\n    a()\n    b()\n}\n", 2, 3, "x()\ny()", "")
+	require.NoError(t, err)
+	assert.Equal(t, "func f() {\n    x()\n    y()\n}\n", res.newContent)
+}
+
+func TestResolveLineEdit_NoReindentWhenAlreadyIndented(t *testing.T) {
+	res, err := resolveLineEdit("func f() {\n    a()\n}\n", 2, 2, "        deep()", "")
+	require.NoError(t, err)
+	assert.Equal(t, "func f() {\n        deep()\n}\n", res.newContent)
+}
+
+// --- edit_file line mode end-to-end ---
+
+func TestEditFile_LineMode(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "m.txt")
+	require.NoError(t, os.WriteFile(f, []byte("alpha\nbeta\ngamma\n"), 0o600))
+	tool := editFileTool(t)
+	res, err := tool.Execute(map[string]any{
+		"file_path":  f,
+		"start_line": float64(2),
+		"end_line":   float64(2),
+		"new_string": "BETA",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, res, "lines 2-2")
+	got, _ := os.ReadFile(f)
+	assert.Equal(t, "alpha\nBETA\ngamma\n", string(got))
+}
+
+func TestEditFile_LineMode_StartOnly(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "s.txt")
+	require.NoError(t, os.WriteFile(f, []byte("a\nb\nc\n"), 0o600))
+	tool := editFileTool(t)
+	_, err := tool.Execute(map[string]any{
+		"file_path": f, "start_line": float64(1), "new_string": "A",
+	})
+	require.NoError(t, err)
+	got, _ := os.ReadFile(f)
+	assert.Equal(t, "A\nb\nc\n", string(got))
+}
+
+func TestEditFile_LineMode_GuardMismatch(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "g.txt")
+	require.NoError(t, os.WriteFile(f, []byte("a\nb\nc\n"), 0o600))
+	tool := editFileTool(t)
+	_, err := tool.Execute(map[string]any{
+		"file_path": f, "start_line": float64(2), "end_line": float64(2),
+		"old_string": "not here", "new_string": "B",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not in lines 2-2")
+}
+
+func TestEditFile_LineMode_StringArgsCoerced(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "c.txt")
+	require.NoError(t, os.WriteFile(f, []byte("x\ny\nz\n"), 0o600))
+	tool := editFileTool(t)
+	// A fenced/prompt protocol may quote the numbers.
+	args := map[string]any{"file_path": f, "start_line": "2", "new_string": "Y"}
+	coerceToolArgTypes(tool.Parameters, args)
+	_, err := tool.Execute(args)
+	require.NoError(t, err)
+	got, _ := os.ReadFile(f)
+	assert.Equal(t, "x\nY\nz\n", string(got))
+}
+
+func TestEditFile_MissingNewString(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "n.txt")
+	require.NoError(t, os.WriteFile(f, []byte("a\n"), 0o600))
+	tool := editFileTool(t)
+	_, err := tool.Execute(map[string]any{"file_path": f, "start_line": float64(1)})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "new_string is required")
+}
+
+func TestEditFile_StringModeStillNeedsOldString(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "o.txt")
+	require.NoError(t, os.WriteFile(f, []byte("a\n"), 0o600))
+	tool := editFileTool(t)
+	_, err := tool.Execute(map[string]any{"file_path": f, "new_string": "b"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "old_string is required")
+}

--- a/pkg/agent/tool_aliases.go
+++ b/pkg/agent/tool_aliases.go
@@ -239,6 +239,8 @@ var toolParamAliases = map[string]map[string]string{
 		"old": "old_string", "old_str": "old_string", "search": "old_string", "find": "old_string",
 		"new": "new_string", "new_str": "new_string", "replace": "new_string", "replacement": "new_string",
 		"all": "replace_all", "global": "replace_all", "replaceall": "replace_all",
+		"start": "start_line", "from": "start_line", "line": "start_line",
+		"end": "end_line", "to": "end_line",
 	},
 	"list_files": {
 		"dir": toolParamPath, "directory": toolParamPath, "folder": toolParamPath, toolParamFilePath: toolParamPath,

--- a/pkg/agent/tool_aliases_test.go
+++ b/pkg/agent/tool_aliases_test.go
@@ -99,6 +99,14 @@ func TestNormalizeToolArgs(t *testing.T) {
 	b := map[string]any{"cmd": "ls -la"}
 	normalizeToolArgs("bash_exec", b)
 	assert.Equal(t, "ls -la", b["command"])
+
+	// edit_file line-range synonyms.
+	e := map[string]any{"start": float64(3), "end": float64(5), "old": "x", "new": "y"}
+	normalizeToolArgs("edit_file", e)
+	assert.Equal(t, float64(3), e["start_line"])
+	assert.Equal(t, float64(5), e["end_line"])
+	assert.Equal(t, "x", e["old_string"])
+	assert.Equal(t, "y", e["new_string"])
 }
 
 func TestNormalizeToolArgs_RealKeyWins(t *testing.T) {


### PR DESCRIPTION
## Summary

`edit_file` still fails a lot: the model has to reproduce `old_string` closely, and small models get whitespace/indentation/wording wrong even with #794's fuzzy matching. `read_file` already prints every line with its number, so let the model point at line numbers instead (the approach `mcp-edit-file-lines` uses).

`edit_file` now takes optional **`start_line` / `end_line`** (1-based, inclusive):
- when set → exactly those lines are replaced with `new_string`; no `old_string` needed
- `old_string`, if given, is a **guard** — if the range no longer contains it (whitespace-insensitive), the edit is refused and the error shows the range's current numbered content
- `new_string` is trailing-newline-agnostic; flush-left against indented target lines → reindented to match; file line-endings preserved
- without line numbers → the existing `old_string` path (exact → loose) is unchanged

Not a separate tool — same operation, kdeps counts tools for lean mode.

## Changes

- `pkg/agent/edit_match.go`: `resolveLineEdit`, `looseContains`, `numberLines`.
- `pkg/agent/builtin_tools.go`: `start_line`/`end_line` params; `planEdit` dispatch helper (keeps `registerEditFile` under gocognit); description leads with line mode.
- `pkg/agent/tool_aliases.go`: `start`/`from`/`line` → `start_line`, `end`/`to` → `end_line`.
- `docs/v2/agent/tools.md`, `book/chapter-05`.

## Tests

12 `resolveLineEdit` unit cases (single/range/multiline, trailing-newline-agnostic, CRLF, last line w/o newline, out-of-range, guard match+mismatch, reindent) + 6 `edit_file` line-mode end-to-end cases (incl. quoted-number coercion) + `normalizeToolArgs` edit_file synonyms. Full suite **14016 passed**; `make lint` clean; docs build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)