### PR TITLE
fix: /compact fails on history containing expression-like text; scale compact budget to model context

### DIFF
--- a/docs/v2/agent/repl.md
+++ b/docs/v2/agent/repl.md
@@ -162,6 +162,20 @@ tool set compact-threshold <n>`), which for a long run of short-but-tool-heavy
 turns may never happen - use `/compact` directly. Neither affects a running
 turn's tool output; that is bounded by the in-flight window above.
 
+Both the compact budget (how much recent conversation stays verbatim) and the
+auto-compaction threshold default to 3/4 of the model's known context window,
+not a flat token count - a session on a small local model and one on a
+200K-token cloud model each get a sensible default without you having to set
+`/model tool set compact-budget <n>` yourself. Switching models with `/model`
+recomputes both immediately for the new model; an unrecognized model keeps a
+conservative flat default.
+
+The conversation text being summarized is never re-evaluated as a kdeps
+expression or template, even if it contains double-curly-brace syntax (kdeps
+expressions you were discussing, another template language's tags, or
+anything else that looks like one) - it reaches the summarizer exactly as
+written.
+
 ## Sessions
 
 Conversations and the agent's memory are stored in `~/.kdeps/`, **partitioned by

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -783,14 +783,27 @@ func applyConfigDefaults(cfg Config) Config {
 	if cfg.Role == "" {
 		cfg.Role = RoleUser
 	}
+	// Scale the compact budget/threshold to the model's real context window
+	// when known -- same ratio and same lookup (ContextWindowForModel) the
+	// REPL's /model switch already applies (repl.go handleModelSwitch), just
+	// also covering the initial model a session starts on. Unknown/local
+	// models (ContextWindowForModel returns 0) keep the flat constants
+	// exactly as before -- no change for that case.
+	const compactBudgetCtxNumerator, compactBudgetCtxDenominator = 3, 4
 	if cfg.CompactTokenBudget <= 0 {
 		cfg.CompactTokenBudget = compactKeepRecentTokens
+		if ctxWindow := ContextWindowForModel(cfg.Model); ctxWindow > 0 {
+			cfg.CompactTokenBudget = ctxWindow * compactBudgetCtxNumerator / compactBudgetCtxDenominator
+		}
 	}
 	if cfg.AutoCompactThreshold < 0 {
 		cfg.AutoCompactThreshold = 0
 	}
 	if cfg.AutoCompactThreshold == 0 {
 		cfg.AutoCompactThreshold = defaultAutoCompactThreshold
+		if ctxWindow := ContextWindowForModel(cfg.Model); ctxWindow > 0 {
+			cfg.AutoCompactThreshold = ctxWindow * compactBudgetCtxNumerator / compactBudgetCtxDenominator
+		}
 	}
 	if cfg.MaxToolRounds <= 0 {
 		cfg.MaxToolRounds = defaultMaxToolRounds
@@ -3367,6 +3380,14 @@ func (l *Loop) buildSyntheticWorkflow(
 	actionID string,
 	chatCfg *domain.ChatConfig,
 ) *domain.Workflow {
+	// Every caller builds Prompt by concatenating Go-constructed instructions
+	// with conversation-derived text (compaction, goal planning, branch
+	// summaries, refine, judge roster) -- never a user-authored workflow. That
+	// embedded text can itself contain {{ }}-looking substrings (kdeps
+	// expression syntax the user discussed, Jinja/Django tags, anything
+	// matching the pattern) that must reach the model unchanged rather than
+	// being re-parsed as a template. See domain.ChatConfig.LiteralPrompt.
+	chatCfg.LiteralPrompt = true
 	return &domain.Workflow{
 		APIVersion: l.workflow.APIVersion,
 		Kind:       l.workflow.Kind,

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -661,6 +661,41 @@ func TestLoop_ForceCompact_CompactsUnderBudget(t *testing.T) {
 	}
 }
 
+// ForceCompact's synthetic chat config must always carry LiteralPrompt: true
+// -- otherwise the executor's expression evaluator (pkg/executor/llm) would
+// try to re-parse the raw conversation text embedded in the compaction
+// prompt as a kdeps expression/template, which fails whenever that history
+// contains {{ }}-looking text (kdeps expression syntax the user discussed,
+// Jinja/Django tags, anything matching the pattern) that isn't actually
+// meant for interpolation. See buildSyntheticWorkflow and
+// domain.ChatConfig.LiteralPrompt.
+func TestLoop_ForceCompact_UsesLiteralPrompt(t *testing.T) {
+	const fakeSummary = "## Progress\n- did things"
+	var gotLiteralPrompt bool
+	eng := executor.NewEngine(nil)
+	eng.SetExecuteFunc(func(wf *domain.Workflow, _ interface{}) (interface{}, error) {
+		gotLiteralPrompt = wf.Resources[0].Chat.LiteralPrompt
+		return fakeSummary, nil
+	})
+	loop := agent.New(eng, newTestWorkflow(), tools.NewRegistry(), agent.Config{
+		Model:              "llama3.2",
+		CompactTokenBudget: 1_000_000,
+	})
+	for range 8 {
+		// A message that looks like kdeps expression syntax the user might
+		// have pasted or discussed -- exactly the reported bug's trigger.
+		if _, err := loop.Run(context.Background(), "how do I use {{ get('x') }} in workflow.yaml?"); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+	}
+	if _, err := loop.ForceCompact(context.Background()); err != nil {
+		t.Fatalf("ForceCompact: %v", err)
+	}
+	if !gotLiteralPrompt {
+		t.Fatal("compaction's synthetic ChatConfig must have LiteralPrompt: true")
+	}
+}
+
 // ForceCompact still does nothing for a session too short to fold anything in.
 func TestLoop_ForceCompact_TooShort(t *testing.T) {
 	eng := newTestEngine("summary", nil)

--- a/pkg/agent/repl_test.go
+++ b/pkg/agent/repl_test.go
@@ -2794,6 +2794,39 @@ func TestApplyConfigDefaults_ModelServiceNotCalledWhenBaseURLSet(t *testing.T) {
 	}
 }
 
+// A recognized model's default CompactTokenBudget/AutoCompactThreshold must
+// scale to its real context window (same 3/4 ratio the REPL's /model switch
+// already applies, repl.go handleModelSwitch) instead of the flat
+// compactKeepRecentTokens/defaultAutoCompactThreshold constants -- so a
+// session that never touches /model still gets sensibly-scaled defaults for
+// whichever model it starts on.
+func TestApplyConfigDefaults_CompactBudgetScalesToKnownModel(t *testing.T) {
+	cfg := applyConfigDefaults(Config{Model: "gpt-3.5-turbo-instruct"}) // 4096 ctx window
+	const want = 4096 * 3 / 4
+	if cfg.CompactTokenBudget != want {
+		t.Errorf("CompactTokenBudget = %d, want %d (scaled to context window)", cfg.CompactTokenBudget, want)
+	}
+	if cfg.AutoCompactThreshold != want {
+		t.Errorf("AutoCompactThreshold = %d, want %d (scaled to context window)", cfg.AutoCompactThreshold, want)
+	}
+}
+
+// An unrecognized model (ContextWindowForModel returns 0) keeps the flat
+// defaults unchanged -- no regression for local/unknown models.
+func TestApplyConfigDefaults_CompactBudgetFlatForUnknownModel(t *testing.T) {
+	cfg := applyConfigDefaults(Config{Model: "some-unregistered-local-gguf"})
+	if cfg.CompactTokenBudget != compactKeepRecentTokens {
+		t.Errorf("CompactTokenBudget = %d, want flat default %d", cfg.CompactTokenBudget, compactKeepRecentTokens)
+	}
+	if cfg.AutoCompactThreshold != defaultAutoCompactThreshold {
+		t.Errorf(
+			"AutoCompactThreshold = %d, want flat default %d",
+			cfg.AutoCompactThreshold,
+			defaultAutoCompactThreshold,
+		)
+	}
+}
+
 // --- buildSystemPreamble zero-limit fallback paths ---
 
 func TestBuildSystemPreamble_ZeroBudgetUsesAutoCompactThreshold(t *testing.T) {

--- a/pkg/domain/resource_chat.go
+++ b/pkg/domain/resource_chat.go
@@ -95,6 +95,15 @@ type ChatConfig struct {
 	// /prompt command.
 	ToolsOut *[]Tool `yaml:"-"`
 
+	// LiteralPrompt, when true, is used verbatim -- never evaluated as a
+	// kdeps expression/template. Set for loop-internal synthetic calls
+	// (compaction, goal planning, branch summaries, refine, judge roster)
+	// whose Prompt embeds raw conversation history that may itself contain
+	// {{ }}-looking text the user wrote or pasted; that text must reach the
+	// model unchanged, not be re-parsed as a template. Never set from YAML --
+	// a real chat: resource's prompt: always supports interpolation.
+	LiteralPrompt bool `yaml:"-"`
+
 	ContextLength int    `yaml:"contextLength,omitempty"` // Context length in tokens: 4096, 8192, 16384, 32768, 65536, 131072, 262144 (default: 4096)
 	Role          string `yaml:"role"`
 	Prompt        string `yaml:"prompt"`

--- a/pkg/executor/llm/executor_resolve_exec.go
+++ b/pkg/executor/llm/executor_resolve_exec.go
@@ -111,9 +111,12 @@ func (e *Executor) resolveModelForExecution(
 		modelStr = fallback
 	}
 
-	promptStr, err := e.evaluateStringOrLiteral(evaluator, ctx, resolvedConfig.Prompt)
-	if err != nil {
-		return "", "", nil, fmt.Errorf("failed to evaluate prompt: %w", err)
+	promptStr := resolvedConfig.Prompt
+	if !resolvedConfig.LiteralPrompt {
+		promptStr, err = e.evaluateStringOrLiteral(evaluator, ctx, resolvedConfig.Prompt)
+		if err != nil {
+			return "", "", nil, fmt.Errorf("failed to evaluate prompt: %w", err)
+		}
 	}
 
 	// "auto-router" needs no llm.models config at all -- unlike "router"

--- a/pkg/executor/llm/executor_resolve_test.go
+++ b/pkg/executor/llm/executor_resolve_test.go
@@ -169,6 +169,45 @@ func TestResolveModelForExecution_EmptyModelFallsBack(t *testing.T) {
 	assert.Equal(t, "my-model", model)
 }
 
+// A prompt containing {{ }}-looking text that is not valid kdeps expression
+// syntax must fail evaluation the normal way (regression guard proving the
+// LiteralPrompt flag below is what actually fixes it, not an accidental
+// side effect elsewhere).
+func TestResolveModelForExecution_PromptWithBraceText_EvaluatedFails(t *testing.T) {
+	t.Setenv("KDEPS_LLM_ROUTER", "")
+	t.Setenv("KDEPS_LLM_MODELS", "my-model")
+	t.Setenv("KDEPS_DEFAULT_BACKEND", "")
+	e := NewExecutor("")
+	ctx, err := executor.NewExecutionContext(&domain.Workflow{Metadata: domain.WorkflowMetadata{Name: "t"}})
+	require.NoError(t, err)
+
+	_, _, _, err = e.resolveModelForExecution(
+		expression.NewEvaluator(ctx.API), ctx,
+		&domain.ChatConfig{Model: "", Prompt: "earlier the user asked about {{ not a real expr"})
+	require.Error(t, err)
+}
+
+// The same prompt with LiteralPrompt set (as buildSyntheticWorkflow always
+// does for loop-internal calls -- compaction, goal planning, branch
+// summaries, refine, judge roster) must resolve without error and reach the
+// backend byte-for-byte unchanged, since it's inert conversation history,
+// not a template.
+func TestResolveModelForExecution_LiteralPrompt_SkipsEvaluation(t *testing.T) {
+	t.Setenv("KDEPS_LLM_ROUTER", "")
+	t.Setenv("KDEPS_LLM_MODELS", "my-model")
+	t.Setenv("KDEPS_DEFAULT_BACKEND", "")
+	e := NewExecutor("")
+	ctx, err := executor.NewExecutionContext(&domain.Workflow{Metadata: domain.WorkflowMetadata{Name: "t"}})
+	require.NoError(t, err)
+
+	const raw = "earlier the user asked about {{ not a real expr, and a django {% if x %} tag too"
+	_, prompt, _, err := e.resolveModelForExecution(
+		expression.NewEvaluator(ctx.API), ctx,
+		&domain.ChatConfig{Model: "", Prompt: raw, LiteralPrompt: true})
+	require.NoError(t, err)
+	assert.Equal(t, raw, prompt, "a literal prompt must reach the backend unchanged")
+}
+
 func TestResolveModelForExecution_AutoRouterPicksLocal(t *testing.T) {
 	t.Setenv("KDEPS_LLM_ROUTER", `{"strategy":"fallback","models":[{"model":"should-not-be-used"}]}`)
 	orig := autoRouterPickFunc


### PR DESCRIPTION
Bug: past conversation history containing text that merely looks like kdeps expression syntax (`{{ ... }}`) later broke `/compact`. Root cause traced to `compactWithLLM` (`pkg/agent/loop.go`) building its summarization prompt by concatenating raw serialized conversation history, then running it through the same real executor every user `chat:` resource uses. That executor's prompt resolution (`pkg/executor/llm/executor_resolve_exec.go`) naively checks `strings.Contains(s, "{{")` and, if true, parses the ENTIRE prompt string as a kdeps expression/template. Historical text that merely looks like `{{ ... }}` (kdeps expression syntax the user discussed, another template language's tags, anything matching the pattern) gets fed to the parser as if it were real template syntax and fails -- it's inert conversation text, not a template.

This is not compaction-specific: every internal loop LLM call built through `buildSyntheticWorkflow` (compaction, goal planning, branch summaries, refine, judge roster -- 6 call sites) embeds Go-constructed text the same way and has the identical exposure.

- `domain.ChatConfig` gains `LiteralPrompt bool` (`yaml:"-"`, runtime-only): when true, `Prompt` is used verbatim, never evaluated as an expression.
- `executor_resolve_exec.go`'s `resolveModelForExecution` skips `evaluateStringOrLiteral` for `Prompt` when `LiteralPrompt` is set.
- `buildSyntheticWorkflow` now sets `chatCfg.LiteralPrompt = true` unconditionally -- it is the single choke-point for all 6 internal call sites, so the fix applies to the whole class at once. No real user-authored `chat:` resource is affected; they never go through `buildSyntheticWorkflow`.

Separately, made the initial (pre-`/model`-switch) `CompactTokenBudget`/`AutoCompactThreshold` defaults scale to the model's real context window (3/4 ratio) via `ContextWindowForModel`, matching the smart behavior the REPL's `/model` switch already applies -- it was previously flat regardless of the starting model. Unrecognized models keep the existing flat constants, unchanged.

5 new tests (2 executor-level, 1 pkg/agent end-to-end reproduction of the exact reported bug, 2 for the model-aware budget). All affected packages pass (`pkg/agent`, `pkg/executor/llm`, `pkg/domain`, full `pkg/executor/*` suite), lint clean, docs build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)