### PR TITLE
fix(agent): /refine sees conversation history

### DIFF
--- a/docs/v2/agent/refine.md
+++ b/docs/v2/agent/refine.md
@@ -25,6 +25,12 @@ The refined text is what the model receives, what `/prompt` shows as the user
 message, and what is saved to the session and the memory bridge for that turn -
 so a later model switch sees exactly what was answered.
 
+**It sees the conversation so far.** The refine call gets the same prior-turn
+history the real turn does, so it can resolve what a reference actually means -
+"change that to use port 465" becomes concrete once the refiner can see the
+config you were just discussing. Only prior turns are included; the prompt
+being refined is not yet part of the history at this point.
+
 **What it will not do.** The rewrite preserves your intent and every concrete
 detail (names, paths, numbers, constraints). It does not answer the request, add
 requirements you did not imply, or invent facts. An already-clear prompt comes

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -3168,6 +3168,9 @@ func (l *Loop) buildChatConfig(
 // through turo when active. Falls back to the plain history for session
 // implementations that do not support reduced serialization.
 func (l *Loop) historyMessages(ctx context.Context) string {
+	if l.session == nil {
+		return ""
+	}
 	if !turoActive(ctx) {
 		return l.session.BuildMessagesJSON()
 	}

--- a/pkg/agent/prompt_refine.go
+++ b/pkg/agent/prompt_refine.go
@@ -38,14 +38,18 @@ const refineActionID = "agent_loop_refine"
 
 const refineSystemPrompt = `You rewrite a user's request so it is clearer for an AI agent to act on.
 
+The conversation history above (if any) is context ONLY, for resolving what the
+request refers to. Do not answer it, continue it, or rewrite any earlier turn.
+
 Reply with ONLY the rewritten request as plain text. No preamble, no quotes, no explanation.
 
 Rules:
 - Preserve the user's intent and every concrete detail (names, paths, numbers, constraints).
-- Make it specific and self-contained: spell out what "it"/"that" refers to, state the expected outcome.
+- Make it specific and self-contained: spell out what "it"/"that"/"the file we discussed" etc.
+  refers to using the conversation history, and state the expected outcome.
 - Do NOT answer or start the task. Do NOT add requirements the user did not imply. Do NOT invent facts.
 - Keep it tight: a 1 to 3 sentence request, not an expansion into a spec.
-- If the request is already clear, return it essentially unchanged.`
+- If the request is already clear and self-contained, return it essentially unchanged.`
 
 // refineExpansionSlack bounds how much longer a rewrite may be than the
 // original before it is treated as a runaway expansion and discarded.
@@ -106,6 +110,14 @@ func refinePrompt(ctx context.Context, l *Loop, input string) string {
 		Backend: l.config.Backend,
 		BaseURL: l.config.BaseURL,
 		Role:    l.config.Role,
+		// The conversation so far, same construction the real turn uses
+		// (historyMessages), so "fix that" / "the file we discussed" can be
+		// resolved against what was actually said -- without it the refiner
+		// has nothing to resolve a reference against and either passes the
+		// prompt through unchanged or rewrites it into something ungrounded.
+		// This is prior turns only: the current input has not been appended
+		// to the session yet, so there is no risk of doubling it up.
+		Messages: l.historyMessages(ctx),
 		// Deliberately NOT routed through turo: the input is the exact request
 		// being clarified and the system prompt is an instruction spec;
 		// reducing either to content words defeats the purpose.

--- a/pkg/agent/prompt_refine_test.go
+++ b/pkg/agent/prompt_refine_test.go
@@ -91,6 +91,40 @@ func TestRefinePrompt_FallsBackOnErrorMapAndEmpty(t *testing.T) {
 	}
 }
 
+// TestRefinePrompt_IncludesConversationHistory is the regression guard for
+// "refine needs context": the refiner must see prior turns so it can resolve
+// "that" / "the file we discussed" against what was actually said, not just
+// the bare new input.
+func TestRefinePrompt_IncludesConversationHistory(t *testing.T) {
+	var gotMessages string
+	l := refineLoop(t, func(wf *domain.Workflow, _ interface{}) (interface{}, error) {
+		gotMessages = wf.Resources[0].Chat.Messages
+		return "rewritten with context", nil
+	})
+	l.session = NewSession(0)
+	l.session.Append("what's in config.yaml?", "It sets the SMTP host and port.")
+
+	got := refinePrompt(context.Background(), l, "actually change that setting to use port 465 instead")
+	if got != "rewritten with context" {
+		t.Fatalf("got %q, want the rewrite", got)
+	}
+	if !strings.Contains(gotMessages, "config.yaml") || !strings.Contains(gotMessages, "SMTP") {
+		t.Fatalf("expected prior turns in the refine call's Messages, got %q", gotMessages)
+	}
+}
+
+// A bare *Loop with no session (as constructed by refineLoop's other callers)
+// must not panic when refining - historyMessages degrades to "".
+func TestRefinePrompt_NoSession_DoesNotPanic(t *testing.T) {
+	l := refineLoop(t, func(*domain.Workflow, interface{}) (interface{}, error) {
+		return "rewritten", nil
+	})
+	got := refinePrompt(context.Background(), l, "do the thing with the config and restart it")
+	if got != "rewritten" {
+		t.Fatalf("got %q", got)
+	}
+}
+
 func TestRefinePrompt_NoEngine(t *testing.T) {
 	in := "do the thing with the config and restart it"
 	if got := refinePrompt(context.Background(), &Loop{config: Config{PromptRefine: true}}, in); got != in {


### PR DESCRIPTION
## Summary

The prompt-refinement synthetic call had no conversation history - it only ever saw the bare new input plus its own rewriting instructions. A reference-laden follow-up ("change that setting to use port 465", "fix the bug we just found") gave the refiner nothing to resolve "that"/"the bug" against, so it either passed the prompt through unchanged or rewrote it into something ungrounded.

## Fix

- `refinePrompt` now sets `chatCfg.Messages` via the same `l.historyMessages(ctx)` the real turn itself uses - prior turns only (the current input hasn't been appended to the session yet at refine time, so there's no risk of doubling it up).
- `refineSystemPrompt` now explicitly tells the model the history above is context only - never to answer or continue it - and to resolve references against it.
- `historyMessages` gained a nil-session guard (`l.session == nil` -> `""`), since the prompt-refinement test helpers (and possibly other synthetic-call sites) build a bare `*Loop` with no session.

## Docs

`docs/v2/agent/refine.md` - new "It sees the conversation so far" section.

## Tests

`TestRefinePrompt_IncludesConversationHistory` (asserts prior turns actually reach the synthetic call's `Messages`), `TestRefinePrompt_NoSession_DoesNotPanic`. Full suite **14033** passing; `make lint` clean; `docs/v2` build clean.

## Note

Separately, `looksTrivial` skips the refine call entirely for inputs ≤32 chars (by design, to save the call on ordinary chat) - a short reference-laden follow-up like "fix that" never reaches the refiner at all regardless of this fix, since it's judged trivial by length alone. Flagging it here rather than changing it, since it's a distinct design decision (when to refine) from what this PR fixes (what the refiner sees when it runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)