### PR TITLE
chore: release v2.28.1

### DIFF
--- a/docs/v2/package.json
+++ b/docs/v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kdeps-docs",
-  "version": "2.28.0",
+  "version": "2.28.1",
   "description": "kdeps Documentation",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Patch release: /instruct! sends the kdeps briefing as a live turn for models that skim injected context (#826, #827).

🤖 Generated with [Claude Code](https://claude.com/claude-code)