### PR TITLE
fix: give the sandbox-hallucination nudge a concrete invoke example

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -1378,6 +1378,9 @@ func looksLikeSandboxHallucination(content string) bool {
 // model to make a real call.
 func nudgeSandboxHallucinationConfig(cfg *domain.ChatConfig) *domain.ChatConfig {
 	nudgeCfg := *cfg
+	// The literal <invoke> block below is appended after turoReduce, not
+	// passed through it -- turo's filler/synonym rewriting is meant for prose
+	// and would mangle the exact whitespace and quoting a model needs to copy.
 	note := turoReduce(context.Background(),
 		"You made no tool call, and phrases like \"NO CONTENT AVAILABLE\", "+
 			"\"expired\", \"/mnt/data\", or \"cannot access the filesystem\" come from a "+
@@ -1385,8 +1388,19 @@ func nudgeSandboxHallucinationConfig(cfg *domain.ChatConfig) *domain.ChatConfig 
 			"and never returns those messages -- nothing ran. The real working directory "+
 			"is a live filesystem with the files from the task present now. Make an actual "+
 			"kdeps tool call (bash_exec, read_file, ...) through the tool interface and wait "+
-			"for the runtime's result. If you were not attempting tool use, ignore this and "+
-			"answer normally.")
+			"for the runtime's result.") +
+		"\n\nIf your backend has no native tool-call channel, emit it as a single " +
+		"matched <invoke>...</invoke> block instead, exactly like this (open tag " +
+		"and close tag, nothing else around it):\n\n" +
+		"  <invoke name=\"bash_exec\">\n" +
+		"  <parameter name=\"command\">pwd && ls</parameter>\n" +
+		"  </invoke>\n\n" +
+		"or, to read a file:\n\n" +
+		"  <invoke name=\"read_file\">\n" +
+		"  <parameter name=\"file_path\">path/from/the/task</parameter>\n" +
+		"  </invoke>\n\n" +
+		"Emit one such block and wait for the runtime's real result before answering. " +
+		"If you were not attempting tool use, ignore this and answer normally."
 	nudgeCfg.Prompt = strings.TrimSpace(cfg.Prompt + "\n\n" + note)
 	return &nudgeCfg
 }

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -1315,6 +1315,24 @@ func (l *Loop) applyRoundOutcome(
 	return convergenceStop(chatCfg, outcome.blocked, convergenceBlocks, forcedFinal)
 }
 
+// invokeExampleBlock is the concrete, copyable <invoke> syntax appended to
+// every nudge that tells a model to "make a real tool call" -- text alone
+// leaves a backend with no native tool-call channel nothing to copy, and it
+// tends to repeat the same hallucination rather than switch tactics. Kept as
+// a literal (never routed through turoReduce) so its exact whitespace and
+// quoting survive intact.
+const invokeExampleBlock = "\n\nIf your backend has no native tool-call channel, emit it as a single " +
+	"matched <invoke>...</invoke> block instead, exactly like this (open tag " +
+	"and close tag, nothing else around it):\n\n" +
+	"  <invoke name=\"bash_exec\">\n" +
+	"  <parameter name=\"command\">pwd && ls</parameter>\n" +
+	"  </invoke>\n\n" +
+	"or, to read a file:\n\n" +
+	"  <invoke name=\"read_file\">\n" +
+	"  <parameter name=\"file_path\">path/from/the/task</parameter>\n" +
+	"  </invoke>\n\n" +
+	"Emit one such block and wait for the runtime's real result before answering."
+
 // nudgeForActionConfig returns a copy of cfg asking the model to commit to an
 // action after a round that produced neither a tool call nor an answer. Tools
 // stay registered: the goal is to get the call the model already decided on in
@@ -1329,7 +1347,8 @@ func nudgeForActionConfig(cfg *domain.ChatConfig) *domain.ChatConfig {
 	note := turoReduce(context.Background(),
 		"Your previous response contained no tool call and no answer. "+
 			"If you intended to call a tool, call it now. Otherwise, answer directly "+
-			"in plain text. Do not reply with reasoning alone.")
+			"in plain text. Do not reply with reasoning alone.") +
+		invokeExampleBlock
 	nudgeCfg.Prompt = strings.TrimSpace(cfg.Prompt + "\n\n" + note)
 	return &nudgeCfg
 }
@@ -1342,9 +1361,9 @@ func nudgeNoFakeToolResponseConfig(cfg *domain.ChatConfig) *domain.ChatConfig {
 	note := turoReduce(context.Background(),
 		"You wrote a <tool_response> block. You never write tool results -- the "+
 			"runtime does, and nothing ran. Make the actual tool call now (your "+
-			"native tool channel, or one matched <invoke name=\"...\">...</invoke> "+
-			"block) and wait for its real result before answering. Never author a "+
-			"<tool_response> yourself.")
+			"native tool channel, or the <invoke> block below) and wait for its "+
+			"real result before answering. Never author a <tool_response> yourself.") +
+		invokeExampleBlock
 	nudgeCfg.Prompt = strings.TrimSpace(cfg.Prompt + "\n\n" + note)
 	return &nudgeCfg
 }
