### PR TITLE
feat(agent): /instruct! sends the briefing as a live turn

### DIFF
--- a/docs/v2/agent/commands.md
+++ b/docs/v2/agent/commands.md
@@ -46,8 +46,9 @@ Inside the [agent loop REPL](/agent/), type `/help` for the full list.
 | `/goal clear` | Drop the active goal (the next prompt starts a new one) |
 | `/refine` | Show whether pre-turn prompt refinement is on (see [Prompt refinement](/agent/refine)) |
 | `/refine on\|off` | Enable or disable rewriting each prompt for clarity before the turn; on by default, persists across sessions |
-| `/instruct` | Print a kdeps briefing (what kdeps is, how to call a tool with worked `<invoke>` examples, the live tool catalog, memory, goals, runtime feedback) and add it to the model's context so the next turn is primed with it |
-| `/instruct <topic>` | Brief on one topic only: `overview`, `modes`, `tools`, `available`, `aliases`, `memory`, `goals`, `feedback`, `files` |
+| `/instruct` | Print a kdeps briefing (what kdeps is, how to call a tool with worked `<invoke>` examples, the live tool catalog, memory, goals, runtime feedback) and append it to history as a settled turn, so the next prompt is primed with it |
+| `/instruct!` | Same briefing, but sent as a **real turn now** - the model reads it and replies with an acknowledgement on the spot. For models that skim injected context |
+| `/instruct <topic>` / `/instruct! <topic>` | Brief on one topic only: `overview`, `modes`, `tools`, `available`, `aliases`, `memory`, `goals`, `feedback`, `files` |
 | `/instruct list` | Name the topics without briefing the model |
 | `/judges` | Show the configured judge panel (reviews each turn's final output - see [Judge panel](/agent/judges)) |
 | `/judges add <name> <criteria>` | Add a judge to the explicit roster |

--- a/pkg/agent/instruct_test.go
+++ b/pkg/agent/instruct_test.go
@@ -128,6 +128,42 @@ func TestCmdInstruct_UnknownTopic(t *testing.T) {
 
 func TestInstructCommand_InBuiltinList(t *testing.T) {
 	assert.Contains(t, builtinCmds, "/instruct")
+	assert.Contains(t, builtinCmds, "/instruct!")
+}
+
+// /instruct! sends the briefing as a real turn instead of appending it silently.
+func TestCmdInstructBang_RunsTurn(t *testing.T) {
+	loop := makeTestLoop(nil)
+	repl := NewREPL(context.Background(), loop)
+	defer repl.cancel()
+
+	var sent string
+	repl.runFn = func(_ context.Context, prompt string) (string, error) {
+		sent = prompt
+		return "Understood.", nil
+	}
+
+	out := testCaptureStdout(t, func() {
+		require.NoError(t, repl.dispatchCommand("/instruct! tools"))
+	})
+	assert.Contains(t, sent, "How to call a tool", "the briefing is the turn's prompt")
+	assert.Contains(t, sent, "mandatory kdeps briefing")
+	assert.Contains(t, out, "Sending the briefing to the model now (tools)")
+}
+
+// /instruct! list only names topics; it does not run a turn.
+func TestCmdInstructBang_ListDoesNotRun(t *testing.T) {
+	loop := makeTestLoop(nil)
+	repl := NewREPL(context.Background(), loop)
+	defer repl.cancel()
+
+	called := false
+	repl.runFn = func(_ context.Context, _ string) (string, error) {
+		called = true
+		return "", nil
+	}
+	require.NoError(t, repl.dispatchCommand("/instruct! list"))
+	assert.False(t, called)
 }
 
 func TestInstructTopicNamesUnique(t *testing.T) {

--- a/pkg/agent/repl.go
+++ b/pkg/agent/repl.go
@@ -112,7 +112,7 @@ var builtinCmds = []string{
 	"/help", "/settings", "/clear", "/model", "/context",
 	"/skills", "/prompts", "/prompt", "/compact", "/history", "/thinking", "/session",
 	"/editor", "/copy", "/reload", "/permission", "/autocontext", "/tools", "/upgrade",
-	"/login", "/stealth", "/refine", "/instruct", "/exit", "/quit",
+	"/login", "/stealth", "/refine", "/instruct", "/instruct!", "/exit", "/quit",
 }
 
 // REPL output styles. Package vars, not constants, so stealth mode (theme.go)
@@ -2510,8 +2510,9 @@ func (r *REPL) dispatchControlCommand(command string, args []string) (bool, erro
 	case "/memory":
 		return true, r.cmdMemory(args)
 	case "/instruct":
-		r.cmdInstruct(args)
-		return true, nil
+		return true, r.cmdInstruct(false, args)
+	case "/instruct!":
+		return true, r.cmdInstruct(true, args)
 	}
 	return false, nil
 }
@@ -2574,8 +2575,9 @@ func (r *REPL) cmdHelp() error {
 		"  /goal skip                         Abandon the active task and move to the next",
 		"  /goal clear                        Drop the active goal (stops task enforcement)",
 		"  /refine [on|off]                   Show or toggle pre-turn prompt refinement (on by default)",
-		"  /instruct                          Brief the model on kdeps: tools, how to call them, memory, modes",
-		"  /instruct <topic>                  Brief on one topic only (/instruct list to see topics)",
+		"  /instruct [topic]                  Brief the model on kdeps (tools, calling, memory, modes); primes the next prompt",
+		"  /instruct! [topic]                 Same briefing, sent as a turn now - the model reads and acknowledges it on the spot",
+		"  /instruct list                     Show the briefing topics",
 		"  /judges                            Show the configured judge panel (reviews each turn's final output)",
 		"  /judges add <name> <criteria>      Add a judge to the explicit roster",
 		"  /judges remove <name>              Remove a judge from the explicit roster",
@@ -4878,10 +4880,13 @@ func (r *REPL) cmdRefine(args []string) {
 	}
 }
 
-// cmdInstruct prints a kdeps briefing and adds it to the model's context so the
-// next turn is primed with it. No argument briefs on every topic; "/instruct
-// <topic>" on one; "/instruct list" just names the topics without briefing.
-func (r *REPL) cmdInstruct(args []string) {
+// cmdInstruct delivers a kdeps briefing to the model. Without live it appends
+// the briefing to history as a settled turn (cheap, primes the next prompt);
+// with live ("/instruct!") it runs a real turn now so the model reads the
+// briefing and acknowledges it on the spot -- for models that skim injected
+// context. No argument briefs on every topic; "<topic>" on one; "list" just
+// names the topics.
+func (r *REPL) cmdInstruct(live bool, args []string) error {
 	topic := ""
 	if len(args) > 0 {
 		topic = strings.ToLower(args[0])
@@ -4892,30 +4897,60 @@ func (r *REPL) cmdInstruct(args []string) {
 			fmt.Fprintf(os.Stdout, "  %-11s %s\n", t.name, t.title)
 		}
 		fmt.Fprintln(os.Stdout, styleReplDim.Render(
-			"/instruct briefs the model on every topic; /instruct <topic> on one."))
-		return
+			"/instruct primes the next prompt; /instruct! sends it as a turn now; add a <topic> for one."))
+		return nil
 	}
 
 	briefing, ok := buildInstruct(r.loop, topic)
 	if !ok {
 		fmt.Fprintf(os.Stdout, "Unknown topic %q. Try /instruct list.\n", topic)
-		return
+		return nil
 	}
 	// Printed raw, not through the markdown renderer: the briefing contains
 	// literal <invoke>/<parameter>/<task-id> tags the renderer would strip.
 	fmt.Fprintln(os.Stdout, briefing)
 
+	scope := "all topics"
+	if topic != "" {
+		scope = topic
+	}
+
+	if live {
+		return r.instructLive(briefing, scope)
+	}
 	r.loop.Session().Append(
 		"Reference briefing on kdeps for you to follow for the rest of this "+
 			"session:\n\n"+briefing,
 		instructAck,
 	)
-	scope := "all topics"
-	if topic != "" {
-		scope = topic
-	}
 	fmt.Fprintln(os.Stdout, styleReplMeta.Render(
 		"Briefing added to the model's context ("+scope+")."))
+	return nil
+}
+
+// instructLive runs a real turn with the briefing as the prompt, so a model
+// that skims injected context has to read and acknowledge it right now.
+func (r *REPL) instructLive(briefing, scope string) error {
+	if r.loop.config.Model == "" {
+		fmt.Fprintln(os.Stdout, styleReplMeta.Render(
+			"No model selected - /instruct! needs one. Use /instruct to prime the context instead."))
+		return nil
+	}
+	prompt := briefing + "\n\n" +
+		"The block above is a mandatory kdeps briefing. Read it now and reply with one " +
+		"short line confirming you have read it and will follow it for the rest of this " +
+		"session. Do not call any tool."
+	fmt.Fprintln(os.Stdout, styleReplMeta.Render("Sending the briefing to the model now ("+scope+")..."))
+	resp, err := r.runWithThinking(r.ctx, prompt)
+	if err != nil {
+		return err
+	}
+	r.syncTokenCounter()
+	if resp != "" && (r.runFn != nil || !r.loop.IsStreaming()) {
+		fmt.Fprint(os.Stdout, renderREPLOutput(resp, false))
+	}
+	r.maybeHintCompact()
+	return nil
 }
 
 // judgesAddMinArgs is "add <name> <criteria...>"; judgesRemoveMinArgs is

--- a/tests/e2e/test_agent_instruct.sh
+++ b/tests/e2e/test_agent_instruct.sh
@@ -53,3 +53,9 @@ if output_grep_fixed "Briefing added to the model's context (all topics)" "$OUTP
 else
     test_failed "instruct - no-arg did not brief all topics" "Output: $OUTPUT"
 fi
+
+if output_grep_fixed "/instruct!" "$OUTPUT"; then
+    test_passed "instruct - /help lists /instruct!"
+else
+    test_failed "instruct - /help missing /instruct!" "Output: $OUTPUT"
+fi


### PR DESCRIPTION
## Summary

Some models skim context that is injected as a settled prior turn. `/instruct!` sends the same briefing as a **real turn right now** - the model reads it and replies with an acknowledgement on the spot.

| Command | Delivery |
|---|---|
| `/instruct [topic]` | Appended to history as a settled turn; primes the next prompt (unchanged) |
| `/instruct! [topic]` | Run as a real turn via `runWithThinking`; the model acknowledges on the spot |
| `/instruct! list` | Names the topics; no turn |

No model selected -> `/instruct!` prints a hint and falls back to suggesting `/instruct`.

## Changes

- `pkg/agent/repl.go`: `cmdInstruct(live bool, args)` + `instructLive`; dispatch handles `/instruct!`; `builtinCmds` + `/help` updated.
- Docs: `docs/v2/agent/commands.md`, `book/chapter-05-agent-mode.md`.
- `tests/e2e/test_agent_instruct.sh`: assert `/help` lists `/instruct!`.

## Tests

`TestCmdInstructBang_RunsTurn` (briefing is the turn's prompt), `TestCmdInstructBang_ListDoesNotRun`. Full suite **14031** passing; `make lint` clean; `docs/v2` build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)