### PR TITLE
fix: escalate against repeat claimed-success after a failed tool call

### DIFF
--- a/docs/v2/agent/tools.md
+++ b/docs/v2/agent/tools.md
@@ -124,9 +124,15 @@ The file's line-ending style is preserved on write.
 Every tool failure is returned to the model as `{"error": ...}` **plus a
 `[TOOL FAILED]` banner** ("nothing changed - fix the cause and retry, or say it
 failed"), so a skimmed error is hard to miss. The turn will not end on a "done"
-claim made right after a work tool failed: the loop pushes back once for a real
-success or an honest "it failed". With a goal active, `task_complete` on such a
-task is refused, and a prose "done" records the task **failed**, not done.
+claim made right after a work tool failed: the loop pushes back for a real
+success or an honest "it failed" - up to twice, with the second push-back
+reading as a repeat, same bound as the other corrective nudges. If the model
+still hasn't acknowledged the failure after both, the turn does not settle on
+the bald claim unflagged: the response is followed by a notice naming the
+tool and its error, so the claim is kept but clearly marked unresolved. An
+honest admission at any point (in whatever words) is accepted immediately,
+no nudge needed. With a goal active, `task_complete` on such a task is
+refused, and a prose "done" records the task **failed**, not done.
 
 Loop-generated notices - goal transitions, budget changes, forced task failures,
 context-window trims - are injected into the model's context as `[kdeps] ...`

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -1446,11 +1446,15 @@ func nudgeSandboxHallucinationConfig(cfg *domain.ChatConfig, repeat bool) *domai
 // nudgeUnresolvedToolFailureConfig fires when the turn is about to end while the
 // last work tool is still failing. The model must retry it to a real success or
 // state plainly that the step failed -- not silently report it done.
-func nudgeUnresolvedToolFailureConfig(cfg *domain.ChatConfig, f *toolFailure) *domain.ChatConfig {
+// repeat is true on the second strike within this turn.
+func nudgeUnresolvedToolFailureConfig(cfg *domain.ChatConfig, f *toolFailure, repeat bool) *domain.ChatConfig {
 	nudgeCfg := *cfg
 	note := "Your last " + f.tool + " call failed: " + f.msg +
 		". It has not succeeded. Retry it and get a real success, or state plainly " +
 		"in your answer that this step failed. Do not claim it is done."
+	if repeat {
+		note += repeatOffenseNote
+	}
 	nudgeCfg.Prompt = strings.TrimSpace(cfg.Prompt + "\n\n" + note)
 	return &nudgeCfg
 }
@@ -1917,10 +1921,10 @@ const maxNudgesPerKind = 2
 // turnNudges tracks how many times each corrective nudge has fired this turn,
 // so each kind fires at most maxNudgesPerKind times and never wedges the loop.
 type turnNudges struct {
-	action        int  // silent round: no tool call and no answer
-	hallucination int  // model wrote a <tool_response> block itself
-	sandbox       int  // prose describing a failed sandbox/code-interpreter session
-	workFailure   bool // turn ending while the last work tool is still failing (single end-of-turn check, not a per-round repeat)
+	action        int // silent round: no tool call and no answer
+	hallucination int // model wrote a <tool_response> block itself
+	sandbox       int // prose describing a failed sandbox/code-interpreter session
+	workFailure   int // turn ending while the last work tool is still failing
 }
 
 // sandboxUnverifiedBanner is prepended to a turn's displayed/returned content
@@ -1930,6 +1934,47 @@ type turnNudges struct {
 // answer, the model's words are kept but clearly flagged as unverified.
 const sandboxUnverifiedBanner = "[kdeps: the response below describes a sandbox/tool session that does " +
 	"not exist in this environment -- no real tool call succeeded here. Treat it as unverified.]\n\n"
+
+// toolFailureUnresolvedNotice is surfaced (to both the writer and the turn's
+// returned content) when maxNudgesPerKind work-failure nudges are spent and
+// the model is still claiming success despite f never having succeeded.
+// Unlike sandboxUnverifiedBanner this is a trailing notice, not a prefix
+// rewrite: by the time resolveEmptyToolRound reaches this branch,
+// handleTextOnlyRound has already written the model's claim to the writer
+// unconditionally, so there is nothing to prepend ahead of -- the notice
+// follows it instead, same as reportGoalEvent/queueModelNote's existing
+// follow-up-notice pattern.
+func toolFailureUnresolvedNotice(f *toolFailure) string {
+	return "\n[kdeps: the response above claims success, but the last " + f.tool +
+		" call actually failed (" + f.msg + ") and was never retried successfully.]\n"
+}
+
+// failureAcknowledgmentWords are substrings whose presence in a round's text
+// signals the model is aware the last work tool failed, rather than silently
+// claiming success over it. Deliberately broad (word fragments, not exact
+// phrases) since a model has endless ways to phrase an admission -- this only
+// needs to distinguish "aware of the failure" from "no acknowledgment at
+// all," not classify the admission precisely.
+//
+//nolint:gochecknoglobals // static lookup table
+var failureAcknowledgmentWords = []string{
+	"fail", "error", "cannot", "can't", "unable", "did not", "didn't",
+	"not able", "no access", "blocked", "wasn't able", "was not able",
+}
+
+// acknowledgesFailure reports whether content shows any awareness that the
+// last work tool failed. A round that admits it (however it phrases that) is
+// accepted as the turn's honest answer rather than nudged/flagged as an
+// unresolved success claim -- only a bald, unqualified claim draws that.
+func acknowledgesFailure(content string) bool {
+	lower := strings.ToLower(content)
+	for _, w := range failureAcknowledgmentWords {
+		if strings.Contains(lower, w) {
+			return true
+		}
+	}
+	return false
+}
 
 // handleEmptyToolRound processes a round the streamer returned with no native
 // tool calls. It first tries to recover a tool call the model wrote as text
@@ -1991,10 +2036,28 @@ func (l *Loop) resolveEmptyToolRound(
 	// res.content (not the pre-call content param) carries any banner
 	// handleEmptyToolRound prepended (e.g. sandboxUnverifiedBanner) -- res.stop
 	// is only ever true once that assignment has happened.
-	if l.lastWorkFailure != nil && !nudges.workFailure {
-		nudges.workFailure = true
-		return nil, res.content,
-			nudgeUnresolvedToolFailureConfig(res.chatCfg, l.lastWorkFailure), false
+	//
+	// Only an unqualified claim (no acknowledgment of the failure at all) is
+	// nudged/flagged -- a round that admits the failure in its own words
+	// (however it phrases that) is accepted as the turn's honest answer, the
+	// same as before this was bounded to more than one nudge. Otherwise a
+	// model that answers honestly on its second attempt would draw a second
+	// nudge anyway, punishing the exact behavior being asked for.
+	if l.lastWorkFailure != nil && !acknowledgesFailure(res.content) {
+		if nudges.workFailure < maxNudgesPerKind {
+			repeat := nudges.workFailure > 0
+			nudges.workFailure++
+			return nil, res.content,
+				nudgeUnresolvedToolFailureConfig(res.chatCfg, l.lastWorkFailure, repeat), false
+		}
+		// Both nudges spent and the model is still claiming success -- unlike
+		// handleEmptyToolRound's sandbox banner, handleTextOnlyRound has already
+		// written this claim to w by the time we get here, so there is no
+		// prefix to rewrite. Flag it as a distinct trailing notice instead:
+		// both the writer and the returned content carry it.
+		notice := toolFailureUnresolvedNotice(l.lastWorkFailure)
+		_, _ = io.WriteString(w, notice)
+		return nil, notice + res.content, res.chatCfg, true
 	}
 	return nil, res.content, res.chatCfg, true
 }

--- a/pkg/agent/loop_integration_test.go
+++ b/pkg/agent/loop_integration_test.go
@@ -2352,6 +2352,72 @@ func TestRunStreaming_FailedToolNotAcceptedAsDone(t *testing.T) {
 	assert.Contains(t, result, "edit failed")
 }
 
+// A model that repeats the bald "done" claim a second time (never
+// acknowledging the failure) draws a second, sharper nudge instead of the
+// turn silently accepting the repeat -- bounded to maxNudgesPerKind, same as
+// the sandbox-hallucination nudge.
+func TestRunStreaming_FailedToolNudgedTwiceThenAdmitsFailure(t *testing.T) {
+	eng := executor.NewEngine(nil)
+	reg := tools.NewRegistry()
+	reg.Register(&tools.Tool{
+		Name: "edit_file", Description: "edit", Parameters: map[string]domain.ToolParam{},
+		Execute: func(_ map[string]any) (string, error) {
+			return "", errors.New("old_string not found in /a.go")
+		},
+	})
+	ms := &cfgRecordingStreamer{inner: mockStreamer{responses: []mockStreamResponse{
+		{content: "", toolCalls: []domain.StreamedToolCall{{ID: "1", Name: "edit_file", Arguments: "{}"}}},
+		{content: "Done. The file has been updated.", toolCalls: nil},
+		{content: "All set, the change is in place.", toolCalls: nil},
+		{content: "I was not able to make that edit; old_string never matched.", toolCalls: nil},
+	}}}
+	loop := New(eng, newTestWorkflowForSession(), reg, Config{
+		Model: "test", Streamer: ms, MaxToolRounds: 10,
+	})
+	var buf bytes.Buffer
+	result, err := loop.RunStreaming(context.Background(), "fix it", &buf)
+	require.NoError(t, err)
+
+	require.Len(t, ms.cfgs, 4, "two bald claims must draw two nudges before the honest admission")
+	assert.NotContains(t, ms.cfgs[2].Prompt, "second time this turn", "first nudge is not a repeat")
+	assert.Contains(t, ms.cfgs[3].Prompt, "second time this turn", "second nudge must read as a repeat")
+	assert.Contains(t, result, "was not able to make that edit")
+	assert.NotContains(t, result, "[kdeps: the response above claims success",
+		"an honest admission must not be flagged as an unresolved claim")
+}
+
+// Once both work-failure nudges are spent and the model is *still* claiming
+// success, the turn must not silently settle on it -- the returned content
+// (and the writer) carry toolFailureUnresolvedNotice instead.
+func TestRunStreaming_FailedToolExhaustedGetsNotice(t *testing.T) {
+	eng := executor.NewEngine(nil)
+	reg := tools.NewRegistry()
+	reg.Register(&tools.Tool{
+		Name: "edit_file", Description: "edit", Parameters: map[string]domain.ToolParam{},
+		Execute: func(_ map[string]any) (string, error) {
+			return "", errors.New("old_string not found in /a.go")
+		},
+	})
+	ms := &cfgRecordingStreamer{inner: mockStreamer{responses: []mockStreamResponse{
+		{content: "", toolCalls: []domain.StreamedToolCall{{ID: "1", Name: "edit_file", Arguments: "{}"}}},
+		{content: "Done. The file has been updated.", toolCalls: nil},
+		{content: "All set, the change is in place.", toolCalls: nil},
+		{content: "Confirmed, everything looks good now.", toolCalls: nil},
+	}}}
+	loop := New(eng, newTestWorkflowForSession(), reg, Config{
+		Model: "test", Streamer: ms, MaxToolRounds: 10,
+	})
+	var buf bytes.Buffer
+	result, err := loop.RunStreaming(context.Background(), "fix it", &buf)
+	require.NoError(t, err)
+
+	require.Len(t, ms.cfgs, 4, "third bald claim exhausts retries and ends the turn")
+	assert.Contains(t, result, "[kdeps: the response above claims success")
+	assert.Contains(t, result, "everything looks good now", "the model's own words are kept, only flagged")
+	assert.Contains(t, buf.String(), "[kdeps: the response above claims success",
+		"the notice reaches the writer too")
+}
+
 // A queued model note (goal transition, budget change, forced failure) must be
 // injected into the next request as a [kdeps] system message.
 func TestRunStreaming_ModelNoteReachesModel(t *testing.T) {


### PR DESCRIPTION
Same class of bug as the sandbox-hallucination escalation (#839): a failed work tool's `[TOOL FAILED]` banner and the end-of-turn nudge (`nudgeUnresolvedToolFailureConfig`) already existed, but `turnNudges.workFailure` was a plain `bool`, so the nudge fired at most once per turn. A model that kept claiming success a second time after being nudged had nothing left to catch it -- `resolveEmptyToolRound`'s `!nudges.workFailure` gate was already spent, so the turn silently accepted the still-false claim.

- `turnNudges.workFailure` is now a bounded `int` counter (`maxNudgesPerKind = 2`), reusing the same constant and `repeatOffenseNote` wording as the sandbox fix.
- New `acknowledgesFailure()` gate: the nudge/flag only applies to an unqualified success claim -- a round that admits the failure in its own words (whatever phrasing) is accepted immediately, so an honest 'it failed' is never punished with a second nudge.
- Once both nudges are spent and the model is still claiming success, `toolFailureUnresolvedNotice` is appended (to both the writer and the returned content) rather than the turn silently settling on the claim. Unlike the sandbox banner this is a trailing notice, not a prefix rewrite: `handleTextOnlyRound` has already written the claim to the writer unconditionally by the time `resolveEmptyToolRound` sees the exhausted case.

Goal mode is unaffected -- `settleActiveFromText`'s existing `lastWorkError` forced-fail block already handles this independently and immediately.

Added 2 new tests; existing `TestRunStreaming_FailedToolNotAcceptedAsDone` passes unmodified. 2361 tests pass, lint clean, docs build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)