@@ -1378,9 +1397,9 @@ func looksLikeSandboxHallucination(content string) bool {
 // model to make a real call.
 func nudgeSandboxHallucinationConfig(cfg *domain.ChatConfig) *domain.ChatConfig {
 	nudgeCfg := *cfg
-	// The literal <invoke> block below is appended after turoReduce, not
-	// passed through it -- turo's filler/synonym rewriting is meant for prose
-	// and would mangle the exact whitespace and quoting a model needs to copy.
+	// invokeExampleBlock is appended after turoReduce, not passed through it --
+	// turo's filler/synonym rewriting is meant for prose and would mangle the
+	// exact whitespace and quoting a model needs to copy.
 	note := turoReduce(context.Background(),
 		"You made no tool call, and phrases like \"NO CONTENT AVAILABLE\", "+
 			"\"expired\", \"/mnt/data\", or \"cannot access the filesystem\" come from a "+
@@ -1389,18 +1408,8 @@ func nudgeSandboxHallucinationConfig(cfg *domain.ChatConfig) *domain.ChatConfig 
 			"is a live filesystem with the files from the task present now. Make an actual "+
 			"kdeps tool call (bash_exec, read_file, ...) through the tool interface and wait "+
 			"for the runtime's result.") +
-		"\n\nIf your backend has no native tool-call channel, emit it as a single " +
-		"matched <invoke>...</invoke> block instead, exactly like this (open tag " +
-		"and close tag, nothing else around it):\n\n" +
-		"  <invoke name=\"bash_exec\">\n" +
-		"  <parameter name=\"command\">pwd && ls</parameter>\n" +
-		"  </invoke>\n\n" +
-		"or, to read a file:\n\n" +
-		"  <invoke name=\"read_file\">\n" +
-		"  <parameter name=\"file_path\">path/from/the/task</parameter>\n" +
-		"  </invoke>\n\n" +
-		"Emit one such block and wait for the runtime's real result before answering. " +
-		"If you were not attempting tool use, ignore this and answer normally."
+		invokeExampleBlock +
+		" If you were not attempting tool use, ignore this and answer normally."
 	nudgeCfg.Prompt = strings.TrimSpace(cfg.Prompt + "\n\n" + note)
 	return &nudgeCfg
 }

--- a/pkg/agent/loop_integration_test.go
+++ b/pkg/agent/loop_integration_test.go
@@ -2418,3 +2418,22 @@ func TestRunStreaming_SandboxHallucinationNudgedOnce(t *testing.T) {
 	assert.Len(t, ms.cfgs, 2, "must nudge exactly once, not loop")
 	assert.NotEmpty(t, strings.TrimSpace(got))
 }
+
+// Every nudge that tells the model to "make a real tool call" must show it
+// the concrete <invoke> syntax to copy -- not just say "call it now" -- so a
+// backend with no native tool-call channel has something to act on.
+func TestNudgeConfigs_IncludeInvokeExample(t *testing.T) {
+	base := &domain.ChatConfig{Prompt: "question"}
+	for name, nudge := range map[string]func(*domain.ChatConfig) *domain.ChatConfig{
+		"nudgeForActionConfig":            nudgeForActionConfig,
+		"nudgeNoFakeToolResponseConfig":   nudgeNoFakeToolResponseConfig,
+		"nudgeSandboxHallucinationConfig": nudgeSandboxHallucinationConfig,
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := nudge(base)
+			assert.Contains(t, got.Prompt, `<invoke name="bash_exec">`)
+			assert.Contains(t, got.Prompt, `<parameter name="command">`)
+			assert.Contains(t, got.Prompt, "</invoke>")
+		})
+	}
+}

--- a/pkg/agent/loop_integration_test.go
+++ b/pkg/agent/loop_integration_test.go
@@ -2396,6 +2396,11 @@ func TestRunStreaming_SandboxHallucinationNudged(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, ms.cfgs, 2, "the fake sandbox transcript must draw exactly one nudge")
 	assert.Contains(t, ms.cfgs[1].Prompt, "code-interpreter sandbox")
+	// The nudge must show a concrete, copyable <invoke> example -- not just
+	// tell the model to "make a real call" with no syntax to follow.
+	assert.Contains(t, ms.cfgs[1].Prompt, `<invoke name="bash_exec">`)
+	assert.Contains(t, ms.cfgs[1].Prompt, `<parameter name="command">`)
+	assert.Contains(t, ms.cfgs[1].Prompt, "</invoke>")
 	assert.Equal(t, "The config timeout is 30s.", got)
 }
 


### PR DESCRIPTION
The mid-turn nudge fired when a model hallucinates a code-interpreter sandbox session ("NO CONTENT AVAILABLE", "expired", /mnt/data) only told it to "make an actual kdeps tool call" with no syntax to follow. A backend with no native tool-call channel had nothing to copy and kept repeating the same hallucination.

Now appends a literal `<invoke>` block example (`bash_exec` and `read_file`), matching the format already shown in `kdepsToolsFirstGuidance`'s system preamble -- but attached after `turoReduce` runs on the surrounding prose, not through it, so filler/synonym rewriting can't mangle the example's exact whitespace and quoting.

Added test coverage asserting the example is present in the nudge prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)