### PR TITLE
chore: bump version to 2.28.3

### DIFF
--- a/docs/v2/package.json
+++ b/docs/v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kdeps-docs",
-  "version": "2.28.2",
+  "version": "2.28.3",
   "description": "kdeps Documentation",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Includes the --file/stdin input size guard (#834/#835).

🤖 Generated with [Claude Code](https://claude.com/claude-code)