### PR TITLE
feat(agent): global memory option, archived checkpoints, and /fold

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -293,13 +293,21 @@ func runAgentLoopCmd(path string, flags *agentLoopFlags) error {
 	llmAdapter := llm.NewAdapter(flags.BaseURL)
 
 	// Sessions and memory are stored under ~/.kdeps, partitioned by the
-	// working directory so each folder keeps its own conversations and memory.
+	// working directory so each folder keeps its own conversations and memory
+	// -- unless KDEPS_MEMORY_GLOBAL requests memory shared across every
+	// project instead. Session storage is always per-directory regardless.
 	store := agent.NewSessionStore("")
 	memStore := agent.NewMemoryStore("")
+	if agent.ResolveGlobalMemoryEnv() {
+		memStore.SetGlobal()
+		_ = memStore.Load()
+	}
 	if cwd, cwdErr := os.Getwd(); cwdErr == nil {
 		store.SetCwd(cwd)
-		memStore.SetCwd(cwd)
-		_ = memStore.Load()
+		if !agent.ResolveGlobalMemoryEnv() {
+			memStore.SetCwd(cwd)
+			_ = memStore.Load()
+		}
 	}
 
 	startModel, startBackend := resolveStartModelWithAutoPick(rootCtx, flags, settings)

--- a/docs/v2/agent/memory-internals.md
+++ b/docs/v2/agent/memory-internals.md
@@ -75,7 +75,9 @@ This preserves important information across compaction boundaries.
 
 ## Checkpoint summaries
 
-After every compaction, a `checkpoint:summary` entry is saved containing the condensed Goal, Progress, Key Decisions, and Critical Context sections. This provides a running project snapshot that persists across sessions.
+After every compaction (or [fold](/agent/repl#fold)), a `checkpoint:summary` entry is saved containing the condensed Goal, Progress, Key Decisions, and Critical Context sections. This provides a running project snapshot that persists across sessions.
+
+The previous checkpoint is never silently discarded: it's archived first, under its own key (`checkpoint:archive:<timestamp>`), the same way every other memory entry persists forever. Only the most recent `FoldContextItems` checkpoints (active + archived, default 5, see `/fold items`) compete for space in the prompt-injected memory block - older ones simply aren't in that window, but stay fully retrievable with `/memory list` or `/memory show checkpoint:archive:<timestamp>`.
 
 ## Session persistence
 

--- a/docs/v2/agent/memory.md
+++ b/docs/v2/agent/memory.md
@@ -8,6 +8,8 @@ Persistent memory is primarily an agent mode concept, but the memory tools also 
 
 Memory is stored in a bbolt (embedded key-value) database at `~/.kdeps/memory/<encoded-cwd>/memory.bolt`. Each entry has a key, value, type, timestamps, and optional references to other entries for graph-based relationship tracking.
 
+Set `KDEPS_MEMORY_GLOBAL=1` to share one memory store across every project instead - it's stored at `~/.kdeps/memory/global/memory.bolt` and every session on the machine reads and writes the same facts, regardless of working directory. Session storage (conversation history) always stays per-directory either way.
+
 The memory store is injected into every LLM call automatically as a single graph-ordered `<memory>` block in the system prompt. Entries appear in causal order and the newest unfinished task is flagged, so a model resuming after an orchestrator model switch knows where to continue. See [Memory internals](/agent/memory-internals#prompt-injection) for the block format.
 
 ## Built-in memory tools

--- a/docs/v2/agent/repl.md
+++ b/docs/v2/agent/repl.md
@@ -176,6 +176,32 @@ expressions you were discussing, another template language's tags, or
 anything else that looks like one) - it reaches the summarizer exactly as
 written.
 
+### Fold
+
+`/fold` is a lighter, more frequent cousin of `/compact` - instead of waiting
+for the full compact-threshold safety net, it checkpoints the conversation
+(same structured Goal/Progress/Decisions summary, saved to
+[memory](/agent/memory-internals#checkpoint-summaries)) every time a
+configurable amount of *new* conversation has accumulated since the last
+checkpoint. It's on by default (2000 tokens, keeping the last 5 checkpoints
+in the prompt's memory block) and needs no setup.
+
+| Command | Effect |
+|---|---|
+| `/fold` | Show status: auto on/off, threshold, items cap, tokens accumulated since the last checkpoint |
+| `/fold now` | Fold immediately, regardless of the threshold |
+| `/fold auto` / `/fold auto off` | Toggle automatic folding (default: on) |
+| `/fold threshold <n>` | Token delta since the last checkpoint that triggers a fold (e.g. `4k`) |
+| `/fold items <n>` | How many recent checkpoints stay in the active memory-prompt window |
+| `/fold preset tight\|balanced\|loose` | Named threshold+items bundles - `balanced` is the shipped default |
+
+All four settings persist across sessions, the same way `/model tool set
+compact-threshold`/`compact-budget` already do.
+
+Both `/compact` and `/fold` refresh the cumulative token counter (`in:`/`out:`
+in the status line) immediately after they run, since the summarization call
+itself uses real tokens that would otherwise never get counted.
+
 ## Sessions
 
 Conversations and the agent's memory are stored in `~/.kdeps/`, **partitioned by

--- a/pkg/agent/compact.go
+++ b/pkg/agent/compact.go
@@ -31,6 +31,17 @@ const (
 	compactMinTurns         = 4     // don't compact unless at least 4 turns exist
 	charsPerToken           = 4     // rough chars-per-token estimate for the fallback path
 	charsPerTokenRoundUp    = 3     // rounding offset for integer ceiling division
+
+	// defaultFoldThreshold is the token delta (since the last checkpoint) that
+	// triggers a "fold" -- a lighter, more frequent checkpoint-only
+	// summarize/archive pass, independent of the full-context-window
+	// auto-compact safety net. Configurable/persisted via
+	// Config.FoldThreshold / ToolTuning.FoldThreshold, see /fold.
+	defaultFoldThreshold = 2000
+	// defaultFoldContextItems caps how many recent checkpoints (active +
+	// archived) compete for space in the memory prompt block. Configurable/
+	// persisted via Config.FoldContextItems / ToolTuning.FoldContextItems.
+	defaultFoldContextItems = 5
 )
 
 // compactionSummaryPrefix / compactionSummarySuffix wrap the LLM-generated
@@ -258,6 +269,37 @@ func shouldAutoCompact(messages []SessionMessage, threshold int, modelHint strin
 		return estimated > ctxWindow-compactReserveTokens
 	}
 	return estimated > threshold
+}
+
+// shouldFold reports whether enough new conversation has accumulated since
+// the last checkpoint to justify folding it in again -- a tighter, more
+// frequent cadence than shouldAutoCompact's full-context-window safety net.
+// sinceNanos is the active checkpoint's UpdatedAt (converted from
+// milliseconds), or 0 when no checkpoint exists yet -- compactMinTurns still
+// gates the very first fold the same way it gates the first compaction.
+func shouldFold(messages []SessionMessage, sinceNanos int64, thresholdTokens int, modelHint string) bool {
+	if thresholdTokens <= 0 {
+		return false
+	}
+	if len(messages) < sessionMsgsPer*compactMinTurns {
+		return false
+	}
+	return tokensSinceCheckpoint(messages, sinceNanos, modelHint) >= thresholdTokens
+}
+
+// tokensSinceCheckpoint estimates the token count of messages newer than
+// sinceNanos (a checkpoint's UpdatedAt converted to nanoseconds, or 0 for "no
+// checkpoint yet" -- every message qualifies). Shared by shouldFold and the
+// /fold status display so they always agree on the same number.
+func tokensSinceCheckpoint(messages []SessionMessage, sinceNanos int64, modelHint string) int {
+	var delta int
+	for _, m := range messages {
+		if m.ID <= sinceNanos {
+			continue
+		}
+		delta += estimateTokens(m, modelHint)
+	}
+	return delta
 }
 
 // serializeConversation formats session messages as plain text for the

--- a/pkg/agent/compact_test.go
+++ b/pkg/agent/compact_test.go
@@ -396,6 +396,76 @@ func TestShouldAutoCompact_KnownModelIgnoresFlatThreshold(t *testing.T) {
 	}
 }
 
+// --- shouldFold ---
+
+// makeTurnsSince builds n turns with strictly increasing IDs (nanoseconds),
+// the first msgsBefore of them dated at/before sinceNanos and the rest after
+// it -- so tests can control exactly how many messages count toward the
+// delta shouldFold/tokensSinceCheckpoint sum.
+func makeTurnsSince(n, msgsBefore int, sinceNanos int64) []SessionMessage {
+	msgs := makeTurns(n)
+	for i := range msgs {
+		if i < msgsBefore {
+			msgs[i].ID = sinceNanos - int64(msgsBefore-i) // strictly before
+		} else {
+			msgs[i].ID = sinceNanos + int64(i-msgsBefore+1) // strictly after
+		}
+	}
+	return msgs
+}
+
+func TestShouldFold_Disabled(t *testing.T) {
+	msgs := makeTurnsSince(compactMinTurns, 0, 1000)
+	if shouldFold(msgs, 0, 0, "gpt-4o") {
+		t.Fatal("expected false when thresholdTokens=0 (disabled)")
+	}
+}
+
+func TestShouldFold_TooFewTurns(t *testing.T) {
+	msgs := makeTurnsSince(compactMinTurns-1, 0, 0)
+	if shouldFold(msgs, 0, 1, "gpt-4o") {
+		t.Fatal("expected false for too-few turns")
+	}
+}
+
+func TestShouldFold_AllMessagesBeforeCheckpoint(t *testing.T) {
+	// Every message dated at/before sinceNanos contributes nothing to the delta.
+	msgs := makeTurnsSince(compactMinTurns, compactMinTurns*sessionMsgsPer, 1_000_000)
+	if shouldFold(msgs, 1_000_000, 1, "gpt-4o") {
+		t.Fatal("expected false: nothing accumulated since the checkpoint")
+	}
+}
+
+func TestShouldFold_BelowThreshold(t *testing.T) {
+	msgs := makeTurnsSince(compactMinTurns, 0, 0)
+	delta := tokensSinceCheckpoint(msgs, 0, "gpt-4o")
+	if shouldFold(msgs, 0, delta+1, "gpt-4o") {
+		t.Fatal("expected false when just under the threshold")
+	}
+}
+
+func TestShouldFold_AtOrAboveThreshold(t *testing.T) {
+	msgs := makeTurnsSince(compactMinTurns, 0, 0)
+	delta := tokensSinceCheckpoint(msgs, 0, "gpt-4o")
+	if !shouldFold(msgs, 0, delta, "gpt-4o") {
+		t.Fatal("expected true exactly at the threshold")
+	}
+	if !shouldFold(msgs, 0, delta-1, "gpt-4o") {
+		t.Fatal("expected true above the threshold")
+	}
+}
+
+func TestShouldFold_ZeroSinceNanosMeansNoCheckpointYet(t *testing.T) {
+	// sinceNanos=0 (no checkpoint saved yet) counts every message, same as
+	// the first-ever compaction being gated only by compactMinTurns.
+	msgs := makeTurnsSince(compactMinTurns, 0, 0)
+	all := tokensSinceCheckpoint(msgs, 0, "gpt-4o")
+	total := estimateSessionTokens(msgs, "gpt-4o")
+	if all != total {
+		t.Fatalf("tokensSinceCheckpoint(sinceNanos=0) = %d, want the full session total %d", all, total)
+	}
+}
+
 // --- Session.rawMessages ---
 
 func TestRawMessages_ReturnsCopy(t *testing.T) {

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -96,6 +96,21 @@ type Config struct {
 	// is automatically compacted before the next LLM call. 0 disables auto-compaction.
 	// Default: 40000.
 	AutoCompactThreshold int
+	// FoldThreshold is the token delta (since the last checkpoint) that
+	// triggers a "fold" -- a lighter, checkpoint-only summarize/archive pass,
+	// independent of AutoCompactThreshold's full-context-window safety net.
+	// 0 uses the default (2000). See /fold in the REPL.
+	FoldThreshold int
+	// FoldContextItems caps how many recent checkpoints (the active
+	// checkpoint:summary plus archived checkpoint:archive:* entries) compete
+	// for space in the memory prompt block. 0 uses the default (5).
+	FoldContextItems int
+	// FoldOff disables automatic folding once FoldThreshold is crossed.
+	// Default: false (auto-fold on) -- inverted like GoalEnforcementOff so
+	// the zero value is the enabled default, not a silently-forced override.
+	// See ToolTuning.FoldAuto/FoldConfigured for the persisted, user-facing
+	// (non-inverted) /fold auto|off setting.
+	FoldOff bool
 	// PromptPaths are additional directories to search for prompt template .md files.
 	PromptPaths []string
 	// Store is an optional session store for /session save|load|list|delete commands.
@@ -805,6 +820,12 @@ func applyConfigDefaults(cfg Config) Config {
 			cfg.AutoCompactThreshold = ctxWindow * compactBudgetCtxNumerator / compactBudgetCtxDenominator
 		}
 	}
+	if cfg.FoldThreshold <= 0 {
+		cfg.FoldThreshold = defaultFoldThreshold
+	}
+	if cfg.FoldContextItems <= 0 {
+		cfg.FoldContextItems = defaultFoldContextItems
+	}
 	if cfg.MaxToolRounds <= 0 {
 		cfg.MaxToolRounds = defaultMaxToolRounds
 	}
@@ -887,12 +908,15 @@ func (l *Loop) Run(ctx context.Context, input string) (string, error) {
 	l.ensureLocalModelReady(ctx)
 	l.ensureM365Ready(ctx)
 
-	// Auto-compact before the LLM call when history exceeds the token threshold.
+	// Auto-compact before the LLM call when history exceeds the token
+	// threshold, or when enough new conversation has accumulated since the
+	// last checkpoint to justify a lighter "fold" (see shouldFold) -- either
+	// condition runs the same compaction call, just at a different cadence.
 	if msgs := l.session.RawMessages(); shouldAutoCompact(
 		msgs,
 		l.config.AutoCompactThreshold,
 		l.config.Model,
-	) {
+	) || l.shouldFoldNow(msgs) {
 		if summary, err := l.CompactWithLLM(ctx); err == nil && summary != "" {
 			if l.onAutoCompact != nil {
 				l.onAutoCompact(summary)
@@ -975,12 +999,15 @@ func (l *Loop) RunStreaming(ctx context.Context, input string, w io.Writer) (str
 	l.ensureLocalModelReady(ctx)
 	l.ensureM365Ready(ctx)
 
-	// Auto-compact before the LLM call when history exceeds the token threshold.
+	// Auto-compact before the LLM call when history exceeds the token
+	// threshold, or when enough new conversation has accumulated since the
+	// last checkpoint to justify a lighter "fold" (see shouldFold) -- either
+	// condition runs the same compaction call, just at a different cadence.
 	if msgs := l.session.RawMessages(); shouldAutoCompact(
 		msgs,
 		l.config.AutoCompactThreshold,
 		l.config.Model,
-	) {
+	) || l.shouldFoldNow(msgs) {
 		if summary, err := l.CompactWithLLM(ctx); err == nil && summary != "" {
 			if l.onAutoCompact != nil {
 				l.onAutoCompact(summary)
@@ -3025,7 +3052,8 @@ func (l *Loop) buildSystemPreamble(focus string) string {
 	var memoryParts []string
 	if l.memoryStore != nil {
 		memoryParts = append(memoryParts, l.memoryRulesPreamble()...)
-		if memPrompt := l.memoryStore.FormatForPrompt(memoryPromptLimit, focus); memPrompt != "" {
+		memPrompt := l.memoryStore.FormatForPromptCapped(memoryPromptLimit, focus, l.config.FoldContextItems)
+		if memPrompt != "" {
 			memoryParts = append(memoryParts, memPrompt)
 		}
 		// Mechanical memory_list: inject the current key list so the LLM
@@ -3521,6 +3549,22 @@ func (l *Loop) Session() SessionReadWriter {
 
 // Config returns a copy of the loop's configuration.
 func (l *Loop) Config() Config { return l.config }
+
+// shouldFoldNow reports whether a "fold" should run now: FoldOff disables it
+// outright; otherwise it delegates to shouldFold using the active
+// checkpoint's UpdatedAt (0 when none exists yet) as the "since" point.
+func (l *Loop) shouldFoldNow(msgs []SessionMessage) bool {
+	if l.config.FoldOff {
+		return false
+	}
+	var sinceNanos int64
+	if l.memoryStore != nil {
+		if cp, ok := l.memoryStore.Get(checkpointSummaryKey); ok {
+			sinceNanos = cp.UpdatedAt * int64(time.Millisecond)
+		}
+	}
+	return shouldFold(msgs, sinceNanos, l.config.FoldThreshold, l.config.Model)
+}
 
 // CompactWithLLM summarizes old conversation turns using the LLM and replaces
 // them with a structured summary, keeping recent turns intact. It returns the

--- a/pkg/agent/memory_store.go
+++ b/pkg/agent/memory_store.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -61,15 +62,27 @@ const (
 //nolint:gochecknoglobals // process-wide singleton; one per agent process
 var memoryStoreInstance *MemoryStore
 
+// ResolveGlobalMemoryEnv reports whether KDEPS_MEMORY_GLOBAL requests memory
+// shared across every project/session instead of the default per-directory
+// isolation (see MemoryStore.SetGlobal / SetCwd).
+func ResolveGlobalMemoryEnv() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv("KDEPS_MEMORY_GLOBAL")))
+	return v == "1" || v == "true" || v == "yes"
+}
+
 // GetOrCreateMemoryStore returns the singleton MemoryStore, creating it lazily
-// with per-project isolation on first access. Used by memory tools so they
-// work in both agent mode (where Loop sets it) and workflow mode (lazy init).
+// with per-project isolation on first access (or shared/global isolation when
+// KDEPS_MEMORY_GLOBAL is set). Used by memory tools so they work in both
+// agent mode (where Loop sets it) and workflow mode (lazy init).
 func GetOrCreateMemoryStore() *MemoryStore {
 	if memoryStoreInstance != nil {
 		return memoryStoreInstance
 	}
 	ms := NewMemoryStore("")
-	if wd, err := os.Getwd(); err == nil && wd != "" {
+	if ResolveGlobalMemoryEnv() {
+		ms.SetGlobal()
+		_ = ms.Load()
+	} else if wd, err := os.Getwd(); err == nil && wd != "" {
 		ms.SetCwd(wd)
 		_ = ms.Load()
 	}
@@ -146,6 +159,16 @@ func (m *MemoryStore) SetCwd(cwd string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.path = filepath.Join(m.basePath, encodeCwd(cwd))
+	m.dbPath = filepath.Join(m.path, "memory.bolt")
+}
+
+// SetGlobal configures memory to be shared across every project/session
+// instead of isolated per working directory (see SetCwd) -- stored under
+// basePath/global/memory.bolt. Call instead of SetCwd, never both.
+func (m *MemoryStore) SetGlobal() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.path = filepath.Join(m.basePath, "global")
 	m.dbPath = filepath.Join(m.path, "memory.bolt")
 }
 
@@ -631,6 +654,27 @@ func (m *MemoryStore) FormatGraphNode(key string) string {
 const memoryGraphLegend = `Legend: workflow chain, parents before children. ` +
 	`"key [type]: value"; "<- P" = derived from P; "(same as K)" = repeats K's fact; "<== RESUME" = continue here.`
 
+// capCheckpointEntries keeps at most maxCheckpoints checkpoint-family entries
+// (checkpointSummaryKey and anything under checkpointArchiveKeyPrefix) --
+// newest updated first -- and every non-checkpoint entry unchanged. Entries
+// dropped here are only excluded from this one render; they remain in the
+// store untouched.
+func capCheckpointEntries(entries []MemoryEntry, maxCheckpoints int) []MemoryEntry {
+	var checkpoints, other []MemoryEntry
+	for _, e := range entries {
+		if e.Key == checkpointSummaryKey || strings.HasPrefix(e.Key, checkpointArchiveKeyPrefix) {
+			checkpoints = append(checkpoints, e)
+		} else {
+			other = append(other, e)
+		}
+	}
+	if len(checkpoints) <= maxCheckpoints {
+		return entries
+	}
+	sort.Slice(checkpoints, func(i, j int) bool { return checkpoints[i].UpdatedAt > checkpoints[j].UpdatedAt })
+	return append(other, checkpoints[:maxCheckpoints]...)
+}
+
 // FormatForPrompt renders memory as a single graph-ordered block for the system
 // prompt. Entries are ordered topologically via the kartographer dependency
 // graph (a parent always precedes the children that reference it), each value is
@@ -640,7 +684,30 @@ const memoryGraphLegend = `Legend: workflow chain, parents before children. ` +
 // edges to dropped entries are omitted so no arrow dangles. Returns "" when there
 // are no entries or cwd is unset.
 func (m *MemoryStore) FormatForPrompt(maxTokens int, focus string) string {
+	return m.FormatForPromptCapped(maxTokens, focus, 0)
+}
+
+// listCapped returns m.List(), optionally passed through capCheckpointEntries
+// -- split out of FormatForPromptCapped purely to keep that function's own
+// cognitive complexity under the lint threshold.
+func (m *MemoryStore) listCapped(maxCheckpoints int) []MemoryEntry {
 	entries := m.List()
+	if maxCheckpoints > 0 {
+		return capCheckpointEntries(entries, maxCheckpoints)
+	}
+	return entries
+}
+
+// FormatForPromptCapped is FormatForPrompt with an additional cap: at most
+// maxCheckpoints checkpoint-family entries (the active checkpoint:summary
+// plus archived checkpoint:archive:* entries, see AutoCapture) are considered
+// for injection, newest first -- keeping the graph focused on a bounded,
+// configurable window of recent checkpoints (Config.FoldContextItems /
+// ToolTuning.FoldContextItems) even though older ones remain in the store,
+// retrievable via /memory list / /memory show. maxCheckpoints <= 0 means no
+// cap (identical to FormatForPrompt).
+func (m *MemoryStore) FormatForPromptCapped(maxTokens int, focus string, maxCheckpoints int) string {
+	entries := m.listCapped(maxCheckpoints)
 	if len(entries) == 0 {
 		return ""
 	}
@@ -1937,8 +2004,14 @@ func inferType(key string) string {
 // AutoCapture parses a compaction summary and saves structured sections to the
 // MemoryStore. Extracts "## Key Decisions" and "## Critical Context" sections.
 // Returns the number of entries captured. No-op when cwd has not been set.
-// checkpointSummaryKey is the memory key for compaction checkpoint snapshots.
-const checkpointSummaryKey = "checkpoint:summary"
+// checkpointSummaryKey is the memory key for the active compaction checkpoint
+// snapshot. checkpointArchiveKeyPrefix, suffixed with the archived entry's
+// former UpdatedAt (millisecond, unique across real folds/compactions),
+// names where the outgoing checkpoint goes when a new one replaces it.
+const (
+	checkpointSummaryKey       = "checkpoint:summary"
+	checkpointArchiveKeyPrefix = "checkpoint:archive:"
+)
 
 // extractSectionText returns the text content of a markdown section by header name.
 func extractSectionText(summary, header string) string {
@@ -1979,18 +2052,25 @@ func (m *MemoryStore) AutoCapture(summary string) int {
 	m.mu.Lock()
 
 	// 1. Save a checkpoint summary snapshot — a condensed view of Goal + Progress.
+	// The previous checkpoint (if any) is archived under its own key first --
+	// unlike every other memory entry, this key used to be silently
+	// overwritten on every fold/compaction, losing the prior snapshot with no
+	// way to look back at it. Archiving means it stays retrievable via
+	// /memory list and /memory show <key> like any other entry.
 	if checkpointText := buildCheckpointText(summary); checkpointText != "" {
+		if existing, ok := m.entries[checkpointSummaryKey]; ok {
+			archiveKey := checkpointArchiveKeyPrefix + strconv.FormatInt(existing.UpdatedAt, 10)
+			archived := existing
+			archived.Key = archiveKey
+			m.entries[archiveKey] = archived
+		}
 		entry := MemoryEntry{
 			Key: checkpointSummaryKey, Value: checkpointText,
 			Type: memTypeStatus, CreatedAt: now, UpdatedAt: now,
 		}
-		if existing, ok := m.entries[checkpointSummaryKey]; ok {
-			entry.CreatedAt = existing.CreatedAt
-			// Auto-link to the parent type.
-			if parentKey := m.findParentKey(memTypeStatus); parentKey != "" {
-				entry.References = append([]string{}, existing.References...)
-				entry.References = append(entry.References, parentKey)
-			}
+		// Auto-link to the parent type.
+		if parentKey := m.findParentKey(memTypeStatus); parentKey != "" {
+			entry.References = append(entry.References, parentKey)
 		}
 		m.entries[checkpointSummaryKey] = entry
 		captured++

--- a/pkg/agent/memory_store_test.go
+++ b/pkg/agent/memory_store_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -63,6 +64,44 @@ func TestMemoryStore_SetCwd(t *testing.T) {
 	store.SetCwd("/Users/test/Projects/foo")
 	assert.Contains(t, store.path, encodeCwd("/Users/test/Projects/foo"))
 	assert.Contains(t, store.dbPath, "memory.bolt")
+}
+
+func TestMemoryStore_SetGlobal(t *testing.T) {
+	dir := t.TempDir()
+	store := NewMemoryStore(dir)
+	store.SetGlobal()
+	assert.Contains(t, store.path, "global")
+	assert.Contains(t, store.dbPath, "memory.bolt")
+}
+
+// Two stores rooted at the same basePath and both set to global must resolve
+// to the identical dbPath -- unlike SetCwd, which isolates by directory.
+func TestMemoryStore_SetGlobal_SharedAcrossDirectories(t *testing.T) {
+	dir := t.TempDir()
+	a := NewMemoryStore(dir)
+	a.SetGlobal()
+	b := NewMemoryStore(dir)
+	b.SetGlobal()
+	assert.Equal(t, a.dbPath, b.dbPath, "global stores from any cwd must share one path")
+
+	// Regression guard: SetCwd from two different directories must still
+	// resolve to two different paths (the default, per-directory behavior).
+	c := NewMemoryStore(dir)
+	c.SetCwd("/Users/test/Projects/foo")
+	d := NewMemoryStore(dir)
+	d.SetCwd("/Users/test/Projects/bar")
+	assert.NotEqual(t, c.dbPath, d.dbPath, "SetCwd must still isolate by directory")
+}
+
+func TestResolveGlobalMemoryEnv(t *testing.T) {
+	for _, v := range []string{"1", "true", "yes", "TRUE", " 1 "} {
+		t.Setenv("KDEPS_MEMORY_GLOBAL", v)
+		assert.True(t, ResolveGlobalMemoryEnv(), "value %q should enable global memory", v)
+	}
+	for _, v := range []string{"", "0", "false", "no"} {
+		t.Setenv("KDEPS_MEMORY_GLOBAL", v)
+		assert.False(t, ResolveGlobalMemoryEnv(), "value %q should not enable global memory", v)
+	}
 }
 
 func TestMemoryStore_SetGet(t *testing.T) {
@@ -241,6 +280,76 @@ func TestMemoryStore_NoCwd_NoOps(t *testing.T) {
 	assert.Nil(t, store.Search("anything"))
 	assert.Equal(t, 0, store.Len())
 	assert.Equal(t, "", store.FormatForPrompt(100, ""))
+}
+
+// --- capCheckpointEntries ---
+
+func TestCapCheckpointEntries_KeepsNewestWithinCap(t *testing.T) {
+	entries := []MemoryEntry{
+		{Key: checkpointSummaryKey, Value: "active", UpdatedAt: 500},
+		{Key: checkpointArchiveKeyPrefix + "400", Value: "c1", UpdatedAt: 400},
+		{Key: checkpointArchiveKeyPrefix + "300", Value: "c2", UpdatedAt: 300},
+		{Key: checkpointArchiveKeyPrefix + "200", Value: "c3", UpdatedAt: 200},
+		{Key: "fact:unrelated", Value: "kept regardless", UpdatedAt: 100},
+	}
+	got := capCheckpointEntries(entries, 2)
+
+	var keys []string
+	for _, e := range got {
+		keys = append(keys, e.Key)
+	}
+	assert.Contains(t, keys, checkpointSummaryKey)
+	assert.Contains(t, keys, checkpointArchiveKeyPrefix+"400")
+	assert.Contains(t, keys, "fact:unrelated", "non-checkpoint entries are never capped")
+	assert.NotContains(t, keys, checkpointArchiveKeyPrefix+"300")
+	assert.NotContains(t, keys, checkpointArchiveKeyPrefix+"200")
+	assert.Len(t, got, 3) // 2 checkpoints (cap) + 1 unrelated fact
+}
+
+func TestCapCheckpointEntries_UnderCapReturnsAllUnchanged(t *testing.T) {
+	entries := []MemoryEntry{
+		{Key: checkpointSummaryKey, Value: "active", UpdatedAt: 200},
+		{Key: "fact:x", Value: "y", UpdatedAt: 100},
+	}
+	got := capCheckpointEntries(entries, 5)
+	assert.Equal(t, entries, got)
+}
+
+func TestFormatForPromptCapped_ExcludesOldCheckpointsButKeepsOthers(t *testing.T) {
+	dir := t.TempDir()
+	store := NewMemoryStore(dir)
+	store.SetCwd("/Users/test/Projects/foo")
+
+	require.NoError(t, store.Set("fact:always", "kept regardless of cap"))
+	store.entries[checkpointSummaryKey] = MemoryEntry{
+		Key:       checkpointSummaryKey,
+		Value:     "newest checkpoint",
+		UpdatedAt: 300,
+		Type:      memTypeStatus,
+	}
+	store.entries[checkpointArchiveKeyPrefix+"200"] = MemoryEntry{
+		Key:       checkpointArchiveKeyPrefix + "200",
+		Value:     "older checkpoint",
+		UpdatedAt: 200,
+		Type:      memTypeStatus,
+	}
+	store.entries[checkpointArchiveKeyPrefix+"100"] = MemoryEntry{
+		Key:       checkpointArchiveKeyPrefix + "100",
+		Value:     "oldest checkpoint dropped from prompt",
+		UpdatedAt: 100,
+		Type:      memTypeStatus,
+	}
+
+	capped := store.FormatForPromptCapped(10000, "", 2)
+	assert.Contains(t, capped, "newest checkpoint")
+	assert.Contains(t, capped, "older checkpoint")
+	assert.NotContains(t, capped, "oldest checkpoint dropped from prompt")
+	assert.Contains(t, capped, "kept regardless of cap")
+
+	// FormatForPrompt (no cap) must still see everything -- /memory list /
+	// /memory show already read the entries directly, unaffected by this.
+	uncapped := store.FormatForPrompt(10000, "")
+	assert.Contains(t, uncapped, "oldest checkpoint dropped from prompt")
 }
 
 func TestMemoryStore_FormatForPrompt(t *testing.T) {
@@ -1386,6 +1495,35 @@ func TestAutoCapture_CriticalContext(t *testing.T) {
 	assert.Equal(t, "https://api.example.com/v2", e.Value)
 }
 
+// A second AutoCapture must archive the first checkpoint under its own key
+// instead of silently overwriting it -- every other memory entry persists
+// under its own key forever; the checkpoint used to be the one exception.
+func TestAutoCapture_ArchivesPreviousCheckpoint(t *testing.T) {
+	dir := t.TempDir()
+	store := NewMemoryStore(dir)
+	store.SetCwd("/Users/test/Projects/foo")
+
+	store.AutoCapture("## Goal\nFirst goal.\n\n## Progress\n### Done\n- [x] step one\n")
+	first, ok := store.Get(checkpointSummaryKey)
+	require.True(t, ok)
+	assert.Contains(t, first.Value, "First goal")
+
+	time.Sleep(2 * time.Millisecond) // guarantee a distinct archive key
+
+	store.AutoCapture("## Goal\nSecond goal.\n\n## Progress\n### Done\n- [x] step two\n")
+	second, ok := store.Get(checkpointSummaryKey)
+	require.True(t, ok)
+	assert.Contains(t, second.Value, "Second goal")
+	assert.NotContains(t, second.Value, "First goal", "the active key must hold only the latest checkpoint")
+
+	// The first checkpoint must still be retrievable under its archive key --
+	// exactly what /memory list / /memory show already surface for any entry.
+	archiveKey := checkpointArchiveKeyPrefix + strconv.FormatInt(first.UpdatedAt, 10)
+	archived, ok := store.Get(archiveKey)
+	require.True(t, ok, "the previous checkpoint must be archived, not lost")
+	assert.Contains(t, archived.Value, "First goal")
+}
+
 func TestAutoCapture_Empty(t *testing.T) {
 	dir := t.TempDir()
 	store := NewMemoryStore(dir)
@@ -1509,7 +1647,10 @@ Build an omnipresent memory system for kdeps.
 	assert.Equal(t, 6, captured) // checkpoint + 3 decisions + 2 context
 
 	// Verify entries exist.
-	for _, key := range []string{"checkpoint:summary", "memory_backend", "graph_library", "auto_capture_source", "project_structure", "test_count"} {
+	for _, key := range []string{
+		"checkpoint:summary", "memory_backend", "graph_library",
+		"auto_capture_source", "project_structure", "test_count",
+	} {
 		_, ok := store.Get(key)
 		assert.True(t, ok, "expected key %q to exist", key)
 	}

--- a/pkg/agent/repl.go
+++ b/pkg/agent/repl.go
@@ -110,7 +110,7 @@ const (
 //nolint:gochecknoglobals // command list must be package-level for completer
 var builtinCmds = []string{
 	"/help", "/settings", "/clear", "/model", "/context",
-	"/skills", "/prompts", "/prompt", "/compact", "/history", "/thinking", "/session",
+	"/skills", "/prompts", "/prompt", "/compact", "/fold", "/history", "/thinking", "/session",
 	"/editor", "/copy", "/reload", "/permission", "/autocontext", "/tools", "/upgrade",
 	"/login", "/stealth", "/refine", "/instruct", "/instruct!", "/exit", "/quit",
 }
@@ -304,6 +304,9 @@ func NewREPL(rootCtx context.Context, loop *Loop) *REPL {
 		autoContextDetect: true,
 	}
 	loop.SetOnAutoCompact(func(summary string) {
+		// The auto-compact/fold call itself consumed real tokens; without
+		// this the cumulative in:/out: counter would silently never count it.
+		r.syncTokenCounter()
 		fmt.Fprintf(os.Stdout, "\n%s\n%s\n\n",
 			styleReplSuccess.Render(fmt.Sprintf(
 				"⚡ auto-compacted · %d turns", loop.Session().TurnCount(),
@@ -2447,6 +2450,8 @@ func (r *REPL) dispatchCommand(cmd string) error {
 		return r.cmdPrompts()
 	case "/compact":
 		return r.cmdCompact()
+	case "/fold":
+		return r.cmdFold(args)
 	case "/history":
 		return r.cmdHistory()
 	case "/prompt":
@@ -2556,6 +2561,7 @@ func (r *REPL) cmdHelp() error {
 		"  /prompts                           List loaded prompt templates",
 		"  /<skill-name> [..]                Invoke a loaded skill or prompt template by name",
 		"  /compact                           Compact conversation history (keep recent turns)",
+		"  /fold [now|auto [off]|threshold <n>|items <n>|preset <name>]  Lighter, more frequent checkpoint-only summarize+archive (default: auto on, 2000 tokens, 5 items)",
 		"  /history                           Show recent conversation turns",
 		"  /prompt                            Show the exact messages+tools sent to the LLM on the last call, with token estimates",
 		"  /prompt raw                        Same, as raw JSON (exact request wire format, full tool schemas)",
@@ -2932,7 +2938,7 @@ func parseOnOff(v string) (bool, bool) {
 	switch strings.ToLower(strings.TrimSpace(v)) {
 	case "on", "true", "yes", "1", "enable", "enabled":
 		return true, true
-	case "off", "false", "no", "0", "disable", "disabled":
+	case toggleOff, "false", "no", "0", "disable", "disabled":
 		return false, true
 	default:
 		return false, false
@@ -3807,6 +3813,10 @@ func (r *REPL) cmdCompact() error {
 			r.loop.Session().TurnCount(), forceKeepTurns)))
 		return nil
 	}
+	// The compaction call itself consumed real tokens (it's a real LLM call);
+	// without this the cumulative in:/out: counter in the status line would
+	// silently never count it.
+	r.syncTokenCounter()
 	fmt.Fprintf(os.Stdout, "%s\n\n%s\n",
 		styleReplHeading.Render("Compaction summary:"),
 		summary,
@@ -3814,6 +3824,185 @@ func (r *REPL) cmdCompact() error {
 	fmt.Fprintln(os.Stdout, styleReplMeta.Render(
 		fmt.Sprintf("History compacted. Session now has %d turns.", r.loop.Session().TurnCount()),
 	))
+	return nil
+}
+
+// foldPreset is one named /fold preset threshold size (tokens) and items cap
+// (checkpoints) bundle -- a shortcut over setting both individually.
+type foldPreset struct {
+	threshold int
+	items     int
+}
+
+// Preset threshold sizes outside the default -- see foldPresets below.
+const (
+	foldPresetTightThreshold = 1000
+	foldPresetTightItems     = 3
+	foldPresetLooseThreshold = 8000
+	foldPresetLooseItems     = 10
+)
+
+//nolint:gochecknoglobals // static lookup table
+var foldPresets = map[string]foldPreset{
+	"tight":    {threshold: foldPresetTightThreshold, items: foldPresetTightItems},
+	"balanced": {threshold: defaultFoldThreshold, items: defaultFoldContextItems},
+	"loose":    {threshold: foldPresetLooseThreshold, items: foldPresetLooseItems},
+}
+
+// foldPresetNames lists valid /fold preset names in a fixed display order
+// (map iteration order is random, so the error message needs its own list).
+//
+//nolint:gochecknoglobals // static, paired with foldPresets above
+var foldPresetNames = []string{"tight", "balanced", "loose"}
+
+// cmdFold handles /fold and its subcommands: a lighter, more frequent
+// checkpoint-only summarize/archive pass than /compact, configurable and
+// persisted the same way /model tool set's compact-threshold/-budget are.
+func (r *REPL) cmdFold(args []string) error {
+	sub := ""
+	if len(args) > 0 {
+		sub = strings.ToLower(args[0])
+	}
+	switch sub {
+	case "":
+		return r.cmdFoldStatus()
+	case "now":
+		return r.cmdFoldNow()
+	case "auto":
+		return r.cmdFoldAuto(args)
+	case "threshold":
+		return r.cmdFoldThreshold(args)
+	case "items":
+		return r.cmdFoldItems(args)
+	case "preset":
+		return r.cmdFoldPreset(args)
+	default:
+		fmt.Fprintf(os.Stdout, "Unknown /fold subcommand: %s. Use now, auto, threshold, items, or preset.\n", sub)
+		return nil
+	}
+}
+
+func (r *REPL) cmdFoldAuto(args []string) error {
+	off := len(args) > 1 && strings.EqualFold(args[1], toggleOff)
+	r.loop.config.FoldOff = off
+	r.persistTuning()
+	state := "on"
+	if off {
+		state = toggleOff
+	}
+	fmt.Fprintf(os.Stdout, "%s\n", styleReplSuccess.Render("Auto-fold "+state+" (saved)"))
+	return nil
+}
+
+func (r *REPL) cmdFoldThreshold(args []string) error {
+	if len(args) < sessionSubcmdArgMin {
+		fmt.Fprintln(os.Stderr, styleReplError.Render("Usage: /fold threshold <n>"))
+		return nil
+	}
+	n := parseTokenCount(args[1])
+	if n <= 0 {
+		fmt.Fprintln(os.Stderr, styleReplError.Render(
+			"threshold must be a positive token count (e.g. 2000, 2k)"))
+		return nil
+	}
+	r.loop.config.FoldThreshold = n
+	r.persistTuning()
+	fmt.Fprintf(os.Stdout, "%s\n", styleReplSuccess.Render(
+		fmt.Sprintf("Fold threshold set to %d tokens (saved)", n)))
+	return nil
+}
+
+func (r *REPL) cmdFoldItems(args []string) error {
+	if len(args) < sessionSubcmdArgMin {
+		fmt.Fprintln(os.Stderr, styleReplError.Render("Usage: /fold items <n>"))
+		return nil
+	}
+	n, err := strconv.Atoi(args[1])
+	if err != nil || n <= 0 {
+		fmt.Fprintln(os.Stderr, styleReplError.Render("items must be a positive integer"))
+		return nil //nolint:nilerr // REPL shows a friendly message; parse error is not propagated
+	}
+	r.loop.config.FoldContextItems = n
+	r.persistTuning()
+	fmt.Fprintf(os.Stdout, "%s\n", styleReplSuccess.Render(
+		fmt.Sprintf("Fold context-items cap set to %d (saved)", n)))
+	return nil
+}
+
+func (r *REPL) cmdFoldPreset(args []string) error {
+	if len(args) < sessionSubcmdArgMin {
+		fmt.Fprintln(os.Stderr, styleReplError.Render(
+			"Usage: /fold preset <"+strings.Join(foldPresetNames, "|")+">"))
+		return nil
+	}
+	name := strings.ToLower(args[1])
+	preset, ok := foldPresets[name]
+	if !ok {
+		fmt.Fprintln(os.Stderr, styleReplError.Render(
+			"Unknown preset: "+name+". Valid: "+strings.Join(foldPresetNames, ", ")))
+		return nil
+	}
+	r.loop.config.FoldThreshold = preset.threshold
+	r.loop.config.FoldContextItems = preset.items
+	r.persistTuning()
+	fmt.Fprintf(os.Stdout, "%s\n", styleReplSuccess.Render(fmt.Sprintf(
+		"Fold preset %q applied: threshold=%d, items=%d (saved)", name, preset.threshold, preset.items)))
+	return nil
+}
+
+// cmdFoldStatus reports the current /fold configuration and how far the
+// session is into accumulating toward the next automatic fold.
+func (r *REPL) cmdFoldStatus() error {
+	cfg := &r.loop.config
+	state := "on"
+	if cfg.FoldOff {
+		state = "off"
+	}
+	threshold := cfg.FoldThreshold
+	if threshold <= 0 {
+		threshold = defaultFoldThreshold
+	}
+	items := cfg.FoldContextItems
+	if items <= 0 {
+		items = defaultFoldContextItems
+	}
+	fmt.Fprintln(os.Stdout, styleReplHeading.Render("Fold"))
+	fmt.Fprintf(os.Stdout, "  auto: %s\n", state)
+	fmt.Fprintf(os.Stdout, "  threshold: %d tokens\n", threshold)
+	fmt.Fprintf(os.Stdout, "  context items: %d\n", items)
+
+	var sinceNanos int64
+	lastFold := "never"
+	if r.loop.memoryStore != nil {
+		if cp, ok := r.loop.memoryStore.Get(checkpointSummaryKey); ok {
+			sinceNanos = cp.UpdatedAt * int64(time.Millisecond)
+			lastFold = formatRelativeAge(memoryNow().UnixMilli() - cp.UpdatedAt)
+		}
+	}
+	accumulated := tokensSinceCheckpoint(r.loop.Session().RawMessages(), sinceNanos, cfg.Model)
+	fmt.Fprintf(os.Stdout, "  last fold: %s\n", lastFold)
+	fmt.Fprintf(os.Stdout, "  accumulated since: %d / %d tokens\n", accumulated, threshold)
+	return nil
+}
+
+// cmdFoldNow triggers a fold immediately, regardless of the threshold --
+// reusing the same compaction call /compact uses (ForceCompact keeps only
+// the last few turns verbatim; a fold's own budget-based cut is normally
+// lighter, but manually forcing it still guarantees something happens even
+// on a session that hasn't crossed the threshold yet).
+func (r *REPL) cmdFoldNow() error {
+	fmt.Fprintln(os.Stdout, styleReplMeta.Render("Folding..."))
+	summary, err := r.loop.CompactWithLLM(r.ctx)
+	if err != nil {
+		return fmt.Errorf("fold: %w", err)
+	}
+	if summary == "" {
+		fmt.Fprintln(os.Stdout, styleReplMeta.Render(
+			"Nothing to fold — the session is still under budget."))
+		return nil
+	}
+	r.syncTokenCounter()
+	fmt.Fprintf(os.Stdout, "%s\n\n%s\n", styleReplHeading.Render("Fold summary:"), summary)
 	return nil
 }
 

--- a/pkg/agent/repl_test.go
+++ b/pkg/agent/repl_test.go
@@ -2827,6 +2827,36 @@ func TestApplyConfigDefaults_CompactBudgetFlatForUnknownModel(t *testing.T) {
 	}
 }
 
+// applyConfigDefaults must fill in the fold defaults (threshold/items) the
+// same "<=0 means use the default" way CompactTokenBudget/AutoCompactThreshold
+// already do; FoldOff's zero value (false) is the enabled default, not
+// something applyConfigDefaults needs to touch.
+func TestApplyConfigDefaults_FoldDefaults(t *testing.T) {
+	cfg := applyConfigDefaults(Config{Model: "test"})
+	if cfg.FoldThreshold != defaultFoldThreshold {
+		t.Errorf("FoldThreshold = %d, want default %d", cfg.FoldThreshold, defaultFoldThreshold)
+	}
+	if cfg.FoldContextItems != defaultFoldContextItems {
+		t.Errorf("FoldContextItems = %d, want default %d", cfg.FoldContextItems, defaultFoldContextItems)
+	}
+	if cfg.FoldOff {
+		t.Error("FoldOff should be false (auto-fold on) by default")
+	}
+}
+
+func TestApplyConfigDefaults_FoldExplicitValuesPreserved(t *testing.T) {
+	cfg := applyConfigDefaults(Config{Model: "test", FoldThreshold: 500, FoldContextItems: 2, FoldOff: true})
+	if cfg.FoldThreshold != 500 {
+		t.Errorf("FoldThreshold = %d, want the explicitly-set 500", cfg.FoldThreshold)
+	}
+	if cfg.FoldContextItems != 2 {
+		t.Errorf("FoldContextItems = %d, want the explicitly-set 2", cfg.FoldContextItems)
+	}
+	if !cfg.FoldOff {
+		t.Error("FoldOff should stay true when explicitly set")
+	}
+}
+
 // --- buildSystemPreamble zero-limit fallback paths ---
 
 func TestBuildSystemPreamble_ZeroBudgetUsesAutoCompactThreshold(t *testing.T) {
@@ -3524,6 +3554,139 @@ func TestCmdModelTool_SetTokenSettingsWithSuffix(t *testing.T) {
 	assert.Equal(t, 5*time.Second, loop.config.AutoRetryBaseDelay)
 	assert.Equal(t, 5, loop.config.AutoRetryMax)
 	assert.Equal(t, 12, loop.config.MaxTurns)
+}
+
+// --- /fold ---
+
+func TestCmdFold_ThresholdAndItemsPersist(t *testing.T) {
+	loop := makeTestLoop(nil)
+	repl := NewREPL(context.Background(), loop)
+	defer repl.cancel()
+
+	captureStdout(t, func() {
+		_ = repl.cmdFold([]string{"threshold", "4k"})
+		_ = repl.cmdFold([]string{"items", "8"})
+	})
+	assert.Equal(t, 4*1024, loop.config.FoldThreshold)
+	assert.Equal(t, 8, loop.config.FoldContextItems)
+
+	// Round-trips through the same snapshot/restore path CompactTokenBudget
+	// etc. already use -- a fresh loop restoring this snapshot must see the
+	// same values, not the built-in defaults.
+	snap := repl.toolTuningSnapshot()
+	loop2 := makeTestLoop(nil)
+	repl2 := NewREPL(context.Background(), loop2)
+	defer repl2.cancel()
+	repl2.applyToolTuning(snap)
+	assert.Equal(t, 4*1024, loop2.config.FoldThreshold)
+	assert.Equal(t, 8, loop2.config.FoldContextItems)
+}
+
+func TestCmdFold_AutoToggleAndPersist(t *testing.T) {
+	loop := makeTestLoop(nil)
+	repl := NewREPL(context.Background(), loop)
+	defer repl.cancel()
+
+	captureStdout(t, func() { _ = repl.cmdFold([]string{"auto", "off"}) })
+	assert.True(t, loop.config.FoldOff)
+
+	snap := repl.toolTuningSnapshot()
+	assert.True(t, snap.FoldConfigured)
+	assert.False(t, snap.FoldAuto)
+
+	loop2 := makeTestLoop(nil)
+	repl2 := NewREPL(context.Background(), loop2)
+	defer repl2.cancel()
+	repl2.applyToolTuning(snap)
+	assert.True(t, loop2.config.FoldOff, "restored snapshot must keep auto-fold off")
+
+	captureStdout(t, func() { _ = repl.cmdFold([]string{"auto"}) })
+	assert.False(t, loop.config.FoldOff)
+}
+
+// A snapshot saved before FoldConfigured existed (zero value: false) must not
+// silently disable the on-by-default behavior -- mirrors
+// TestToolTuning_ZeroPersistedValuesPreserveDefaults's reasoning for the
+// other *Configured sentinels.
+func TestCmdFold_UnconfiguredSnapshotKeepsAutoOn(t *testing.T) {
+	loop := makeTestLoop(nil)
+	repl := NewREPL(context.Background(), loop)
+	defer repl.cancel()
+
+	repl.applyToolTuning(ToolTuning{FoldConfigured: false})
+	assert.False(t, loop.config.FoldOff, "an unconfigured snapshot must leave auto-fold on")
+}
+
+func TestCmdFold_Preset(t *testing.T) {
+	loop := makeTestLoop(nil)
+	repl := NewREPL(context.Background(), loop)
+	defer repl.cancel()
+
+	captureStdout(t, func() { _ = repl.cmdFold([]string{"preset", "tight"}) })
+	assert.Equal(t, foldPresets["tight"].threshold, loop.config.FoldThreshold)
+	assert.Equal(t, foldPresets["tight"].items, loop.config.FoldContextItems)
+
+	captureStdout(t, func() { _ = repl.cmdFold([]string{"preset", "loose"}) })
+	assert.Equal(t, foldPresets["loose"].threshold, loop.config.FoldThreshold)
+	assert.Equal(t, foldPresets["loose"].items, loop.config.FoldContextItems)
+}
+
+func TestCmdFold_UnknownPresetRejectedNoPartialChange(t *testing.T) {
+	loop := makeTestLoop(nil)
+	repl := NewREPL(context.Background(), loop)
+	defer repl.cancel()
+	loop.config.FoldThreshold = 999
+	loop.config.FoldContextItems = 9
+
+	// The rejection message goes to stderr; captureStdout only observes
+	// stdout, so the meaningful assertion here is the config staying
+	// unchanged, not the printed text.
+	captureStdout(t, func() { _ = repl.cmdFold([]string{"preset", "nonexistent"}) })
+	assert.Equal(t, 999, loop.config.FoldThreshold, "an unknown preset must not partially apply")
+	assert.Equal(t, 9, loop.config.FoldContextItems)
+}
+
+// The compaction/fold call itself consumes real tokens (it's a real LLM
+// call); cmdCompact and cmdFoldNow must call syncTokenCounter afterward so
+// the cumulative in:/out: display counts it, not just leave it at whatever
+// the last real turn left behind.
+func TestCmdCompact_SyncsTokenCounter(t *testing.T) {
+	loop := makeTestLoopWithEngine("## Progress\n- did things")
+	// forcedCutIndex needs n > forceKeepTurns*sessionMsgsPer + sessionMsgsPer
+	// (see its own bounds check), so forceKeepTurns+1 turns (exactly at the
+	// boundary) returns 0 -- one more turn is required to actually cut.
+	for range forceKeepTurns + 2 {
+		loop.session.Append("user msg", "assistant reply")
+	}
+	repl := NewREPL(context.Background(), loop)
+	defer repl.cancel()
+	repl.tokenCounter.Reset()
+
+	GlobalPromptCacheStats.RecordCacheUsageFromTokens(123, 45)
+	captureStdout(t, func() { _ = repl.cmdCompact() })
+
+	assert.Equal(t, int64(123), repl.tokenCounter.InputTokens())
+	assert.Equal(t, int64(45), repl.tokenCounter.OutputTokens())
+}
+
+func TestCmdFoldNow_SyncsTokenCounter(t *testing.T) {
+	// CompactTokenBudget left at its zero value: findCutIndex treats <=0 as
+	// "keep almost nothing," so with enough turns there is always something
+	// to compact -- unlike ForceCompact, CompactWithLLM has no separate
+	// "keep the last N turns regardless" override.
+	loop := makeTestLoopWithEngine("## Progress\n- did things")
+	for range compactMinTurns + 1 {
+		loop.session.Append("user msg", "assistant reply")
+	}
+	repl := NewREPL(context.Background(), loop)
+	defer repl.cancel()
+	repl.tokenCounter.Reset()
+
+	GlobalPromptCacheStats.RecordCacheUsageFromTokens(77, 33)
+	captureStdout(t, func() { _ = repl.cmdFoldNow() })
+
+	assert.Equal(t, int64(77), repl.tokenCounter.InputTokens())
+	assert.Equal(t, int64(33), repl.tokenCounter.OutputTokens())
 }
 
 func TestCmdModelTool_ZeroDisablesCompactThreshold(t *testing.T) {
@@ -5165,10 +5328,10 @@ func TestCRLFWriter_ReturnLenOfInput(t *testing.T) {
 	assert.Equal(t, 6, n) // returns len of original input, not converted
 }
 
-func makeTestLoopWithEngine(result any, engineErr error) *Loop {
+func makeTestLoopWithEngine(result any) *Loop {
 	eng := executor.NewEngine(nil)
 	eng.SetExecuteFunc(func(_ *domain.Workflow, _ any) (any, error) {
-		return result, engineErr
+		return result, nil
 	})
 	return &Loop{
 		config:  Config{Model: "test-model"},
@@ -5185,7 +5348,7 @@ func makeTestLoopWithEngine(result any, engineErr error) *Loop {
 func TestCmdClear_WithManyTurns(t *testing.T) {
 	// Must have >= compactMinTurns (4) turns to trigger the summarize-branch path.
 	// Engine returns empty string so SummarizeBranch returns "".
-	loop := makeTestLoopWithEngine("", nil)
+	loop := makeTestLoopWithEngine("")
 	for range compactMinTurns + 1 {
 		loop.session.Append("user msg", "assistant reply")
 	}
@@ -5199,7 +5362,7 @@ func TestCmdClear_WithManyTurns(t *testing.T) {
 
 func TestCmdClear_WithSummary(t *testing.T) {
 	// Engine returns non-empty summary, covering the summary-printing branch.
-	loop := makeTestLoopWithEngine("Branch summary text here.", nil)
+	loop := makeTestLoopWithEngine("Branch summary text here.")
 	for range compactMinTurns + 1 {
 		loop.session.Append("user msg", "assistant reply")
 	}

--- a/pkg/agent/tool_tuning.go
+++ b/pkg/agent/tool_tuning.go
@@ -91,6 +91,21 @@ type ToolTuning struct {
 	// lets a future default flip.
 	RefineOff        bool
 	RefineConfigured bool
+	// FoldThreshold persists the /fold threshold <n> choice (token delta
+	// since the last checkpoint that triggers an automatic fold). 0 means
+	// never configured -- applyConfigDefaults' default (2000) applies.
+	FoldThreshold int
+	// FoldContextItems persists the /fold items <n> choice (how many recent
+	// checkpoints stay in the active prompt-injection window). 0 means never
+	// configured -- applyConfigDefaults' default (5) applies.
+	FoldContextItems int
+	// FoldAuto persists the /fold auto|off choice (default: on).
+	// FoldConfigured is its "was this ever set" sentinel -- same role as
+	// GoalConfigured/RefineConfigured above, so a snapshot saved before this
+	// feature existed (FoldAuto unmarshals to false) still restores the
+	// on-by-default behavior instead of silently disabling it.
+	FoldAuto       bool
+	FoldConfigured bool
 }
 
 // toolTuningSnapshot captures the current tool settings for persistence.
@@ -135,6 +150,10 @@ func (r *REPL) toolTuningSnapshot() ToolTuning {
 		ContextSize:          r.contextSize,
 		RefineOff:            !c.PromptRefine,
 		RefineConfigured:     true,
+		FoldThreshold:        c.FoldThreshold,
+		FoldContextItems:     c.FoldContextItems,
+		FoldAuto:             !c.FoldOff,
+		FoldConfigured:       true,
 	}
 }
 
@@ -218,6 +237,15 @@ func (r *REPL) applyToolTuningExtras(t ToolTuning) {
 	}
 	if t.RefineConfigured {
 		r.loop.SetPromptRefine(!t.RefineOff)
+	}
+	if t.FoldThreshold > 0 {
+		c.FoldThreshold = t.FoldThreshold
+	}
+	if t.FoldContextItems > 0 {
+		c.FoldContextItems = t.FoldContextItems
+	}
+	if t.FoldConfigured {
+		c.FoldOff = !t.FoldAuto
 	}
 	// PermissionMode empty is already the natural "unconfigured" value
 	// (resolvePermissionMode/checkToolPermission fall back to the env var or

--- a/pkg/tui/settings.go
+++ b/pkg/tui/settings.go
@@ -84,6 +84,10 @@ type AgentLoopTuning struct {
 	ContextSize          int    `yaml:"context_size,omitempty"`
 	RefineOff            bool   `yaml:"refine_off,omitempty"`
 	RefineConfigured     bool   `yaml:"refine_configured,omitempty"`
+	FoldThreshold        int    `yaml:"fold_threshold,omitempty"`
+	FoldContextItems     int    `yaml:"fold_context_items,omitempty"`
+	FoldAuto             bool   `yaml:"fold_auto,omitempty"`
+	FoldConfigured       bool   `yaml:"fold_configured,omitempty"`
 }
 
 // SaveAgentLoopTuning persists the agent-loop tool settings, preserving the rest


### PR DESCRIPTION
## Summary
- `MemoryStore.SetGlobal()` shares memory across every project/session (`basePath/global/memory.bolt`), opt-in via `KDEPS_MEMORY_GLOBAL=1`. Session storage stays per-directory.
- Checkpoint summaries are archived (`checkpoint:archive:<ts>`) instead of overwritten on every compaction -- no more silent data loss. Archived checkpoints stay browsable via `/memory list` / `/memory show <key>`.
- The `<memory>` prompt block now caps how many checkpoint-family entries compete for space (default 5, configurable) via `FormatForPromptCapped`; non-checkpoint entries and the underlying store are unaffected.
- New **fold**: a lighter, more-frequent, delta-based checkpoint refresh distinct from `/compact`'s full-context-window safety net. Once ~2000 tokens of new conversation accumulate since the last checkpoint, a fold fires automatically (same underlying compaction call `/compact` uses). Threshold and context-item cap are configurable and persist the same way the existing compact settings do.
- New `/fold` REPL command: bare status, `/fold now`, `/fold auto[ off]`, `/fold threshold <n>`, `/fold items <n>`, `/fold preset tight|balanced|loose`.
- `/compact` and the auto-compact callback now call `syncTokenCounter()` so the displayed token counter reflects a fold/compaction immediately instead of going stale until the next real turn.

## Tests
- `go test ./pkg/agent/... ./pkg/tui/... ./cmd/...` -- 4262 passed.
- `make lint` -- 0 issues.
- New unit tests: `SetGlobal`/global-env resolution, checkpoint archiving, `capCheckpointEntries`/`FormatForPromptCapped`, `shouldFold` boundary conditions, `/fold` threshold/items/auto/preset persistence, token-counter sync on `/compact` and `/fold now`.

## Docs
- `docs/v2/agent/memory.md` -- global memory option.
- `docs/v2/agent/memory-internals.md` -- checkpoint archiving.
- `docs/v2/agent/repl.md` -- new Fold section.