### PR TITLE
fix(agent): surface every loop notice and tool failure back to the model

### DIFF
--- a/docs/v2/agent/goals.md
+++ b/docs/v2/agent/goals.md
@@ -62,6 +62,13 @@ It calls one of two tools and the code validates the id against the active task:
 If a turn ends with a text answer instead of either call, the loop settles the
 active task from that text and continues with the next one.
 
+**Failed-tool gate (always on).** A task cannot close as *done* while its most
+recent work tool (anything other than `task_complete` / `task_fail`) is still
+failing: `task_complete` is refused ("your last `edit_file` call failed ... retry
+it or call `task_fail`"), and a prose "done" records the task **failed**. A later
+successful call to that tool clears the gate. This is independent of
+`RequireTaskEvidence` below.
+
 **Evidence-gated completion (`RequireTaskEvidence`).** By default, `task_complete`
 only checks *which* task is being closed - the claimed outcome itself is
 unverified. With `RequireTaskEvidence: true`, a task that made tool calls must

--- a/docs/v2/agent/tools.md
+++ b/docs/v2/agent/tools.md
@@ -104,6 +104,20 @@ every occurrence. If nothing matches, the error names the closest region in the
 file with line numbers. Either way, the file's line-ending style is preserved on
 write.
 
+### Failed tool calls are fed back to the model
+
+Every tool failure is returned to the model as `{"error": ...}` **plus a
+`[TOOL FAILED]` banner** ("nothing changed - fix the cause and retry, or say it
+failed"), so a skimmed error is hard to miss. The turn will not end on a "done"
+claim made right after a work tool failed: the loop pushes back once for a real
+success or an honest "it failed". With a goal active, `task_complete` on such a
+task is refused, and a prose "done" records the task **failed**, not done.
+
+Loop-generated notices - goal transitions, budget changes, forced task failures,
+context-window trims - are injected into the model's context as `[kdeps] ...`
+messages, since the human at the REPL cannot act on them but the model can
+adjust.
+
 ## Web and search
 
 | Tool | Required env var | Description |

--- a/pkg/agent/goal_enforce.go
+++ b/pkg/agent/goal_enforce.go
@@ -71,6 +71,11 @@ type goalEnforcer struct {
 	// blockedTools are tool names whose results were errors or convergence
 	// blocks this task; the narrow step removes them.
 	blockedTools map[string]bool
+	// lastWorkError is the most recent work tool (not task_complete/task_fail)
+	// whose result was an error and has not since succeeded. Non-nil blocks
+	// task_complete: a task is not done on a failed tool. Cleared by a later
+	// successful work-tool result and by resetTask.
+	lastWorkError *toolFailure
 	// budget re-sizes the per-category tool caps from measured yield.
 	budget *budgetTuner
 	// budgetNote holds a pending "category budget → N" message to surface at
@@ -240,7 +245,16 @@ func (e *goalEnforcer) resultIsNew(toolName, result string) bool {
 	if trimmed == "" {
 		return false
 	}
-	if isConvergenceBlocked(trimmed) || strings.HasPrefix(trimmed, `{"error"`) {
+	errored := strings.HasPrefix(trimmed, `{"error"`)
+	if !isTaskStateTool(toolName) {
+		switch {
+		case errored && !isConvergenceBlocked(trimmed):
+			e.lastWorkError = &toolFailure{tool: toolName, msg: shortToolError(trimmed)}
+		case !errored:
+			e.lastWorkError = nil // a work tool succeeded; failure resolved
+		}
+	}
+	if isConvergenceBlocked(trimmed) || errored {
 		e.blockedTools[toolName] = true
 		return false
 	}
@@ -311,6 +325,7 @@ func (e *goalEnforcer) resetTask() {
 	e.unproductive = 0
 	e.strikes = 0 // a new task starts with a clean record
 	e.hasEvidence = false
+	e.lastWorkError = nil
 	e.seenResults = make(map[string]bool)
 	e.blockedTools = make(map[string]bool)
 }
@@ -616,6 +631,7 @@ func (l *Loop) settleActiveFromText(content string, w io.Writer) bool {
 	}
 
 	status := GoalTaskDone
+	note := firstLine(content)
 	lower := strings.ToLower(content)
 	for _, m := range refusalMarkers {
 		if strings.Contains(lower, m) {
@@ -623,8 +639,16 @@ func (l *Loop) settleActiveFromText(content string, w io.Writer) bool {
 			break
 		}
 	}
+	// A prose "done" right after a work tool failed is the exact bug this
+	// guards: record the task failed, not done, and tell the model why.
+	if status == GoalTaskDone && e.lastWorkError != nil {
+		status = GoalTaskFailed
+		note = fmt.Sprintf("last %s call failed: %s", e.lastWorkError.tool, e.lastWorkError.msg)
+		l.queueModelNote(fmt.Sprintf(
+			"task %d recorded FAILED, not done — %s. It was not completed.", active.ID, note))
+	}
 
-	e.goal.Advance(status, firstLine(content))
+	e.goal.Advance(status, note)
 	e.resetTask()
 	saveGoal(e.store, e.goal)
 
@@ -683,9 +707,11 @@ func (l *Loop) enforceGoalProgress(cfg **domain.ChatConfig, outcome roundOutcome
 	*cfg = withGoalDirective(*cfg, e.directive()+e.escalationNote(level))
 }
 
-// reportGoalEvent surfaces a state-machine transition to the user. Silent when
-// there is nowhere to write it (library callers with no writer at all).
+// reportGoalEvent surfaces a state-machine transition to the user AND queues it
+// for the model's next request -- the human cannot act on a forced task
+// failure or a cursor move, but the model must know it happened.
 func (l *Loop) reportGoalEvent(w io.Writer, msg string) {
+	l.queueModelNote("goal: " + msg)
 	pw := l.progressWriter(w)
 	if pw == nil {
 		return

--- a/pkg/agent/goal_tools.go
+++ b/pkg/agent/goal_tools.go
@@ -128,6 +128,15 @@ func (l *Loop) settleTask(args map[string]any, status GoalTaskStatus) (string, e
 			id, active.ID, active.Desc, strikes, penaltyNotice(strikes))
 	}
 
+	if status == GoalTaskDone && e.lastWorkError != nil {
+		strikes := e.recordViolation("")
+		return "", fmt.Errorf(
+			"REFUSED: task %d — your last %s call failed: %q. Retry it and get a "+
+				"real success, or call task_fail. Do not mark this task done on a "+
+				"failed tool result. Strike %d — %s",
+			active.ID, e.lastWorkError.tool, e.lastWorkError.msg, strikes, penaltyNotice(strikes))
+	}
+
 	if status == GoalTaskDone && e.requireEvidence && len(e.taskSigs) > 0 && !e.hasEvidence {
 		return "", fmt.Errorf(
 			"REFUSED: task %d has tool calls but none of them verify the claimed "+

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -271,6 +271,16 @@ type Loop struct {
 	// enforcer drives the active goal's task state machine. Set per turn when
 	// GoalEnforcement is on; nil means the plain round loop.
 	enforcer *goalEnforcer
+	// modelNotes are loop-generated notices (goal transitions, budget changes,
+	// forced task failures) queued to be injected into the model's next request
+	// as a [kdeps] system message. The human sees them on the terminal; the
+	// model must see them too so it can adjust. Reset per turn in runToolRounds.
+	modelNotes []string
+	// lastWorkFailure records the most recent work tool (not task_complete /
+	// task_fail) whose result was an error and has not since succeeded. Nil once
+	// a later work tool succeeds. Drives the end-of-turn "did that actually
+	// work?" nudge.
+	lastWorkFailure *toolFailure
 	// goalToolsRegistered guards the lazy registration of task_complete /
 	// task_fail, which happens on the first enforced turn.
 	goalToolsRegistered bool
@@ -1180,12 +1190,15 @@ func (l *Loop) runToolRounds(
 		return "", err
 	}
 	l.captureCallOutputs(chatCfg)
+	l.modelNotes = nil
+	l.lastWorkFailure = nil
 
 	var finalContent string
 	capped := false
 	directiveDropped := false
 	nudged := false
 	hallucinationNudged := false
+	workFailureNudged := false
 	// Repeat-block loop guard: a model that re-issues the exact same tool call
 	// every round (common once a tool is blocked by convergence or keeps
 	// failing) makes no progress. Track consecutive identical calls and break
@@ -1199,24 +1212,9 @@ func (l *Loop) runToolRounds(
 	// final answer.
 	unlimited := l.config.MaxToolRounds <= 0
 	for i := 0; unlimited || i < l.config.MaxToolRounds; i++ {
-		// Auto-checkpoint: save session state before each LLM call.
-		l.saveCheckpoint()
-
-		// Warn at half the tool budget so the user has time to react before
-		// the turn is capped. Present interactive options to increase the
-		// budget, set a new number, or do nothing.
-		if !unlimited && i == l.config.MaxToolRounds/2 {
-			remaining := l.config.MaxToolRounds - i
-			l.promptBudgetOptions(w, remaining)
-		}
-
-		// Last allowed round: remove the tools so the model must produce a
-		// text answer. Breaking out on a tool-call round instead would end
-		// the turn with no visible output (tool-call rounds usually have
-		// empty content with reasoning models).
-		if !unlimited && i == l.config.MaxToolRounds-1 {
-			capped = i > 0
-			chatCfg = forceAnswerConfig(chatCfg)
+		var roundCapped bool
+		if chatCfg, roundCapped = l.prepareRound(chatCfg, i, unlimited, w); roundCapped {
+			capped = true
 		}
 
 		var roundBuf strings.Builder
@@ -1234,13 +1232,13 @@ func (l *Loop) runToolRounds(
 		finalContent = content
 
 		if len(toolCalls) == 0 {
-			salvaged, res := l.handleEmptyToolRound(
-				chatCfg, content, roundBuf.String(), &nudged, &hallucinationNudged, w)
-			if len(salvaged) > 0 {
-				toolCalls, content, finalContent = salvaged, res.cleaned, res.cleaned
-			} else {
-				chatCfg = res.chatCfg
-				if res.stop {
+			var stop bool
+			toolCalls, content, chatCfg, stop = l.resolveEmptyToolRound(
+				chatCfg, content, roundBuf.String(),
+				&nudged, &hallucinationNudged, &workFailureNudged, w)
+			finalContent = content
+			if len(toolCalls) == 0 {
+				if stop {
 					break
 				}
 				continue
@@ -1266,29 +1264,58 @@ func (l *Loop) runToolRounds(
 		if ctx.Err() != nil {
 			return finalContent, ctx.Err()
 		}
-		// Goal enforcement runs before the convergence guard: it can advance the
-		// cursor past a wedged task, which is a better outcome than force-
-		// answering the whole turn.
-		l.enforceGoalProgress(&chatCfg, outcome, w)
-		chatCfg, convergenceBlocks, forcedFinal = convergenceStop(
-			chatCfg,
-			outcome.blocked,
-			convergenceBlocks,
-			forcedFinal,
-		)
+		chatCfg, convergenceBlocks, forcedFinal = l.applyRoundOutcome(
+			chatCfg, outcome, convergenceBlocks, forcedFinal, w)
 	}
-	// A turn must never end in silence. Reasoning models sometimes put an
-	// entire round into thinking tokens and return empty content: on a capped
-	// round that loses the forced final answer, and otherwise it means the
-	// model stalled even after the nudge above.
-	if strings.TrimSpace(stripContentToolCalls(finalContent)) == "" {
-		if capped {
-			finalContent = l.budgetExhaustedNotice(w)
-		} else {
-			finalContent = l.silentTurnNotice(w)
-		}
+	return l.ensureNonSilentFinal(finalContent, capped, w), nil
+}
+
+// ensureNonSilentFinal guarantees a turn never ends in silence. Reasoning models
+// sometimes put an entire round into thinking tokens and return empty content:
+// on a capped round that loses the forced final answer, and otherwise it means
+// the model stalled even after the end-of-turn nudge.
+func (l *Loop) ensureNonSilentFinal(finalContent string, capped bool, w io.Writer) string {
+	if strings.TrimSpace(stripContentToolCalls(finalContent)) != "" {
+		return finalContent
 	}
-	return finalContent, nil
+	if capped {
+		return l.budgetExhaustedNotice(w)
+	}
+	return l.silentTurnNotice(w)
+}
+
+// prepareRound runs the per-round housekeeping before the LLM call: an
+// auto-checkpoint, a half-budget warning with interactive options, and -- on the
+// last allowed round -- stripping the tools so the model must produce a text
+// answer. It returns the config to use and whether this round was capped.
+func (l *Loop) prepareRound(
+	chatCfg *domain.ChatConfig, i int, unlimited bool, w io.Writer,
+) (*domain.ChatConfig, bool) {
+	l.saveCheckpoint()
+	if unlimited {
+		return chatCfg, false
+	}
+	if i == l.config.MaxToolRounds/2 {
+		l.promptBudgetOptions(w, l.config.MaxToolRounds-i)
+	}
+	if i == l.config.MaxToolRounds-1 {
+		return forceAnswerConfig(chatCfg), i > 0
+	}
+	return chatCfg, false
+}
+
+// applyRoundOutcome runs goal enforcement (which can advance the cursor past a
+// wedged task -- a better outcome than force-answering the whole turn) and then
+// the convergence guard.
+func (l *Loop) applyRoundOutcome(
+	chatCfg *domain.ChatConfig,
+	outcome roundOutcome,
+	convergenceBlocks int,
+	forcedFinal bool,
+	w io.Writer,
+) (*domain.ChatConfig, int, bool) {
+	l.enforceGoalProgress(&chatCfg, outcome, w)
+	return convergenceStop(chatCfg, outcome.blocked, convergenceBlocks, forcedFinal)
 }
 
 // nudgeForActionConfig returns a copy of cfg asking the model to commit to an
@@ -1320,6 +1347,18 @@ func nudgeNoFakeToolResponseConfig(cfg *domain.ChatConfig) *domain.ChatConfig {
 			"runtime does, and nothing ran. Make the actual tool call now through "+
 			"the tool interface and wait for its real result before answering. Do "+
 			"not write <tool_call> or <tool_response> as text.")
+	nudgeCfg.Prompt = strings.TrimSpace(cfg.Prompt + "\n\n" + note)
+	return &nudgeCfg
+}
+
+// nudgeUnresolvedToolFailureConfig fires when the turn is about to end while the
+// last work tool is still failing. The model must retry it to a real success or
+// state plainly that the step failed -- not silently report it done.
+func nudgeUnresolvedToolFailureConfig(cfg *domain.ChatConfig, f *toolFailure) *domain.ChatConfig {
+	nudgeCfg := *cfg
+	note := "Your last " + f.tool + " call failed: " + f.msg +
+		". It has not succeeded. Retry it and get a real success, or state plainly " +
+		"in your answer that this step failed. Do not claim it is done."
 	nudgeCfg.Prompt = strings.TrimSpace(cfg.Prompt + "\n\n" + note)
 	return &nudgeCfg
 }
@@ -1796,6 +1835,33 @@ func (l *Loop) handleEmptyToolRound(
 	return nil, emptyRoundResult{chatCfg: next, stop: !keepGoing}
 }
 
+// resolveEmptyToolRound wraps handleEmptyToolRound for the round loop: it
+// returns any salvaged tool calls (with the cleaned content), the config to use
+// next, and whether the turn should stop. When the turn is about to end on an
+// unresolved work-tool failure, it injects a single push-back nudge instead of
+// stopping.
+func (l *Loop) resolveEmptyToolRound(
+	chatCfg *domain.ChatConfig,
+	content, buffered string,
+	nudged, hallucinationNudged, workFailureNudged *bool,
+	w io.Writer,
+) ([]domain.StreamedToolCall, string, *domain.ChatConfig, bool) {
+	salvaged, res := l.handleEmptyToolRound(
+		chatCfg, content, buffered, nudged, hallucinationNudged, w)
+	if len(salvaged) > 0 {
+		return salvaged, res.cleaned, chatCfg, false
+	}
+	if !res.stop {
+		return nil, content, res.chatCfg, false
+	}
+	if l.lastWorkFailure != nil && !*workFailureNudged {
+		*workFailureNudged = true
+		return nil, content,
+			nudgeUnresolvedToolFailureConfig(res.chatCfg, l.lastWorkFailure), false
+	}
+	return nil, content, res.chatCfg, true
+}
+
 // handleTextOnlyRound processes a round the model ended without calling a tool.
 // It returns the config for the next round, the updated nudge flag, and whether
 // the loop should keep going.
@@ -1837,7 +1903,6 @@ func (l *Loop) appendToolRoundTrip(
 	toolCalls []domain.StreamedToolCall,
 	w io.Writer,
 ) (*domain.ChatConfig, roundOutcome) {
-	var outcome roundOutcome
 	var history []map[string]any
 	if cfg.Messages != "" {
 		_ = json.Unmarshal([]byte(cfg.Messages), &history)
@@ -1884,32 +1949,9 @@ func (l *Loop) appendToolRoundTrip(
 	}
 	history = append(history, assistant)
 
-	// Execute each tool and add tool result messages. After a Ctrl+C the
-	// remaining tools are skipped with an interrupted marker instead of run.
-	// Each tool's call line is displayed right before it runs so its
-	// completion can attach to the same line.
-	for _, tc := range toolCalls {
-		result := `{"error":"interrupted by user"}`
-		if ctx.Err() == nil { // Ctrl+C skips the remaining tools
-			result = l.dispatchOrRefuse(tc, w)
-		}
-		if isConvergenceBlocked(result) {
-			outcome.blocked = true
-		}
-		if l.enforcer.observeResult(tc.Name, result) {
-			outcome.productive = true
-		}
-		if isTaskStateTool(tc.Name) && !strings.HasPrefix(strings.TrimSpace(result), `{"error"`) {
-			outcome.advanced = true
-		}
-		history = append(history, map[string]any{
-			"role":           "tool",
-			"tool_call_id":   tc.ID,
-			"name":           tc.Name,
-			toolParamContent: turoReduce(ctx, capToolResult(result)),
-		})
-		l.recordToolCall(tc.Name, tc.Arguments, result)
-	}
+	// Execute each tool and add tool result messages.
+	toolMsgs, outcome := l.executeToolCalls(ctx, toolCalls, w)
+	history = append(history, toolMsgs...)
 
 	updated := *cfg
 	// Bound the in-flight transcript: auto-compaction only runs at turn
@@ -1926,11 +1968,84 @@ func (l *Loop) appendToolRoundTrip(
 			)
 		}
 	}
+
+	// Inject loop-generated notices (goal transitions, budget changes, forced
+	// task failures) into the model's context as one [kdeps] system message.
+	if len(l.modelNotes) > 0 {
+		history = append(history, map[string]any{
+			"role":           RoleSystem,
+			toolParamContent: "[kdeps] " + strings.Join(l.modelNotes, "\n[kdeps] "),
+		})
+		l.modelNotes = nil
+	}
+
 	if b, err := json.Marshal(history); err == nil {
 		updated.Messages = string(b)
 		updated.Prompt = "" // already in history
 	}
 	return &updated, outcome
+}
+
+// executeToolCalls runs each tool call and returns the resulting "tool" role
+// messages plus the aggregate round outcome. After a Ctrl+C the remaining tools
+// are skipped with an interrupted marker instead of run. Each tool's call line
+// is displayed right before it runs so its completion can attach to it.
+func (l *Loop) executeToolCalls(
+	ctx context.Context,
+	toolCalls []domain.StreamedToolCall,
+	w io.Writer,
+) ([]map[string]any, roundOutcome) {
+	var outcome roundOutcome
+	msgs := make([]map[string]any, 0, len(toolCalls))
+	for _, tc := range toolCalls {
+		result := `{"error":"interrupted by user"}`
+		if ctx.Err() == nil { // Ctrl+C skips the remaining tools
+			result = l.dispatchOrRefuse(tc, w)
+		}
+		if isConvergenceBlocked(result) {
+			outcome.blocked = true
+		}
+		if l.enforcer.observeResult(tc.Name, result) {
+			outcome.productive = true
+		}
+		if isTaskStateTool(tc.Name) && !isToolErrorResult(result) {
+			outcome.advanced = true
+		}
+		msgs = append(msgs, map[string]any{
+			"role":           "tool",
+			"tool_call_id":   tc.ID,
+			"name":           tc.Name,
+			toolParamContent: l.toolResultMessage(ctx, tc, result),
+		})
+		l.recordToolCall(tc.Name, tc.Arguments, result)
+	}
+	return msgs, outcome
+}
+
+// toolResultMessage builds the "tool" message content for one call. A failed
+// work tool is flagged unmistakably (turo left untouched so the exact error
+// survives) and remembered for the end-of-turn "did that actually work?" nudge;
+// a later success on any work tool clears that memory.
+func (l *Loop) toolResultMessage(
+	ctx context.Context,
+	tc domain.StreamedToolCall,
+	result string,
+) string {
+	if isTaskStateTool(tc.Name) {
+		return turoReduce(ctx, capToolResult(result))
+	}
+	switch {
+	case isToolErrorResult(result) && !isConvergenceBlocked(result):
+		l.lastWorkFailure = &toolFailure{tool: tc.Name, msg: shortToolError(result)}
+		return capToolResult(result) + "\n\n[TOOL FAILED] " + tc.Name +
+			" did not run. Nothing changed. Fix the cause and call it again, " +
+			"or say in your answer that this step failed -- do NOT report it as done."
+	case !isToolErrorResult(result):
+		l.lastWorkFailure = nil // a work tool succeeded; failure resolved
+		return turoReduce(ctx, capToolResult(result))
+	default:
+		return turoReduce(ctx, capToolResult(result))
+	}
 }
 
 // dispatchOrRefuse runs a tool call unless it breaks a goal rule: repeating work
@@ -2205,6 +2320,42 @@ func capToolResult(result string) string {
 		cutoff, len(result), len(cutoff))
 }
 
+// toolFailure names a tool whose call returned an error.
+type toolFailure struct {
+	tool string
+	msg  string
+}
+
+// queueModelNote records a loop-generated notice to inject into the model's
+// next request (as a [kdeps] system message from appendToolRoundTrip). Notices
+// go here in ADDITION to any terminal print -- the human cannot act on them,
+// the model can.
+func (l *Loop) queueModelNote(text string) {
+	text = strings.TrimSpace(text)
+	if l == nil || text == "" {
+		return
+	}
+	l.modelNotes = append(l.modelNotes, text)
+}
+
+// isToolErrorResult reports whether a tool result is the {"error": ...} shape
+// dispatchStreamToolCall / the enforcer produce for a failed call.
+func isToolErrorResult(result string) bool {
+	return strings.HasPrefix(strings.TrimSpace(result), `{"error"`)
+}
+
+// shortToolError pulls a readable message out of a {"error": "..."} result for
+// use in a nudge, falling back to the raw (capped) string.
+func shortToolError(result string) string {
+	var m struct {
+		Error string `json:"error"`
+	}
+	if json.Unmarshal([]byte(strings.TrimSpace(result)), &m) == nil && m.Error != "" {
+		return truncateEllipsis(m.Error, toolErrorMaxLen)
+	}
+	return truncateEllipsis(strings.TrimSpace(result), toolErrorMaxLen)
+}
+
 // toolErrorJSON formats a tool failure as a JSON error result, truncated so a
 // provider error embedding a whole HTML page cannot flood the LLM context.
 func toolErrorJSON(err error) string {
@@ -2386,6 +2537,10 @@ Send independent tool calls in a single message to run them concurrently.
 A tool has not run until its real result comes back from the runtime. Never
 describe, quote, or invent a result you have not received, and never write a
 <tool_call> or <tool_response> block as text.
+
+Every "[kdeps] ..." note and every {"error": ...} result is feedback for you ---
+read it and change what you do next. A step is not done until its tool returned
+a real success; if a tool failed, retry it or say plainly that it failed.
 
 Temporary files go under /tmp/kdeps/<task-id>/, never the project root.
 Clean up temp files when the task is done.

--- a/pkg/agent/loop_integration_test.go
+++ b/pkg/agent/loop_integration_test.go
@@ -255,10 +255,23 @@ func newTestWorkflowForSession() *domain.Workflow {
 	}
 }
 
+// newStreamingRegistry has a working "noop" tool so a "Name: noop" tool call
+// in a mock response exercises the tool-succeeded path (an empty registry would
+// make every noop call return {"error":"tool not found"}).
+func newStreamingRegistry() *tools.Registry {
+	reg := tools.NewRegistry()
+	reg.Register(&tools.Tool{
+		Name:        "noop",
+		Description: "no-op test tool",
+		Parameters:  map[string]domain.ToolParam{},
+		Execute:     func(_ map[string]any) (string, error) { return "noop ok", nil },
+	})
+	return reg
+}
+
 func newStreamingLoop(streamer Streamer, maxRounds int) *Loop {
 	eng := executor.NewEngine(nil)
-	reg := tools.NewRegistry()
-	return New(eng, newTestWorkflowForSession(), reg, Config{
+	return New(eng, newTestWorkflowForSession(), newStreamingRegistry(), Config{
 		Model:         "test",
 		Streamer:      streamer,
 		MaxToolRounds: maxRounds,
@@ -267,8 +280,7 @@ func newStreamingLoop(streamer Streamer, maxRounds int) *Loop {
 
 func newStreamingLoopFinalOnly(streamer Streamer, maxRounds int) *Loop {
 	eng := executor.NewEngine(nil)
-	reg := tools.NewRegistry()
-	return New(eng, newTestWorkflowForSession(), reg, Config{
+	return New(eng, newTestWorkflowForSession(), newStreamingRegistry(), Config{
 		Model:           "test",
 		Streamer:        streamer,
 		MaxToolRounds:   maxRounds,
@@ -698,7 +710,7 @@ func TestRunStreaming_SessionStoresResponse(t *testing.T) {
 // when StreamFinalOnly=true, intermediate tool-call rounds are not written
 // to the caller's writer.
 func TestRunStreaming_StreamFinalOnly_SuppressesIntermediateRounds(t *testing.T) {
-	toolCall := domain.StreamedToolCall{ID: "t1", Name: "echo", Arguments: `{}`}
+	toolCall := domain.StreamedToolCall{ID: "t1", Name: "noop", Arguments: `{}`}
 	ms := &mockStreamer{
 		responses: []mockStreamResponse{
 			{content: "intermediate", toolCalls: []domain.StreamedToolCall{toolCall}},
@@ -725,7 +737,7 @@ func TestRunStreaming_StreamFinalOnly_SuppressesIntermediateRounds(t *testing.T)
 // TestRunStreaming_StreamFinalOnly_FalseStreamsAll verifies that
 // when StreamFinalOnly=false (default), all rounds are streamed.
 func TestRunStreaming_StreamFinalOnly_FalseStreamsAll(t *testing.T) {
-	toolCall := domain.StreamedToolCall{ID: "t1", Name: "echo", Arguments: `{}`}
+	toolCall := domain.StreamedToolCall{ID: "t1", Name: "noop", Arguments: `{}`}
 	ms := &mockStreamer{
 		responses: []mockStreamResponse{
 			{content: "round1", toolCalls: []domain.StreamedToolCall{toolCall}},
@@ -738,7 +750,7 @@ func TestRunStreaming_StreamFinalOnly_FalseStreamsAll(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(buf.String(), "[echo") {
+	if !strings.Contains(buf.String(), "[noop") {
 		t.Errorf(
 			"tool call summary should be written when StreamFinalOnly=false, got %q",
 			buf.String(),
@@ -1604,7 +1616,7 @@ func (m *midTurnDropStreamer) StreamChat(
 // the failed attempt must not leak into the response.
 func TestRunStreaming_MidTurnDropRetriesRound(t *testing.T) {
 	ms := &midTurnDropStreamer{}
-	loop := New(executor.NewEngine(nil), newTestWorkflowForSession(), tools.NewRegistry(), Config{
+	loop := New(executor.NewEngine(nil), newTestWorkflowForSession(), newStreamingRegistry(), Config{
 		Model:              "test",
 		Streamer:           ms,
 		MaxToolRounds:      5,
@@ -2301,4 +2313,66 @@ func TestRunStreaming_SalvagesAnthropicInvoke(t *testing.T) {
 	assert.Equal(t, "host-1", got["target"])
 	assert.NotContains(t, result, "parameter")
 	assert.NotContains(t, result, "invoke")
+}
+
+// A failed work tool must be flagged to the model with a [TOOL FAILED] banner,
+// and the loop must not end the turn on a "done" claim right after it -- it
+// nudges once for a real success or an honest failure.
+func TestRunStreaming_FailedToolNotAcceptedAsDone(t *testing.T) {
+	calls := 0
+	eng := executor.NewEngine(nil)
+	reg := tools.NewRegistry()
+	reg.Register(&tools.Tool{
+		Name: "edit_file", Description: "edit", Parameters: map[string]domain.ToolParam{},
+		Execute: func(_ map[string]any) (string, error) {
+			calls++
+			return "", errors.New("old_string not found in /a.go")
+		},
+	})
+	ms := &cfgRecordingStreamer{inner: mockStreamer{responses: []mockStreamResponse{
+		{content: "", toolCalls: []domain.StreamedToolCall{{ID: "1", Name: "edit_file", Arguments: "{}"}}},
+		{content: "Done. The file has been updated.", toolCalls: nil},
+		{content: "Actually the edit failed: old_string not found.", toolCalls: nil},
+	}}}
+	loop := New(eng, newTestWorkflowForSession(), reg, Config{
+		Model: "test", Streamer: ms, MaxToolRounds: 10,
+	})
+	var buf bytes.Buffer
+	result, err := loop.RunStreaming(context.Background(), "fix it", &buf)
+	require.NoError(t, err)
+
+	require.GreaterOrEqual(t, len(ms.cfgs), 2)
+	assert.Contains(t, ms.cfgs[1].Messages, "[TOOL FAILED]",
+		"the model must see the failed tool flagged")
+	require.Len(t, ms.cfgs, 3, "a 'done' claim after a failed tool must draw one nudge")
+	assert.Contains(t, ms.cfgs[2].Prompt, "edit_file call failed")
+	assert.Contains(t, result, "edit failed")
+}
+
+// A queued model note (goal transition, budget change, forced failure) must be
+// injected into the next request as a [kdeps] system message.
+func TestRunStreaming_ModelNoteReachesModel(t *testing.T) {
+	eng := executor.NewEngine(nil)
+	reg := tools.NewRegistry()
+	var loop *Loop
+	reg.Register(&tools.Tool{
+		Name: "noop", Description: "noop", Parameters: map[string]domain.ToolParam{},
+		Execute: func(_ map[string]any) (string, error) {
+			loop.queueModelNote("goal: task 1 failed — continuing with task 2")
+			return "noop ok", nil
+		},
+	})
+	ms := &cfgRecordingStreamer{inner: mockStreamer{responses: []mockStreamResponse{
+		{content: "", toolCalls: []domain.StreamedToolCall{{ID: "1", Name: "noop", Arguments: "{}"}}},
+		{content: "the answer", toolCalls: nil},
+	}}}
+	loop = New(eng, newTestWorkflowForSession(), reg, Config{
+		Model: "test", Streamer: ms, MaxToolRounds: 10,
+	})
+	var buf bytes.Buffer
+	_, err := loop.RunStreaming(context.Background(), "go", &buf)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(ms.cfgs), 2)
+	assert.Contains(t, ms.cfgs[1].Messages, `"role":"system"`)
+	assert.Contains(t, ms.cfgs[1].Messages, "[kdeps] goal: task 1 failed")
 }


### PR DESCRIPTION
## Summary

The agent loop printed goal transitions, budget changes, and forced task failures only to the terminal, and a failed work tool (`edit_file`, `bash_exec`) returned a bare `{"error":...}` the model skimmed past. Result: the loop kept going and reported the task done even though nothing changed. The human in the REPL cannot act on those notices - they need to reach the model so it self-corrects.

## Changes

- **`pkg/agent/loop.go`**
  - `Loop.modelNotes` channel + `queueModelNote`; flushed into the model's next request as one `[kdeps]` system message in `appendToolRoundTrip`.
  - `Loop.lastWorkFailure` + `toolFailure`; failed work-tool results get a `[TOOL FAILED]` banner and skip `turoReduce` so the exact error survives (`executeToolCalls` / `toolResultMessage`).
  - `resolveEmptyToolRound`: one end-of-turn `nudgeUnresolvedToolFailureConfig` when a work tool is still failing and was never fixed or acknowledged.
  - `toolUseGuidance`: tells the model `[kdeps]` notes and `{"error":...}` results are feedback to act on.
  - Extracted `prepareRound`, `applyRoundOutcome`, `ensureNonSilentFinal`, `executeToolCalls`, `toolResultMessage` (complexity).
- **`pkg/agent/goal_enforce.go`**: `reportGoalEvent` and the forced task-fail transition also `queueModelNote`; `goalEnforcer.lastWorkError` set/cleared in `resultIsNew` / `resetTask`; `settleActiveFromText` records the task **failed** when a work tool is still failing.
- **`pkg/agent/goal_tools.go`**: `settleTask` refuses `task_complete` while the last work tool is failing.

## Docs

`docs/v2/agent/tools.md`, `docs/v2/agent/goals.md`, `book/chapter-05-agent-mode.md`.

## Tests

`TestRunStreaming_FailedToolNotAcceptedAsDone`, `TestRunStreaming_ModelNoteReachesModel`, plus registry fixes for existing streaming tests. Full suite: 14038 passing. `make lint` clean. `docs/v2` build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)